### PR TITLE
Unregister shared stream callbacks on downstream destruction

### DIFF
--- a/src/bq/include/bq/stream/sharedcontrol.h
+++ b/src/bq/include/bq/stream/sharedcontrol.h
@@ -15,6 +15,11 @@ namespace bq
         {
             std::vector<std::pair<std::function<void(T)>, size_t>> callbacks;
             std::shared_ptr<Control<T>> upstream;
+
+            // Source of callback ids. Lives on the control (not on a view) so
+            // that every SharedStream viewing this control — including sibling
+            // shares — draws from the same sequence and gets a unique id.
+            size_t nextIndex = 1;
         };
 
     } // stream

--- a/src/bq/include/bq/stream/sharedstream.h
+++ b/src/bq/include/bq/stream/sharedstream.h
@@ -3,6 +3,9 @@
 #include "stream.h"
 #include "sharedcontrol.h"
 
+#include <optional>
+#include <utility>
+
 namespace bq
 {
     namespace stream
@@ -10,15 +13,36 @@ namespace bq
         template <typename T>
         class SharedStream
         {
+            // Move-only, fire-once RAII guard: runs its function exactly once,
+            // when the still-active instance is destroyed. Moving transfers the
+            // function, disarming the moved-from instance so that the temporary
+            // spun up while constructing the downstream control does not fire
+            // the unregister early (before the callback is even registered) or a
+            // second time.
             template <typename TFunc>
             struct OnDelete
             {
-                ~OnDelete()
+                explicit OnDelete(TFunc callBack) :
+                    callBack(std::move(callBack))
                 {
-                    callBack();
                 }
 
-                TFunc callBack;
+                OnDelete(OnDelete&& other) noexcept :
+                    callBack(std::exchange(other.callBack, std::nullopt))
+                {
+                }
+
+                OnDelete(OnDelete const&) = delete;
+                OnDelete& operator=(OnDelete&&) = delete;
+                OnDelete& operator=(OnDelete const&) = delete;
+
+                ~OnDelete()
+                {
+                    if (callBack)
+                        (*callBack)();
+                }
+
+                std::optional<TFunc> callBack;
             };
 
         public:
@@ -31,17 +55,22 @@ namespace bq
             auto fmap(TFunc&& f) const -> Stream<std::invoke_result_t<TFunc, T>>
             {
                 using NewType = std::invoke_result_t<TFunc, T>;
-                size_t index = nextIndex_++;
+                size_t index = control_->nextIndex++;
 
-                auto destructor = [index, control = control_]()
+                auto unregister = [index, control = control_]()
                 {
                     for (auto i = control->callbacks.begin();
                             i != control->callbacks.end(); ++i)
                     {
                         if (i->second == index)
+                        {
                             control->callbacks.erase(i);
+                            break;
+                        }
                     }
                 };
+
+                OnDelete<decltype(unregister)> destructor(std::move(unregister));
 
                 using NewControl = ControlWithData<NewType, decltype(destructor)>;
                 auto newControl = std::make_shared<NewControl>(std::move(destructor));
@@ -68,7 +97,6 @@ namespace bq
 
         private:
             std::shared_ptr<SharedControl<T>> control_;
-            mutable size_t nextIndex_ = 1;
         };
     } // stream
 } // reactive

--- a/src/bq/test/streamtest.cpp
+++ b/src/bq/test/streamtest.cpp
@@ -169,6 +169,59 @@ TEST(Stream, lateContextMissesPriorEvents)
     EXPECT_EQ((std::vector<std::string>{ "late" }), c2.evaluate());
 }
 
+// A shared downstream must unregister its callback when destroyed, so its
+// mapping function stops running on subsequent events. (Currently fails: the
+// unregister lambda is stored on the control but never invoked.)
+TEST(Stream, sharedUnregistersOnDestroy)
+{
+    auto p = pipe<std::string>();
+    auto shared = std::move(p.stream).share();
+
+    int count = 0;
+    {
+        auto d = shared.fmap([&count](std::string s) { ++count; return s; });
+        p.handle.push("a");
+        EXPECT_EQ(1, count);
+    }
+
+    // d is destroyed; its callback must no longer run.
+    p.handle.push("b");
+    EXPECT_EQ(1, count);
+}
+
+// Destroying one shared view must not unregister a sibling that shares the same
+// control, even when destroyed out of creation order (callback ids must be
+// unique per control). Reachable because share() is idempotent per control.
+TEST(Stream, unregisterDoesNotStarveSibling)
+{
+    auto p = pipe<std::string>();
+
+    Stream<std::string> copy1 = p.stream;
+    Stream<std::string> copy2 = p.stream;
+
+    auto shared1 = std::move(copy1).share();
+    auto shared2 = std::move(copy2).share();
+
+    int count1 = 0;
+    int count2 = 0;
+
+    auto d1 = shared1.fmap([&count1](std::string s) { ++count1; return s; });
+
+    {
+        // Created after d1, destroyed before it.
+        auto d2 = shared2.fmap([&count2](std::string s) { ++count2; return s; });
+
+        p.handle.push("a");
+        EXPECT_EQ(1, count1);
+        EXPECT_EQ(1, count2);
+    }
+
+    // d2 is gone; d1 must still be registered, d2 must not fire.
+    p.handle.push("b");
+    EXPECT_EQ(2, count1);
+    EXPECT_EQ(1, count2);
+}
+
 TEST(Stream, collect)
 {
     auto p = pipe<std::string>();


### PR DESCRIPTION
## The bug

`SharedStream::fmap` (in `sharedstream.h`) registered a callback in
`SharedControl::callbacks` and built an `unregister` lambda meant to remove it
when the downstream `Stream` is destroyed. But that lambda was stored inertly as
the `data` member of `ControlWithData` and **nothing ever invoked it** —
`ControlWithData` just holds `TData data;`, and destroying it merely destroyed
the lambda without calling it. The `OnDelete` wrapper (`~OnDelete(){ callBack(); }`)
that was meant to be that `data` type was unused.

Net effect: **shared callbacks were never unregistered.** A destroyed
downstream's mapping function kept running on every future event, and (via
`collect`) the callback held a strong `shared_ptr` to a dead `Collect::Control`,
so destroying a `SignalContext` never detached it from its streams (leak).

A second, related defect: the callback id came from a **per-`SharedStream`**
counter, so two views of the same `SharedControl` (now possible because
`share()` is idempotent) could get colliding ids, and an out-of-order destroy
could erase the wrong callback.

## The fix

1. **Make the unregister actually run on destruction.** `OnDelete` is now a
   **move-only, fire-once** RAII guard: it holds the unregister in a
   `std::optional<TFunc>`, its move constructor `std::exchange`s the source to
   `std::nullopt` (disarming the moved-from instance), and `~OnDelete` calls
   back only while still armed. `ControlWithData` move-constructs the guard, so
   the temporary spun up in `fmap` is disarmed and the unregister fires exactly
   once — when the downstream control is destroyed — never early or twice.
2. **Unique callback ids per control.** The `nextIndex` counter moved from the
   per-view `SharedStream` onto `SharedControl` (`size_t nextIndex = 1;`), so
   every view — including sibling shares — draws unique ids.
3. **Fixed the erase loop** to `break` after erasing the matching callback
   instead of continuing with an invalidated iterator.

## Tests

The two characterizing tests now pass: `Stream.sharedUnregistersOnDestroy` and
`Stream.unregisterDoesNotStarveSibling`. The full `bq` and `btl` suites stay
green (including `Stream.share`, `Stream.collect`, `Stream.iterate`).

This PR is stacked on `stream-share-safe`; base is set accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)