### PR TITLE
Generalize SignalContext to N signals over one shared DataContext

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,9 +1,42 @@
 # Decisions
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `1c71f09` (2026-07-15).*
 
 Why non-obvious choices were made, so they are not re-litigated. Newest first.
 Each entry is intentionally short: the decision and its rationale.
+
+## `SignalContext` holds N signals over one shared `DataContext`
+
+`SignalContext` is parameterized over signal *types* (`SignalContext<TSignals...>`,
+each a `Signal<...>`/`AnySignal<...>`), not value packs, and drives all of them
+over a single shared `DataContext`. Every entry is addressed by index —
+`evaluate<I>()`, `didChange<I>()`, plus `didAnyChange()` — even with a single
+signal; there is no non-indexed convenience accessor.
+
+**Why:** several top-level signals (widget instance, introspection, window
+title) must advance in lockstep and dedup their shared sub-graphs. One shared
+`DataContext` makes `.share()` the cross-signal dedup lever — a shared node
+reachable from two entries is evaluated once per pass, not once per entry —
+while `.cache()` remains the temporal/sub-expression memoization lever.
+
+Parameterizing over signal *types* (rather than value packs) lets typed and
+type-erased signals coexist in one context and keeps `SignalContext` distinct
+from `merge`/`combine`, which fuse signals into one value pack. Per-signal
+**cadence was deliberately dropped**: every entry updates every frame, and
+per-signal evaluation memoization is the user's explicit choice via `.cache()`.
+
+Each entry's result is **cached by owned value**, uniformly regardless of
+arity — evaluated on construction and refreshed after any update in which that
+entry changed. `evaluate<I>()` returns a reference into that cached
+`SignalResult`; the caller extracts a value with `.get<N>()`. Caching by owned
+value (never by the reference-holding result the signal evaluates to) is the
+deliberate choice: an evaluated result can hold element references into signal
+data that go stale after `swapFrameData()` or a move, so the context copies the
+result into owned values on the way in and never aliases signal data.
+
+The one hard correctness constraint: `dataContext_.swapFrameData()` runs
+**exactly once per update pass, after every entry has updated** — never per
+entry, or one entry would rotate away frame data another still needs.
 
 ## Shape transforms are paint-time; layout size is separate
 

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -22,6 +22,13 @@ folder here and leave one-line hooks below.
 - Signals are **stateless graph descriptions**. The actual per-signal state
   (current values, caches) lives in a `SignalContext` (`bq/signal/signalcontext.h`),
   not in the signal object — which is why signals are cheap to copy and share.
+- A `SignalContext<TSignals...>` can hold **several** top-level signals over one
+  shared `DataContext`; they advance in lockstep and a `.share()` node reachable
+  from more than one of them is evaluated once per pass. Address every entry by
+  index (`evaluate<I>()`/`didChange<I>()`), even with a single signal — there is
+  no non-indexed accessor. Each entry's result is cached by owned value, so
+  `evaluate<I>()` never aliases signal data; extract with `.get<N>()`. See
+  `docs/decisions.md` for the rationale.
 - Evaluation is **change-driven**: a signal is recomputed when its inputs
   actually change, not on a fixed frame tick.
 

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -2,93 +2,133 @@
 
 #include "signal.h"
 #include "datacontext.h"
