### PR TITLE
Infra: fix .clang-format config + bump checkout to v5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -104,7 +104,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 BreakStringLiterals: false
-  #BreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: Yes
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
@@ -168,7 +168,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
   #MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
+NamespaceIndentation: All
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true

--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: "ubuntu-latest"
         if: false
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           with:
               fetch-depth: 1
               ref: ${{ github.event.pull_request.head.sha }}
@@ -37,7 +37,7 @@ jobs:
                   { "deps": "clang-11", "CC": "clang-11", "CXX": "clang++-11", "type": "release", config: "-Dtracy_enable=true"} ]
         runs-on: "ubuntu-22.04"
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           with:
               submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
     build-macos:
         runs-on: "macos-15"
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           with:
               submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
                   { "name": "msvc", "CC": "", "CXX": "" },
                   { "name": "clang-cl", "CC": "clang-cl", "CXX": "clang-cl" } ]
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           name: checkout
           with:
               submodules: recursive


### PR DESCRIPTION
Two small, independent infra fixes. No source is reformatted and no build behavior changes.

## Commits
- **Fix .clang-format to match the codebase conventions** — `NamespaceIndentation: None -> All` (the codebase indents namespace bodies), and replace the commented, clang-format-19-only `BreakTemplateDeclarations` key with `AlwaysBreakTemplateDeclarations: Yes` (valid across clang-format 17-22). This only corrects the config for when the formatter is adopted; it reformats nothing now (the clang-format CI job stays disabled).
- **CI: bump actions/checkout to v5** — `@v4` still runs on the deprecated Node 20; `@v5` targets Node 24 and clears the deprecation annotations.

## Testing
`.clang-format` validated to parse and produce the intended output (indented namespace + one-per-line template declaration). The workflow change is exercised by this PR's own CI run.