### PR TITLE
Anchor test data paths at the repo root

### DIFF
--- a/src/avg/meson.build
+++ b/src/avg/meson.build
@@ -51,5 +51,7 @@ avgtest =  executable('avgtest',
   dependencies: [gtestdep, libavgdep],
   )
 
-test('avg', avgtest, timeout: 1200, args: ['--gtest_output=xml'])
+test('avg', avgtest, timeout: 1200,
+  args: ['--gtest_output=xml:' + meson.current_build_dir() / 'test_detail.xml'],
+  workdir: meson.project_source_root())
 

--- a/src/avg/test/fonttest.cpp
+++ b/src/avg/test/fonttest.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <string>
 
-const std::string fontPath = "../../data/fonts/OpenSans-Regular.ttf";
+const std::string fontPath = "data/fonts/OpenSans-Regular.ttf";
 
 TEST(Font, ToPath)
 {

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -94,4 +94,6 @@ bquitest =  executable('bquitest',
   dependencies: [gtestdep, libbquidep],
   )
 
-test('bqui', bquitest, timeout: 1200, args: ['--gtest_output=xml'])
+test('bqui', bquitest, timeout: 1200,
+  args: ['--gtest_output=xml:' + meson.current_build_dir() / 'test_detail.xml'],
+  workdir: meson.project_source_root())

--- a/src/bqui/src/theme.cpp
+++ b/src/bqui/src/theme.cpp
@@ -57,7 +57,7 @@ struct ThemeDeferred
     avg::Color blue                 = color::blue;
     avg::Color cyan                 = color::cyan;
     avg::Color green                = color::green;
-    avg::Font font = avg::Font("../../data/fonts/OpenSans-Regular.ttf", 0);
+    avg::Font font = avg::Font("data/fonts/OpenSans-Regular.ttf", 0);
     float textHeight = 12.0f;
 
     bool operator==(ThemeDeferred const& rhs) const
@@ -111,7 +111,7 @@ ThemeDeferred::ThemeDeferred() :
     blue(color::blue),
     cyan(color::cyan),
     green(color::green),
-    font(avg::Font("../../data/fonts/OpenSans-Regular.ttf", 0)),
+    font(avg::Font("data/fonts/OpenSans-Regular.ttf", 0)),
     textHeight(12.0f)
 {
 }


### PR DESCRIPTION
## Problem

`lw test <profile>` failed on the `avg` and `bqui` suites because they couldn't find the font data. The path was hardcoded as `"../../data/fonts/OpenSans-Regular.ttf"` — relative to a working directory two levels deep under the repo. But Meson runs tests from the build tree, which can be nested arbitrarily deep (here it's `.nvim/build/reactive/clang-cl-18.1.7/variant_Debug`), so `../../data` never resolved.

## Fix

Anchor data paths at the repo root instead of at some assumed depth:

- Change the three hardcoded paths from `../../data/fonts/...` to `data/fonts/...` (`fonttest.cpp`, `theme.cpp` ×2).
- Set the `avg` and `bqui` test `workdir` to `meson.project_source_root()`, so tests run from the repo root and resolve `data/...` regardless of where the build dir lives.
- Redirect gtest's XML output into the build dir — with the workdir now at the repo root, a bare `--gtest_output=xml` would otherwise litter the source tree with `test_detail.xml`.

## Caveat / follow-up

`theme.cpp` is library code, not a test, so the **app** now finds the font only when launched from the repo root. That matches the new test convention and is no more fragile than before (the old `../../data` was already CWD-dependent). Making data lookup fully CWD-independent — resolving against a compile-time data dir or the executable location — is a sensible follow-up but out of scope here.

## Test

`lw test Debug:clang-cl-18.1.7` — all 4 suites (`bq`, `avg`, `bqui`, `btl`) pass; source tree stays clean.