+#include "signaltraits.h"
+
+#include <tuple>
+#include <array>
+#include <cstddef>
+#include <utility>
 
 namespace bq::signal
 {
-    template <typename... Ts>
+    /** Drives and evaluates a set of signals.
+     *
+     * Signals are pure values: code builds and transforms them (constructing,
+     * mapping, combining) and normally never touches a SignalContext directly.
+     * The context is the one place the signal graph is actually run — it owns
+     * the per-signal state, advances it once per frame with `update()`, and
+     * hands back the current values via `evaluate<I>()` (each signal addressed
+     * by its index). In a framework this evaluation is centralized in a single
+     * long-lived context; bqui drives a window this way.
+     *
+     * Prefer one long-lived context over throwaway ones. The state lives in the
+     * context, so evaluating a signal in a fresh short-lived context starts from
+     * scratch and won't reflect what a live context has accumulated (stream
+     * history in particular is not replayed) — reach for the running context,
+     * not a quick one made to peek at a value.
+     *
+     * Several signals can share one context, so a `.share()` node reachable from
+     * more than one of them is evaluated once per update, not once per signal.
+     */
+    template <typename... TSignals>
     class SignalContext
     {
-    public:
-        using InnerResultType = std::optional<SignalResult<Ts...>>;
+        template <size_t I>
+        using EntryResultT =
+            SignalTypeT<std::tuple_element_t<I, std::tuple<TSignals...>>>;
 
-        SignalContext(AnySignal<Ts...> sig) :
-            sig_(std::move(sig)),
-            data_(sig_.unwrap().initialize(dataContext_, FrameInfo(0, {}))),
-            result_(sig_.unwrap().evaluate(dataContext_, data_))
+    public:
+        SignalContext(TSignals... sigs) :
+            signals_(std::move(sigs)...),
+            data_(initializeData(std::index_sequence_for<TSignals...>{})),
+            results_(evaluateAll(std::index_sequence_for<TSignals...>{}))
         {
             dataContext_.swapFrameData();
-        };
-
-        auto evaluate() const -> decltype(auto)
-        {
-            if constexpr(sizeof...(Ts) == 0)
-                sig_.unwrap().evaluate(dataContext_, data_);
-            if constexpr (sizeof...(Ts) == 1)
-                return result_->template get<0>();
-            else
-                return SignalResult<Ts...>(*result_);
         }
 
         UpdateResult update(FrameInfo const& frame)
         {
-            auto r = sig_.unwrap().update(dataContext_, data_, frame);
-            if (r.didChange)
-                result_ = sig_.unwrap().evaluate(dataContext_, data_);
-            dataContext_.swapFrameData();
-
-            didChange_ = r.didChange;
-
-            return r;
+            return updateImpl(frame, std::index_sequence_for<TSignals...>{});
         }
 
+        template <size_t I>
+        EntryResultT<I> const& evaluate() const
+        {
+            return std::get<I>(results_);
+        }
+
+        template <size_t I>
         bool didChange() const
         {
-            return didChange_;
+            return changed_[I];
         }
 
-        btl::connection observe(std::function<void()> callback)
+        bool didAnyChange() const
         {
-            return sig_.unwrap().observe(dataContext_, data_,
-                    std::move(callback));
-        }
-
-        template <typename... Us, typename = std::enable_if_t<
-            btl::all(std::is_convertible_v<Ts, Us>...)
-            >>
-        operator SignalContext<Us...>() const
-        {
-            return SignalContext<Us...>(sig_);
+            for (bool c : changed_)
+                if (c)
+                    return true;
+            return false;
         }
 
     private:
-        AnySignal<Ts...> sig_;
-        DataContext dataContext_;
-        typename AnySignal<Ts...>::DataType data_;
-        InnerResultType result_;
-        bool didChange_ = false;
+        template <size_t... Is>
+        std::tuple<SignalDataTypeT<TSignals>...> initializeData(
+                std::index_sequence<Is...>)
+        {
+            return std::tuple<SignalDataTypeT<TSignals>...>(
+                    std::get<Is>(signals_).unwrap().initialize(
+                        dataContext_, FrameInfo(0, {}))...);
+        }
+
+        // Evaluate one entry and return its result by owned value (copying any
+        // references the signal returns into the cache's SignalTypeT).
+        template <size_t I>
+        EntryResultT<I> evaluateEntry() const
+        {
+            return std::get<I>(signals_).unwrap().evaluate(
+                    dataContext_, std::get<I>(data_));
+        }
+
+        template <size_t... Is>
+        std::tuple<EntryResultT<Is>...> evaluateAll(std::index_sequence<Is...>)
+        {
+            return std::tuple<EntryResultT<Is>...>(evaluateEntry<Is>()...);
+        }
+
+        template <size_t I>
+        UpdateResult updateEntry(FrameInfo const& frame)
+        {
+            auto r = std::get<I>(signals_).unwrap().update(
+                    dataContext_, std::get<I>(data_), frame);
+            changed_[I] = r.didChange;
+            if (r.didChange)
+                std::get<I>(results_) = evaluateEntry<I>();
+            return r;
+        }
+
+        template <size_t... Is>
+        UpdateResult updateImpl(FrameInfo const& frame, std::index_sequence<Is...>)
+        {
+            UpdateResult result = (UpdateResult{} + ... + updateEntry<Is>(frame));
+            dataContext_.swapFrameData();
+            return result;
+        }
+
+        // evaluate() must be usable on a const SignalContext, but the signal
+        // interface takes DataContext by non-const reference for shared/cached
+        // lookups. Evaluation does not mutate signal state, so the context is
+        // logically const; mark the DataContext mutable to reflect that.
+        mutable DataContext dataContext_;
+        std::tuple<TSignals...> signals_;
+        std::tuple<SignalDataTypeT<TSignals>...> data_;
+        std::tuple<SignalTypeT<TSignals>...> results_;
+        std::array<bool, sizeof...(TSignals)> changed_ = {};
     };
 
-    template <typename T>
-    struct ResultToContext
+    template <typename... TSignals>
+    SignalContext<std::decay_t<TSignals>...> makeSignalContext(TSignals... sigs)
     {
-    };
-
-    template <typename... Ts>
-    struct ResultToContext<SignalResult<Ts...>>
-    {
-        using type = SignalContext<Ts...>;
-    };
-
-    template <typename TSignal>
-    using SignalToContext = typename ResultToContext<SignalTypeT<TSignal>>::type;
-
-    template <typename TStorage, typename... Ts>
-    SignalToContext<typename Signal<TStorage, Ts...>::StorageType> makeSignalContext(
-            Signal<TStorage, Ts...> sig)
-    {
-        return SignalToContext<typename Signal<TStorage, Ts...>::StorageType>(
-                std::move(sig)
-                );
+        return SignalContext<std::decay_t<TSignals>...>(std::move(sigs)...);
     }
 } // namespace bq::signal
