### PR TITLE
CI: add clang-cl to the Windows build matrix

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -37,7 +37,7 @@ jobs:
                   { "deps": "clang-11", "CC": "clang-11", "CXX": "clang++-11", "type": "release", config: "-Dtracy_enable=true"} ]
         runs-on: "ubuntu-22.04"
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
               submodules: recursive
 
@@ -58,9 +58,9 @@ jobs:
             ninja -C build/${{ matrix.compiler.CC }}-${{ matrix.compiler.type }} test
 
     build-macos:
-        runs-on: "macOS-latest"
+        runs-on: "macos-15"
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
               submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
                   { "name": "msvc", "CC": "", "CXX": "" },
                   { "name": "clang-cl", "CC": "clang-cl", "CXX": "clang-cl" } ]
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           name: checkout
           with:
               submodules: recursive
@@ -157,4 +157,26 @@ jobs:
             echo 'Building...'
             ninja -C $builddir
             ninja -C $builddir test
+
+    # Aggregating gate: this is the ONLY job to mark as a required status check.
+    # It turns green only if every job it needs succeeded, so new matrix legs are
+    # covered automatically; adding a brand-new top-level job just means adding it
+    # to `needs` below (reviewed in-repo, not in branch-protection settings).
+    ci-success:
+        name: ci-success
+        if: always()
+        needs: [build-linux, build-macos, build-win]
+        runs-on: "ubuntu-22.04"
+        steps:
+        - name: Verify all required jobs succeeded
+          run: |
+            results="${{ join(needs.*.result, ' ') }}"
+            echo "Required job results: $results"
+            for r in $results; do
+              if [ "$r" != "success" ]; then
+                echo "::error::A required job did not succeed (got '$r'). Failing the gate."
+                exit 1
+              fi
+            done
+            echo "All required jobs succeeded."
 

--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -82,7 +82,13 @@ jobs:
             ninja -C build/release test
 
     build-win:
+        name: "build-win (${{ matrix.compiler.name }})"
         runs-on: "windows-2022"
+        strategy:
+            matrix:
+                compiler: [
+                  { "name": "msvc", "CC": "", "CXX": "" },
+                  { "name": "clang-cl", "CC": "clang-cl", "CXX": "clang-cl" } ]
         steps:
         - uses: actions/checkout@v2
           name: checkout
@@ -138,11 +144,17 @@ jobs:
 
             $env:PKG_CONFIG_LIBDIR = "."
 
-            md build\win-release
+            # Select compiler for this matrix leg (empty CC => default MSVC).
+            if ("${{ matrix.compiler.CC }}" -ne "") {
+                $env:CC = "${{ matrix.compiler.CC }}"
+                $env:CXX = "${{ matrix.compiler.CXX }}"
+            }
+
+            $builddir = "build/win-${{ matrix.compiler.name }}"
+            md $builddir
             echo 'Configuring...'
-            python build\meson\meson.py setup --buildtype=release --wrap-mode=forcefallback  . build/win-release
-            #python build\meson\meson.py compile -C build/win-$(BUILDTYPE)
+            python build\meson\meson.py setup --buildtype=release --wrap-mode=forcefallback . $builddir
             echo 'Building...'
-            ninja -C build/win-release
-            ninja -C build/win-release test
+            ninja -C $builddir
+            ninja -C $builddir test
 

--- a/src/avg/src/animated.cpp
+++ b/src/avg/src/animated.cpp
@@ -10,15 +10,15 @@
 
 namespace avg
 {
-template class Animated<float>;
-template class Animated<Vector2f>;
-template class Animated<Rect>;
-template class Animated<Transform>;
-template class Animated<Obb>;
-template class Animated<Color>;
-template class Animated<Brush>;
-template class Animated<Pen>;
-template class Animated<Curve>;
+template class AVG_EXPORT_TEMPLATE Animated<float>;
+template class AVG_EXPORT_TEMPLATE Animated<Vector2f>;
+template class AVG_EXPORT_TEMPLATE Animated<Rect>;
+template class AVG_EXPORT_TEMPLATE Animated<Transform>;
+template class AVG_EXPORT_TEMPLATE Animated<Obb>;
+template class AVG_EXPORT_TEMPLATE Animated<Color>;
+template class AVG_EXPORT_TEMPLATE Animated<Brush>;
+template class AVG_EXPORT_TEMPLATE Animated<Pen>;
+template class AVG_EXPORT_TEMPLATE Animated<Curve>;
 
 } // namespace avg
 

--- a/src/bqui/src/widget/widget.cpp
+++ b/src/bqui/src/widget/widget.cpp
@@ -8,14 +8,14 @@
 
 namespace bqui::widget
 {
-    template class Widget<std::function<AnyBuilder(BuildParams)>>;
-    template class Element<bq::signal::AnySignal<Instance>>;
+    template class BQUI_EXPORT_TEMPLATE Widget<std::function<AnyBuilder(BuildParams)>>;
+    template class BQUI_EXPORT_TEMPLATE Element<bq::signal::AnySignal<Instance>>;
 }
 
 namespace bqui::modifier
 {
-    template class WidgetModifier<std::function<widget::AnyWidget(widget::AnyWidget)>>;
-    template class BuilderModifier<std::function<widget::AnyBuilder(widget::AnyBuilder)>>;
-    template class ElementModifier<std::function<widget::AnyElement(widget::AnyElement)>>;
+    template class BQUI_EXPORT_TEMPLATE WidgetModifier<std::function<widget::AnyWidget(widget::AnyWidget)>>;
+    template class BQUI_EXPORT_TEMPLATE BuilderModifier<std::function<widget::AnyBuilder(widget::AnyBuilder)>>;
+    template class BQUI_EXPORT_TEMPLATE ElementModifier<std::function<widget::AnyElement(widget::AnyElement)>>;
 }
 

--- a/src/btl/include/btl/visibility.h
+++ b/src/btl/include/btl/visibility.h
@@ -27,8 +27,8 @@
 #elif defined(_WIN32)
     #define BTL_EXPORT __declspec(dllexport)
     #define BTL_IMPORT __declspec(dllimport)
-    #define BTL_EXPORT_TEMPLATE
-    #define BTL_IMPORT_TEMPLATE
+    #define BTL_EXPORT_TEMPLATE __declspec(dllexport)
+    #define BTL_IMPORT_TEMPLATE __declspec(dllimport)
     #define BTL_EXPORT_CLASS_TEMPLATE
 
     #define BTL_FORCE_INLINE inline


### PR DESCRIPTION
Adds a second Windows CI leg that builds with **clang-cl**, alongside the existing MSVC build, plus the source fix required to make that build link.

## Commits
- **Fix template symbol export for clang-cl on Windows** — the Windows visibility macros left `BTL_EXPORT_TEMPLATE`/`BTL_IMPORT_TEMPLATE` empty, so the extern-template export scheme was a no-op. MSVC tolerated it by re-emitting inline members in each consumer; clang-cl honors `extern template` strictly and expects the symbols from the DLL, which never exported them → unresolved `Animated<T>`, `Widget<>`, `Element<>`, modifier templates. Marks the extern-template decls dllimport/dllexport and puts the export attribute on the explicit instantiation definitions.
- **CI: build Windows with both MSVC and clang-cl** — converts `build-win` into a `{msvc, clang-cl}` matrix.

## Why together
The clang-cl CI leg only links because of the export fix, so they belong in one self-contained PR (independent of the shape-utilities work in #84).

## Testing
Verified locally on Windows with clang-cl 18 and MSVC 19.43 (both build + link clean). This PR's own `build-win (clang-cl)` leg is the CI validation.