### PR TITLE
Make stream share() safe to call more than once

### DIFF
--- a/src/bq/include/bq/stream/control.h
+++ b/src/bq/include/bq/stream/control.h
@@ -1,17 +1,26 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 
 namespace bq
 {
     namespace stream
     {
         template <typename T>
+        struct SharedControl;
+
+        template <typename T>
         struct Control
         {
             virtual ~Control() {}
 
             std::function<void(T)> callback;
+
+            // The SharedControl produced by this control's first share(), kept
+            // weakly. A later share() of the same underlying stream reuses this
+            // broadcast instead of overwriting callback and starving it.
+            std::weak_ptr<SharedControl<T>> shared;
         };
 
         template <typename T, typename TData>

--- a/src/bq/include/bq/stream/stream.h
+++ b/src/bq/include/bq/stream/stream.h
@@ -49,11 +49,18 @@ namespace bq
 
             SharedStream<T> share() &&
             {
+                // Sharing is idempotent per underlying Control: if this stream
+                // was already shared and that broadcast is still alive, reuse
+                // it. Otherwise a second share() would overwrite callback and
+                // starve the earlier shared view.
+                if (auto existing = control_->shared.lock())
+                    return SharedStream<T>(std::move(existing));
+
                 auto newControl = std::make_shared<SharedControl<T>>();
                 std::weak_ptr<SharedControl<T>> weakControl(newControl);
 
                 control_->callback =
-                    [control = std::move(weakControl)](T value)
+                    [control = weakControl](T value)
                     {
                         if (auto p = control.lock())
                         {
@@ -63,6 +70,7 @@ namespace bq
                         }
                     };
 
+                control_->shared = std::move(weakControl);
                 newControl->upstream = std::move(control_);
 
                 return SharedStream<T>(std::move(newControl));

--- a/src/bq/test/streamtest.cpp
+++ b/src/bq/test/streamtest.cpp
@@ -100,10 +100,10 @@ TEST(Stream, convertShared)
     Stream<std::string> s = std::move(p.stream).share();
 }
 
-// stream.h:55: share() assigns control_->callback outright (no chaining). So
-// share()ing the SAME underlying stream twice makes the second share win and
-// silently starves the first. This pins that behaviour down: sharing a stream
-// more than once (e.g. collecting the same raw stream in two places) is a bug.
+// share() is idempotent per underlying Control: sharing the SAME underlying
+// stream more than once reuses the first broadcast instead of overwriting the
+// callback, so every shared view still receives every event. (Previously the
+// second share() won and silently starved the first.)
 TEST(Stream, shareSameStreamTwice)
 {
     auto p = pipe<std::string>();
@@ -121,8 +121,8 @@ TEST(Stream, shareSameStreamTwice)
 
     p.handle.push("event");
 
-    // The second share() overwrote the first: copy1's shared view is starved.
-    EXPECT_EQ(0, count1);
+    // Both shared views see the event: the second share() reused the first.
+    EXPECT_EQ(1, count1);
     EXPECT_EQ(1, count2);
 }
 

--- a/src/bq/test/streamtest.cpp
+++ b/src/bq/test/streamtest.cpp
@@ -100,6 +100,75 @@ TEST(Stream, convertShared)
     Stream<std::string> s = std::move(p.stream).share();
 }
 
+// stream.h:55: share() assigns control_->callback outright (no chaining). So
+// share()ing the SAME underlying stream twice makes the second share win and
+// silently starves the first. This pins that behaviour down: sharing a stream
+// more than once (e.g. collecting the same raw stream in two places) is a bug.
+TEST(Stream, shareSameStreamTwice)
+{
+    auto p = pipe<std::string>();
+
+    Stream<std::string> copy1 = p.stream;
+    Stream<std::string> copy2 = p.stream;
+
+    auto shared1 = std::move(copy1).share();
+    auto shared2 = std::move(copy2).share();
+
+    int count1 = 0;
+    int count2 = 0;
+    auto d1 = shared1.fmap([&count1](std::string s) { ++count1; return s; });
+    auto d2 = shared2.fmap([&count2](std::string s) { ++count2; return s; });
+
+    p.handle.push("event");
+
+    // The second share() overwrote the first: copy1's shared view is starved.
+    EXPECT_EQ(0, count1);
+    EXPECT_EQ(1, count2);
+}
+
+// Two SignalContexts built from the SAME collect signal, both alive before any
+// event: does each independently see every event? (multi-context coexistence)
+TEST(Stream, collectInTwoContexts)
+{
+    auto p = pipe<std::string>();
+    auto s = collect(std::move(p.stream));
+
+    auto c1 = signal::makeSignalContext(s);
+    auto c2 = signal::makeSignalContext(s);
+
+    p.handle.push("a");
+
+    auto r1 = c1.update(signal::FrameInfo(1, {}));
+    auto r2 = c2.update(signal::FrameInfo(1, {}));
+
+    EXPECT_TRUE(r1.didChange);
+    EXPECT_TRUE(r2.didChange);
+    EXPECT_EQ((std::vector<std::string>{ "a" }), c1.evaluate());
+    EXPECT_EQ((std::vector<std::string>{ "a" }), c2.evaluate());
+}
+
+// A context created AFTER an event was pushed misses that event permanently
+// (streams have no current-value convergence like signal inputs).
+TEST(Stream, lateContextMissesPriorEvents)
+{
+    auto p = pipe<std::string>();
+    auto s = collect(std::move(p.stream));
+
+    auto c1 = signal::makeSignalContext(s);
+
+    p.handle.push("early");
+
+    auto c2 = signal::makeSignalContext(s);
+
+    p.handle.push("late");
+
+    c1.update(signal::FrameInfo(1, {}));
+    c2.update(signal::FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<std::string>{ "early", "late" }), c1.evaluate());
+    EXPECT_EQ((std::vector<std::string>{ "late" }), c2.evaluate());
+}
+
 TEST(Stream, collect)
 {
     auto p = pipe<std::string>();


### PR DESCRIPTION
## The bug

`bq::stream::Stream<T>::share()` assigned `control_->callback` outright, and `Control<T>` holds a **single** `callback`. `Stream` is copyable (a shared reference to the same `Control`), so if the SAME underlying stream is `share()`d more than once, the second `share()` overwrites the first's broadcast callback and the first shared view is silently starved — it receives no events. There was no chaining.

This bites, for example, when the same raw stream is collected in two places.

## The fix

Make `share()` **idempotent per underlying `Control`**:

- `Control<T>` now keeps a `std::weak_ptr<SharedControl<T>>` to the `SharedControl` its first `share()` produced.
- A subsequent `share()` of the same stream, if that broadcast is still alive, returns a `SharedStream` viewing the existing `SharedControl` instead of overwriting `callback`.
- The back-reference is **weak**, so it introduces no ownership cycle — the `SharedControl` still owns the raw `Control` through `upstream`.

Result: every shared view of a stream receives every event, no matter how many times the stream was shared.

## Tests

- `Stream.shareSameStreamTwice` now asserts the corrected contract (`count1 == 1`, `count2 == 1`); its comment is rewritten to describe the fixed, idempotent behaviour (it previously documented the bug).
- `Stream.collectInTwoContexts` and `Stream.lateContextMissesPriorEvents` are unchanged and still pass (multi-context coexistence; a late context legitimately misses prior events).
- The full `bq` suite is green, including `share`, `convertShared`, `collect`, and `iterate` (which rely on `share()`), plus the signal tests. The `avg`/`bqui` suites fail identically on the base branch (pre-existing graphics-backend crashes in the headless test environment) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)