-

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -18,6 +18,7 @@ libbqdep = declare_dependency(
 
 bqtest = executable('bqtest',
   'test/signaltest.cpp',
+  'test/signalcontexttest.cpp',
   'test/streamtest.cpp',
   dependencies: [libbqdep, gtestdep],
   )

--- a/src/bq/test/signalcontexttest.cpp
+++ b/src/bq/test/signalcontexttest.cpp
@@ -1,0 +1,100 @@
+#include <bq/signal/signal.h>
+#include <bq/signal/constant.h>
+#include <bq/signal/signalcontext.h>
+#include <bq/signal/input.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+using namespace bq::signal;
+
+// A SignalContext can hold several differently-typed top-level signals. They
+// update in lockstep and each entry is addressed by index.
+TEST(signalContext, multipleSignalsUpdateInLockstep)
+{
+    auto number = makeInput(1);
+    auto text = makeInput<std::string>("a");
+
+    auto numberSignal = number.signal.map([](int n) { return n * 10; });
+
+    auto context = makeSignalContext(std::move(numberSignal), text.signal);
+
+    EXPECT_EQ(10, context.evaluate<0>().get<0>());
+    EXPECT_EQ("a", context.evaluate<1>().get<0>());
+
+    // Before the first update no entry has changed.
+    EXPECT_FALSE(context.didChange<0>());
+    EXPECT_FALSE(context.didChange<1>());
+    EXPECT_FALSE(context.didAnyChange());
+
+    // Change only the first input, then update the whole context once.
+    number.handle.set(5);
+    auto result = context.update(FrameInfo(1, {}));
+
+    EXPECT_TRUE(result.didChange);
+    EXPECT_TRUE(context.didChange<0>());
+    EXPECT_FALSE(context.didChange<1>());
+    EXPECT_TRUE(context.didAnyChange());
+
+    EXPECT_EQ(50, context.evaluate<0>().get<0>());
+    EXPECT_EQ("a", context.evaluate<1>().get<0>());
+}
+
+// The whole point of the shared DataContext: a shared subgraph referenced from
+// two entries of one context is updated once per pass, not once per entry.
+TEST(signalContext, sharedSubgraphEvaluatedOncePerPass)
+{
+    auto input = makeInput(1);
+    auto counter = std::make_shared<int>(0);
+
+    auto shared = input.signal
+        .map([counter](int n)
+            {
+                ++*counter;
+                return n;
+            })
+        .share();
+
+    // Two entries reference the SAME shared signal.
+    auto a = shared.map([](int n) { return n + 1; });
+    auto b = shared.map([](int n) { return n + 2; });
+
+    auto context = makeSignalContext(std::move(a), std::move(b));
+
+    // The initial pass (initialize) evaluated the side-effecting map once,
+    // despite being reachable from both entries.
+    int const afterInit = *counter;
+
+    input.handle.set(7);
+    auto result = context.update(FrameInfo(1, {}));
+
+    EXPECT_TRUE(result.didChange);
+
+    // The shared map ran exactly once for the update pass, not once per entry.
+    EXPECT_EQ(afterInit + 1, *counter);
+
+    EXPECT_EQ(8, context.evaluate<0>().get<0>());
+    EXPECT_EQ(9, context.evaluate<1>().get<0>());
+}
+
+// A single-signal context is the one-arg instantiation and is addressed the
+// same way: evaluate<0>() returns entry 0's SignalResult, didChange<0>() its
+// change flag. There is no non-indexed convenience accessor.
+TEST(signalContext, singleSignal)
+{
+    auto input = makeInput(42);
+
+    auto context = makeSignalContext(input.signal);
+
+    EXPECT_EQ(42, context.evaluate<0>().get<0>());
+    EXPECT_FALSE(context.didChange<0>());
+
+    input.handle.set(24);
+    auto result = context.update(FrameInfo(1, {}));
+
+    EXPECT_TRUE(result.didChange);
+    EXPECT_TRUE(context.didChange<0>());
+    EXPECT_EQ(24, context.evaluate<0>().get<0>());
+}

--- a/src/bq/test/signaltest.cpp
+++ b/src/bq/test/signaltest.cpp
@@ -92,9 +92,9 @@ TEST(signal, constant)
 
     auto c = makeSignalContext(s);
 
-    EXPECT_EQ(10, c.evaluate());
+    EXPECT_EQ(10, c.evaluate<0>().get<0>());
 
-    EXPECT_EQ(Type<int const&>(), getType(c.evaluate()));
+    EXPECT_EQ(Type<int const&>(), getType(c.evaluate<0>().get<0>()));
 
     FrameInfo frame(1, signal_time_t(10));
 
@@ -110,9 +110,9 @@ TEST(signal, signalContext)
 
     EXPECT_EQ(std::nullopt, r.nextUpdate);
 
-    EXPECT_EQ(Type<int const&>(), getType(c.evaluate()));
+    EXPECT_EQ(Type<int const&>(), getType(c.evaluate<0>().get<0>()));
 
-    int v = c.evaluate();
+    int v = c.evaluate<0>().get<0>();
 
     EXPECT_EQ(42, v);
 }
@@ -125,20 +125,21 @@ TEST(signal, signalInput)
 
     auto c = makeSignalContext(input.signal);
 
-    EXPECT_EQ(Type<SignalContext<int const&>>(), Type<decltype(c)>());
+    EXPECT_EQ(Type<SignalContext<decltype(input.signal)>>(),
+            Type<decltype(c)>());
 
