### PR TITLE
Implement PresentCommand

### DIFF
--- a/include/ase/commandbuffer.h
+++ b/include/ase/commandbuffer.h
@@ -34,6 +34,8 @@ namespace ase
                 bool stencil = false
                 );
 
+        void pushPresent(Window window);
+
         size_t size() const;
         Iterator begin();
         Iterator end();

--- a/include/ase/dummyrendercontext.h
+++ b/include/ase/dummyrendercontext.h
@@ -10,7 +10,6 @@ namespace ase
         void submit(CommandBuffer&& commands) override;
         void flush() override;
         void finish() override;
-        void present(Window& window) override;
 
         std::shared_ptr<ProgramImpl> makeProgramImpl(
                 VertexShader const& vertexShader,

--- a/include/ase/glrendercontext.h
+++ b/include/ase/glrendercontext.h
@@ -28,11 +28,12 @@ namespace ase
 
         ~GlRenderContext() override;
 
+        virtual void present(Dispatched dispatched, Window& window) = 0;
+
         // From RenderContextImpl
         void submit(CommandBuffer&& commands) override;
         void flush() override;
         void finish() override;
-        void present(Window& window) override;
 
         GlFramebuffer const& getDefaultFramebuffer() const;
 

--- a/include/ase/glxrendercontext.h
+++ b/include/ase/glxrendercontext.h
@@ -20,8 +20,8 @@ namespace ase
         GlxRenderContext(GlxPlatform& platform);
         ~GlxRenderContext();
 
-        // From RenderContextImpl
-        void present(Window& window) override;
+        // From GlRenderContext
+        void present(Dispatched d, Window& window) override;
 
     private:
         friend class GlxPlatform;

--- a/include/ase/rendercommand.h
+++ b/include/ase/rendercommand.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "window.h"
 #include "drawcommand.h"
 
 #include <variant>
@@ -18,6 +19,11 @@ namespace ase
         bool stencil = true;
     };
 
-    using RenderCommand = std::variant<DrawCommand, ClearCommand>;
+    struct PresentCommand
+    {
+        Window window;
+    };
+
+    using RenderCommand = std::variant<DrawCommand, ClearCommand, PresentCommand>;
 
 } // namespace ase

--- a/include/ase/rendercontext.h
+++ b/include/ase/rendercontext.h
@@ -66,7 +66,6 @@ namespace ase
 
         void flush();
         void finish();
-        void present(Window& window);
         void submit(CommandBuffer&& renderQueue);
 
         VertexShader makeVertexShader(std::string const& source);

--- a/include/ase/rendercontextimpl.h
+++ b/include/ase/rendercontextimpl.h
@@ -42,7 +42,6 @@ namespace ase
         virtual void submit(CommandBuffer&& commands) = 0;
         virtual void flush() = 0;
         virtual void finish() = 0;
-        virtual void present(Window& window) = 0;
 
         virtual std::shared_ptr<ProgramImpl> makeProgramImpl(
                 VertexShader const& vertexShader,

--- a/include/ase/wglrendercontext.h
+++ b/include/ase/wglrendercontext.h
@@ -17,7 +17,7 @@ namespace ase
 
         WglDispatchedContext const& getWglContext() const;
 
-        void present(Window& window) override;
+        void present(Dispatched d, Window& window) override;
 
     private:
         friend class WglFramebuffer;

--- a/include/ase/window.h
+++ b/include/ase/window.h
@@ -30,6 +30,9 @@ namespace ase
         Window(Window const&) = default;
         Window(Window&&) noexcept = default;
 
+        Window& operator=(Window const&) = default;
+        Window& operator=(Window&&) = default;
+
         void setVisible(bool value);
         bool isVisible() const;
 

--- a/src/ase/commandbuffer.cpp
+++ b/src/ase/commandbuffer.cpp
@@ -43,6 +43,13 @@ void CommandBuffer::pushClear(Framebuffer target,
             });
 }
 
+void CommandBuffer::pushPresent(Window window)
+{
+    commands_.push_back(PresentCommand{
+            std::move(window)
+            });
+}
+
 size_t CommandBuffer::size() const
 {
     return commands_.size();

--- a/src/ase/dummy/dummyrendercontext.cpp
+++ b/src/ase/dummy/dummyrendercontext.cpp
@@ -32,10 +32,6 @@ void DummyRenderContext::finish()
 {
 }
 
-void DummyRenderContext::present(Window& /*window*/)
-{
-}
-
 std::shared_ptr<ProgramImpl> DummyRenderContext::makeProgramImpl(
         VertexShader const& /*vertexShader*/,
         FragmentShader const& /*fragmentShader*/)

--- a/src/ase/gl/glrendercontext.cpp
+++ b/src/ase/gl/glrendercontext.cpp
@@ -41,7 +41,10 @@ GlRenderContext::GlRenderContext(
     fgContext_(std::move(fgContext)),
     bgContext_(std::move(bgContext)),
     objectManager_(*this),
-    renderState_(*this, *fgContext_),
+    renderState_(*this, *fgContext_, [this](Dispatched d, Window& w)
+            {
+                present(d, w);
+            }),
     defaultFramebuffer_(*this, nullptr),
     sharedFramebuffer_(*this)
 {
@@ -76,11 +79,6 @@ void GlRenderContext::finish()
                 glFinish();
             });
     wait();
-}
-
-void GlRenderContext::present(Window& /*window*/)
-{
-    renderState_.endFrame();
 }
 
 GlFramebuffer const& GlRenderContext::getDefaultFramebuffer() const