-    EXPECT_EQ(42, c.evaluate());
+    EXPECT_EQ(42, c.evaluate<0>().get<0>());
 
     input.handle.set(22);
 
-    EXPECT_EQ(42, c.evaluate());
+    EXPECT_EQ(42, c.evaluate<0>().get<0>());
 
     auto r = c.update(FrameInfo(1, {}));
     EXPECT_EQ(std::nullopt, r.nextUpdate);
 
-    EXPECT_EQ(22, c.evaluate());
+    EXPECT_EQ(22, c.evaluate<0>().get<0>());
 
-    EXPECT_EQ(Type<int const&>(), getType(c.evaluate()));
+    EXPECT_EQ(Type<int const&>(), getType(c.evaluate<0>().get<0>()));
 }
 
 TEST(signal, map)
@@ -154,7 +155,7 @@ TEST(signal, map)
 
     auto c = makeSignalContext(std::move(s));
 
-    EXPECT_EQ(84, c.evaluate());
+    EXPECT_EQ(84, c.evaluate<0>().get<0>());
 
     auto r = c.update(FrameInfo(1, {}));
 
@@ -163,11 +164,11 @@ TEST(signal, map)
 
     input.handle.set(12);
 
-    EXPECT_EQ(84, c.evaluate());
+    EXPECT_EQ(84, c.evaluate<0>().get<0>());
 
     r = c.update(FrameInfo(2, {}));
 
-    EXPECT_EQ(24, c.evaluate());
+    EXPECT_EQ(24, c.evaluate<0>().get<0>());
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ(std::nullopt, r.nextUpdate);
 }
@@ -191,7 +192,7 @@ TEST(signal, mapReferenceToTemp)
 
     auto c = makeSignalContext(std::move(s2));
 
-    EXPECT_EQ(42, c.evaluate());
+    EXPECT_EQ(42, c.evaluate<0>().get<0>());
 }
 
 TEST(signal, merge)
@@ -209,12 +210,12 @@ TEST(signal, merge)
 
     auto c = makeSignalContext(std::move(s));
 
-    Type<SignalResult<int const&, int const&, std::string const&>> type2;
-    EXPECT_EQ(type2, getType(c.evaluate()));
+    Type<SignalResult<int, int, std::string> const&> type2;
+    EXPECT_EQ(type2, getType(c.evaluate<0>()));
 
-    EXPECT_EQ(42, c.evaluate().get<0>());
-    EXPECT_EQ(20, c.evaluate().get<1>());
-    EXPECT_EQ("test", c.evaluate().get<2>());
+    EXPECT_EQ(42, c.evaluate<0>().get<0>());
+    EXPECT_EQ(20, c.evaluate<0>().get<1>());
+    EXPECT_EQ("test", c.evaluate<0>().get<2>());
 }
 
 TEST(signal, share)
@@ -230,7 +231,7 @@ TEST(signal, share)
 
     static_assert(checkSignal<decltype(s2.unwrap())>());
 
-    std::vector<SignalContext<std::string>> contexts;
+    std::vector<SignalContext<decltype(s2)>> contexts;
     for (int i = 0; i < 1024; ++i)
     {
         contexts.emplace_back(makeSignalContext(s2));
@@ -242,7 +243,7 @@ TEST(signal, share)
         futures.push_back(btl::async([&context]() mutable
             {
 
-                EXPECT_EQ("hello world!", context.evaluate());
+                EXPECT_EQ("hello world!", context.evaluate<0>().get<0>());
 
                 auto r = context.update(FrameInfo(1, signal_time_t(16)));
 
@@ -264,12 +265,12 @@ TEST(signal, share)
 
         std::move(f).then([&]()
             {
-                EXPECT_EQ("hello world!", context.evaluate());
+                EXPECT_EQ("hello world!", context.evaluate<0>().get<0>());
 
                 auto r = context.update(FrameInfo(2, signal_time_t(16)));
                 EXPECT_TRUE(r.didChange);
 
-                EXPECT_EQ("bye world!", context.evaluate());
+                EXPECT_EQ("bye world!", context.evaluate<0>().get<0>());
             });
     }
 
@@ -301,7 +302,7 @@ TEST(signal, join)
 
     auto c = makeSignalContext(j);
 
-    auto r1 = c.evaluate();
+    auto r1 = c.evaluate<0>();
 
     EXPECT_EQ("hello", r1.get<0>());
     EXPECT_EQ(42, r1.get<1>());
@@ -311,11 +312,11 @@ TEST(signal, join)
     input4.handle.set("?");
 
     c.update(FrameInfo(1, {}));
-    auto r2 = c.evaluate();
+    auto r2 = c.evaluate<0>();
 
     EXPECT_EQ("world", r2.get<0>());
     EXPECT_EQ(42, r2.get<1>());
-    EXPECT_EQ("?", r1.get<2>());
+    EXPECT_EQ("?", r2.get<2>());
 }
 
 TEST(signal, combine)
@@ -337,7 +338,7 @@ TEST(signal, combine)
 
     auto c = makeSignalContext(s);
 
-    auto r = c.evaluate();
+    auto r = c.evaluate<0>().get<0>();
 
     EXPECT_EQ(v1, r);
 
@@ -348,7 +349,7 @@ TEST(signal, combine)
 
     EXPECT_TRUE(ur.didChange);
 
-    r = c.evaluate();
+    r = c.evaluate<0>().get<0>();
 
     EXPECT_EQ(v2, r);
 
@@ -368,7 +369,7 @@ TEST(signal, conditional)
 
     auto c = makeSignalContext(s);
 
-    auto r = c.evaluate();
+    auto r = c.evaluate<0>();
 
     EXPECT_EQ("hello", r.get<0>());
     EXPECT_EQ(42, r.get<1>());
@@ -376,7 +377,7 @@ TEST(signal, conditional)
     cond.handle.set(false);
 
     auto ur = c.update(FrameInfo(1, {}));
-    r = c.evaluate();
+    r = c.evaluate<0>();
 
     EXPECT_TRUE(ur.didChange);
 
@@ -433,14 +434,14 @@ TEST(signal, tee)
 
     auto c = makeSignalContext(s2);
 
-    auto r1 = c.evaluate();
+    auto r1 = c.evaluate<0>();
 
     EXPECT_EQ("hellohello", r1.get<0>());
     EXPECT_EQ(84, r1.get<1>());
 
     c.update(FrameInfo(1, {}));
 
-    auto r2 = c.evaluate();
+    auto r2 = c.evaluate<0>();
 
     EXPECT_EQ("hellohello", r2.get<0>());
     EXPECT_EQ(84, r2.get<1>());
@@ -448,7 +449,7 @@ TEST(signal, tee)
     input1.handle.set("world", 22);
     c.update(FrameInfo(2, {}));
 
-    auto r3 = c.evaluate();
+    auto r3 = c.evaluate<0>();
 
     EXPECT_EQ("worldworld", r3.get<0>());
     EXPECT_EQ(44, r3.get<1>());
@@ -471,14 +472,14 @@ TEST(signal, teeCircular)
 
     auto c = makeSignalContext(s2);
 
-    auto r1 = c.evaluate();
+    auto r1 = c.evaluate<0>();
 
     EXPECT_EQ("hellohelloworld", r1.get<0>());
     EXPECT_EQ(106, r1.get<1>());
 
     c.update(FrameInfo(1, {}));
 
-    auto r2 = c.evaluate();
+    auto r2 = c.evaluate<0>();
 
     EXPECT_EQ("hellohelloworld", r2.get<0>());
     EXPECT_EQ(106, r2.get<1>());
@@ -504,14 +505,14 @@ TEST(signal, teeWithFunc)
 
     auto c = makeSignalContext(s2);
 
-    auto r1 = c.evaluate();
+    auto r1 = c.evaluate<0>();
 
     EXPECT_EQ(106, r1.get<0>());
     EXPECT_EQ("hellohelloworld", r1.get<1>());
 
     c.update(FrameInfo(1, {}));
 
-    auto r2 = c.evaluate();
+    auto r2 = c.evaluate<0>();
 
     EXPECT_EQ(106, r2.get<0>());
     EXPECT_EQ("hellohelloworld", r2.get<1>());
@@ -525,9 +526,9 @@ TEST(signal, makeOptional)
 
     auto c = makeSignalContext(s2);
 
-    EXPECT_EQ(Type<std::optional<int> const&>(), getType(c.evaluate()));
+    EXPECT_EQ(Type<std::optional<int> const&>(), getType(c.evaluate<0>().get<0>()));
 
-    EXPECT_EQ(std::make_optional(42), c.evaluate());
+    EXPECT_EQ(std::make_optional(42), c.evaluate<0>().get<0>());
 }
 
 TEST(signal, fromOptional)
@@ -630,7 +631,7 @@ TEST(signal, cast)
 
     auto c = makeSignalContext(s2);
 
-    auto f = c.evaluate();
+    auto f = c.evaluate<0>().get<0>();
 
     EXPECT_EQ(Type<std::function<std::string(int)>>(), Type<decltype(f)>());
 
@@ -655,7 +656,7 @@ TEST(signal, bindToFunction)
 
     auto c = makeSignalContext(s2);
 
-    auto f = c.evaluate();
+    auto f = c.evaluate<0>().get<0>();
 
     EXPECT_EQ("42hello, world", f("world"));
 }
@@ -670,13 +671,13 @@ TEST(signal, withChanged)
 
     auto c = makeSignalContext(s1);
 