--- a/src/ase/gl/glrenderstate.h
+++ b/src/ase/gl/glrenderstate.h
@@ -8,6 +8,7 @@
 
 namespace ase
 {
+    class Window;
     class GlRenderContext;
     class CommandBuffer;
     class VertexSpec;
@@ -22,7 +23,8 @@ namespace ase
     class ASE_EXPORT GlRenderState
     {
     public:
-        GlRenderState(GlRenderContext& context, GlDispatchedContext& dispatcher);
+        GlRenderState(GlRenderContext& context, GlDispatchedContext& dispatcher,
+                std::function<void(Dispatched, Window&)> presentCallback);
         ~GlRenderState();
 
         void submit(CommandBuffer&& commands);
@@ -40,6 +42,7 @@ namespace ase
     private:
         GlRenderContext& context_;
         GlDispatchedContext& dispatcher_;
+        std::function<void(Dispatched, Window&)> presentCallback_;
 
         // Current state
         Vector2i viewportSize_;

--- a/src/ase/glx/glxrendercontext.cpp
+++ b/src/ase/glx/glxrendercontext.cpp
@@ -32,18 +32,15 @@ GlxRenderContext::GlxRenderContext(GlxPlatform& platform) :
 
 GlxRenderContext::~GlxRenderContext()
 {
+    // make sure queues are clear before calling parent destructor
+    wait();
+    waitBg();
 }
 
-void GlxRenderContext::present(Window& window)
+void GlxRenderContext::present(Dispatched d, Window& window)
 {
-    dispatch([&window](GlFunctions const&) mutable
-            {
-                GlxWindow& glxWindow = window.getImpl<GlxWindow>();
-                glxWindow.present(Dispatched());
-            });
-    wait();
-
-    GlRenderContext::present(window);
+    GlxWindow& glxWindow = window.getImpl<GlxWindow>();
+    glxWindow.present(d);
 }
 
 GlxDispatchedContext const& GlxRenderContext::getGlxContext() const

--- a/src/ase/rendercontext.cpp
+++ b/src/ase/rendercontext.cpp
@@ -39,12 +39,6 @@ void RenderContext::finish()
         d()->finish();
 }
 
-void RenderContext::present(Window& window)
-{
-    if (d())
-        d()->present(window);
-}
-
 void RenderContext::submit(CommandBuffer&& commands)
 {
     if (d())

--- a/src/ase/windows/wglrendercontext.cpp
+++ b/src/ase/windows/wglrendercontext.cpp
@@ -33,25 +33,18 @@ WglDispatchedContext const& WglRenderContext::getWglContext() const
             );
 }
 
-void WglRenderContext::present(Window& window)
+void WglRenderContext::present(Dispatched, Window& window)
 {
-    dispatch([this, &window](GlFunctions const& gl) mutable
-            {
-                WglWindow& wglWindow = window.getImpl<WglWindow>();
-                WglDispatchedContext const& wglContext =
-                    static_cast<WglDispatchedContext const&>(getFgContext());
+    WglWindow& wglWindow = window.getImpl<WglWindow>();
+    WglDispatchedContext const& wglContext =
+        static_cast<WglDispatchedContext const&>(getFgContext());
 
-                wglMakeCurrent(
-                        wglWindow.getDc(),
-                        wglContext.getWglContext()
-                        );
+    wglMakeCurrent(
+            wglWindow.getDc(),
+            wglContext.getWglContext()
+            );
 
-                SwapBuffers(wglWindow.getDc());
-            });
-
-    wait();
-
-    GlRenderContext::present(window);
+    SwapBuffers(wglWindow.getDc());
 }
 
 } // namespace ase

--- a/src/reactive/app.cpp
+++ b/src/reactive/app.cpp
@@ -273,8 +273,10 @@ public:
                     aseWindow.getSize(), aseWindow.getScalingFactor(),
                     painter_, widget_.getDrawing().evaluate());
 
+            commands.pushPresent(aseWindow);
+
             context_.submit(std::move(commands));
-            context_.present(aseWindow);
+
             redraw_ = false;
 
             ++frames_;


### PR DESCRIPTION
Move present functionality from RenderContext to the CommandBuffer as a render command. This will help with the synchronization as there is no need to wait for queue to complete before presenting.