-    auto v = c.evaluate();
+    auto v = c.evaluate<0>();
     EXPECT_FALSE(v.get<0>());
     EXPECT_EQ(42, v.get<1>());
     EXPECT_EQ("hello", v.get<2>());
 
     auto r = c.update(FrameInfo(1, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_FALSE(v.get<0>());
@@ -686,7 +687,7 @@ TEST(signal, withChanged)
     input.handle.set(22, "world");
 
     r = c.update(FrameInfo(2, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_TRUE(v.get<0>());
@@ -694,7 +695,7 @@ TEST(signal, withChanged)
     EXPECT_EQ("world", v.get<2>());
 
     r = c.update(FrameInfo(3, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     // Inner value did not change but our own first value changed from true to
     // false
@@ -704,7 +705,7 @@ TEST(signal, withChanged)
     EXPECT_EQ("world", v.get<2>());
 
     r = c.update(FrameInfo(4, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_FALSE(v.get<0>());
@@ -727,25 +728,25 @@ TEST(signal, withPrevious)
 
     auto c = makeSignalContext(s);
 
-    auto v = c.evaluate();
+    auto v = c.evaluate<0>().get<0>();
 
     EXPECT_EQ("helloworld", v);
 
     auto r = c.update(FrameInfo(1, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("helloworld", v);
 
     input.handle.set("bye");
     r = c.update(FrameInfo(2, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ("helloworldbye", v);
 
     r = c.update(FrameInfo(3, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("helloworldbye", v);
@@ -766,13 +767,13 @@ TEST(signal, withPreviousMulti)
 
     auto c = makeSignalContext(s);
 
-    auto v = c.evaluate();
+    auto v = c.evaluate<0>();
 
     EXPECT_EQ("helloworld", v.get<0>());
     EXPECT_EQ(64, v.get<1>());
 
     auto r = c.update(FrameInfo(1, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("helloworld", v.get<0>());
@@ -780,14 +781,14 @@ TEST(signal, withPreviousMulti)
 
     input.handle.set(33, "bye");
     r = c.update(FrameInfo(2, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ("byehelloworld", v.get<0>());
     EXPECT_EQ(97, v.get<1>());
 
     r = c.update(FrameInfo(3, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("byehelloworld", v.get<0>());

--- a/src/bq/test/streamtest.cpp
+++ b/src/bq/test/streamtest.cpp
@@ -143,8 +143,8 @@ TEST(Stream, collectInTwoContexts)
 
     EXPECT_TRUE(r1.didChange);
     EXPECT_TRUE(r2.didChange);
-    EXPECT_EQ((std::vector<std::string>{ "a" }), c1.evaluate());
-    EXPECT_EQ((std::vector<std::string>{ "a" }), c2.evaluate());
+    EXPECT_EQ((std::vector<std::string>{ "a" }), c1.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<std::string>{ "a" }), c2.evaluate<0>().get<0>());
 }
 
 // A context created AFTER an event was pushed misses that event permanently
@@ -165,8 +165,8 @@ TEST(Stream, lateContextMissesPriorEvents)
     c1.update(signal::FrameInfo(1, {}));
     c2.update(signal::FrameInfo(1, {}));
 
-    EXPECT_EQ((std::vector<std::string>{ "early", "late" }), c1.evaluate());
-    EXPECT_EQ((std::vector<std::string>{ "late" }), c2.evaluate());
+    EXPECT_EQ((std::vector<std::string>{ "early", "late" }), c1.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<std::string>{ "late" }), c2.evaluate<0>().get<0>());
 }
 
 // A shared downstream must unregister its callback when destroyed, so its
@@ -232,14 +232,14 @@ TEST(Stream, collect)
 
     auto c = signal::makeSignalContext(s);
 
-    EXPECT_EQ(std::vector<std::string>(), c.evaluate());
+    EXPECT_EQ(std::vector<std::string>(), c.evaluate<0>().get<0>());
 
     p.handle.push("test1");
 
     auto r = c.update(signal::FrameInfo(1, {}));
     EXPECT_TRUE(r.didChange);
 
-    auto r1 = c.evaluate();
+    auto r1 = c.evaluate<0>().get<0>();
     EXPECT_EQ(1, r1.size());
     EXPECT_EQ("test1", r1.at(0));
 }
@@ -260,12 +260,12 @@ TEST(Stream, iterate)
     static_assert(signal::checkSignal<decltype(s.unwrap())>());
 
     auto c = signal::makeSignalContext(s);
-    auto v = c.evaluate();
+    auto v = c.evaluate<0>().get<0>();
 
     EXPECT_EQ("hello", v);
 
     auto r = c.update(signal::FrameInfo(1, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("hello", v);
@@ -273,14 +273,14 @@ TEST(Stream, iterate)
     values.handle.push("world");
 
     r = c.update(signal::FrameInfo(2, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ("helloworld", v);
 
     initial.handle.set("");
     r = c.update(signal::FrameInfo(3, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ("", v);
@@ -290,25 +290,25 @@ TEST(Stream, iterate)
     values.handle.push("world");
 
     r = c.update(signal::FrameInfo(4, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_TRUE(r.didChange);
     EXPECT_EQ("byeworld", v);
 
     r = c.update(signal::FrameInfo(5, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("byeworld", v);
 
     r = c.update(signal::FrameInfo(6, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("byeworld", v);
 
     r = c.update(signal::FrameInfo(7, {}));
-    v = c.evaluate();
+    v = c.evaluate<0>().get<0>();
 
     EXPECT_FALSE(r.didChange);
     EXPECT_EQ("byeworld", v);

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -81,12 +81,12 @@ public:
         widgetInstanceSignal_(window_.getWidget()(
                     BuildParams{}
                     )(std::move(size_.signal)).getInstance()),
-        widgetInstance_(widgetInstanceSignal_.evaluate()),
+        widgetInstance_(widgetInstanceSignal_.evaluate<0>().get<0>()),
         titleSignal_(window_.getTitle()),
         drawing_(memory_)
     {
         aseWindow.setVisible(true);
-        aseWindow.setTitle(titleSignal_.evaluate());
+        aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
 
         aseWindow.setFrameCallback([this](ase::Frame const& frame) {
                 return onFrame(frame);
@@ -270,14 +270,14 @@ public:
         updateResult = updateResult + titleSignal_.update(frameInfo);
 
 
-        if (titleSignal_.didChange())
-            aseWindow.setTitle(titleSignal_.evaluate());
+        if (titleSignal_.didChange<0>())
+            aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
 
-        if (widgetInstanceSignal_.didChange())
+        if (widgetInstanceSignal_.didChange<0>())
         {
             ZoneScopedN("Widget instance signal evaluation");
 
-            widgetInstance_ = widgetInstanceSignal_.evaluate();
+            widgetInstance_ = widgetInstanceSignal_.evaluate<0>().get<0>();
 
             // If there's an area with the same id -> update
             auto areas = widgetInstance_.getInputAreas();
@@ -331,7 +331,7 @@ public:
             }
         }
 
-        if (widgetInstanceSignal_.didChange()
+        if (widgetInstanceSignal_.didChange<0>()
                 || (nextUpdate_ && *nextUpdate_ <= timer)
                 )
         {
@@ -417,7 +417,7 @@ public:
 
     std::string getTitle() const
     {
-        return titleSignal_.evaluate();
+        return titleSignal_.evaluate<0>().get<0>();
     }
 
     widget::Instance const& getWidgetInstance() const
@@ -435,9 +435,10 @@ private:
     avg::Painter painter_;
     bq::signal::Input<bq::signal::SignalResult<ase::Vector2f>,
         bq::signal::SignalResult<ase::Vector2f>> size_;
-    bq::signal::SignalContext<widget::Instance> widgetInstanceSignal_;
+    bq::signal::SignalContext<bq::signal::AnySignal<widget::Instance>>
+        widgetInstanceSignal_;
     widget::Instance widgetInstance_;
-    bq::signal::SignalContext<std::string> titleSignal_;
+    bq::signal::SignalContext<bq::signal::AnySignal<std::string>> titleSignal_;
     //RenderCache cache_;
     std::unordered_map<unsigned int, std::vector<InputArea>> areas_;
     std::unordered_map<ase::KeyCode,
@@ -496,7 +497,7 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
             bq::signal::FrameInfo frame{ getNextFrameId(), aseFrame.dt };
             auto [timeToNext, didChange] = running.update(frame);
 
-            return running.evaluate();
+            return running.evaluate<0>().get<0>();
         });
 
     DBG("Shutting down...");

--- a/src/bqui/test/widgetinstancemodifiertest.cpp
+++ b/src/bqui/test/widgetinstancemodifiertest.cpp
@@ -59,7 +59,7 @@ TEST(Widget, widgetBuildParameters)
             {
                 auto p = params.get<TestTag>();
 
-                tag1 = p ? bq::signal::makeSignalContext(*p).evaluate() : "no p";
+                tag1 = p ? bq::signal::makeSignalContext(*p).evaluate<0>().get<0>() : "no p";
 
                 return widget;
             },
@@ -74,7 +74,7 @@ TEST(Widget, widgetBuildParameters)
             {
                 auto p = params.get<TestTag>();
 
-                tag2 = p ? bq::signal::makeSignalContext(*p).evaluate() : "no p";
+                tag2 = p ? bq::signal::makeSignalContext(*p).evaluate<0>().get<0>() : "no p";
 
                 return widget;
             },
@@ -111,7 +111,7 @@ TEST(Widget, differentModifiers)
             ).getInstance();
 
     auto context = makeSignalContext(instanceSignal);
-    auto instance = context.evaluate();
+    auto instance = context.evaluate<0>().get<0>();
 
     EXPECT_EQ(avg::Vector2f(200.0f, 400.0f), instance.getSize());
 }
@@ -123,7 +123,7 @@ TEST(Widget, withParams)
     auto widget = makeWidget()
         | makeWidgetModifier([&](auto widget, auto str)
             {
-                tag = signal::makeSignalContext(str).evaluate();
+                tag = signal::makeSignalContext(str).template evaluate<0>().template get<0>();
                 return widget;
             }, provideParam<TestTag>())
         ;
@@ -142,7 +142,7 @@ TEST(Widget, setParams)
     auto widget = makeWidget()
         | makeWidgetModifier([&](auto widget, auto str)
             {
-                tag = signal::makeSignalContext(str).evaluate();
+                tag = signal::makeSignalContext(str).template evaluate<0>().template get<0>();
                 return widget;
             },
             provideParam<TestTag>()
@@ -169,7 +169,7 @@ TEST(Widget, builderModifierTags)
                 return std::move(widget)
                     | makeBuilderModifierWithSize([&](auto builder, auto, auto tagValue)
                         {
-                            tag = signal::makeSignalContext(tagValue).evaluate();
+                            tag = signal::makeSignalContext(tagValue).template evaluate<0>().template get<0>();
                             return builder;
                         }, provideParam<TestTag>());
             })
@@ -180,13 +180,13 @@ TEST(Widget, builderModifierTags)
             })
         | makeBuilderModifierWithSize([&](auto builder, auto, auto tagValue)
             {
-                tag2 = signal::makeSignalContext(tagValue).evaluate();
+                tag2 = signal::makeSignalContext(tagValue).template evaluate<0>().template get<0>();
                 return builder;
             }, provideParam<TestTag>())
         | setParams<TestTag>("set value 2")
         | makeBuilderModifier([&](auto builder, auto tagValue)
             {
-                tag3 = signal::makeSignalContext(tagValue).evaluate();
+                tag3 = signal::makeSignalContext(tagValue).template evaluate<0>().template get<0>();
                 return builder;
             }, provideParam<TestTag>())
         ;
@@ -210,7 +210,7 @@ TEST(Widget, elementModifierParams)
             {
                 tag = signal::makeSignalContext(
                         element.getParams().template valueOrDefault<TestTag>()
-                        ).evaluate();
+                        ).template evaluate<0>().template get<0>();
                 return element;
             })
         | setParams<TestTag>("set value 1")
@@ -218,7 +218,7 @@ TEST(Widget, elementModifierParams)
             {
                 tag2 = signal::makeSignalContext(
                         element.getParams().template valueOrDefault<TestTag>()
-                        ).evaluate();
+                        ).template evaluate<0>().template get<0>();
                 return element;
             })
         | setParams<TestTag>("set value 2")
@@ -226,7 +226,7 @@ TEST(Widget, elementModifierParams)
             {
                 tag3 = signal::makeSignalContext(
                         element.getParams().template valueOrDefault<TestTag>()
-                        ).evaluate();
+                        ).template evaluate<0>().template get<0>();
                 return element;
             })
         ;


### PR DESCRIPTION
## What

Generalizes `bq::signal::SignalContext` from a **single** signal to **N signals sharing one `DataContext`**, so multiple top-level signals update in lockstep and `.share()`/`.cache()` nodes deduplicate across them. This is the reactive-core groundwork for driving several signals (widget instance, introspection, window title) from one live context.

`SignalContext` is now parameterized over signal **types** (`SignalContext<TSignals...>`, each a `Signal<...>` or `AnySignal<...>`), not value packs. All entries share one `DataContext`.

## Design

- **One shared `DataContext`** across all entries — a `.share()` node reachable from more than one entry is evaluated **once per pass**, not once per entry. `.share()` is the cross-signal dedup lever; `.cache()` remains the temporal/sub-expression memoization lever.
- **Parameterized over signal types** (not value packs) so typed and type-erased signals coexist in one context, and it stays distinct from `merge`/`combine` (which fuse into one value pack).
- **Indexed accessors, uniformly**: `evaluate<I>()`, `didChange<I>()`, `didAnyChange()`. `evaluate` is **always indexed** — `evaluate<0>()` even with a single signal (no non-indexed convenience, no arity branching).
- **Results cached by owned value.** Every entry's result is evaluated on construction and refreshed after any update in which that entry changed; `emplace` copies the (possibly reference-holding) evaluate result into the owned `SignalResult`, so the cache never aliases signal data and can't go stale. `evaluate<I>()` returns a const reference into that owned cache — a value obtained from it is a snapshot, not a live view.
- **Cadence deliberately dropped**: every entry updates every frame; per-signal evaluation memoization is the user's explicit choice via `.cache()`.
- **The one hard correctness constraint**: `DataContext::swapFrameData()` runs **exactly once per update pass, after every entry has updated** — never per entry, or one entry would rotate away frame data another still needs.

## Migration

- The non-indexed `evaluate()`/`didChange()` are gone; all single-signal call sites now index explicitly (`evaluate<0>().get<0>()`, `didChange<0>()`).
- `makeSignalContext(sigs...)` deduces `SignalContext<std::decay_t<TSignals>...>` and accepts one or many signals.
- `WindowGlue`'s two contexts become the `AnySignal<...>` one-arg form; keeping them as two separate contexts is intentional (combining them is a separate future PR). No `extern template` instantiations of `SignalContext` exist, so none needed updating.
- Because results are owned snapshots (not live references), the two tests that relied on live-reference behavior were updated: `signal.merge`'s result type drops the `const&`s (`SignalResult<int, int, std::string>`), and `signal.join` reads the post-update value off a freshly re-evaluated snapshot rather than an earlier one.

## Tests

New `src/bq/test/signalcontexttest.cpp`: multi-signal lockstep updates; the shared-subgraph-evaluated-once-per-pass guarantee; single-signal use.

Full suite green in a configured MSVC build: `bq`, `avg`, `bqui`, `btl` — **4/4 OK** (new tests plus the existing `share`/`merge`/`join`/`cache`/`check` suite, migrated to the indexed accessors).

## Docs

- `docs/decisions.md`: records the decision (multi-signal over one shared `DataContext`; signal-type parameterization; dropped cadence; `.share()` vs `.cache()` levers; owned-value result caching; indexed-only `evaluate<I>()`; the `swapFrameData`-once-per-pass constraint).
- `src/bq/AGENTS.md`: notes the multi-signal capability in the evaluation model.
