### PR TITLE
WIP: reproduce + fix whenAll ARM64 cancel race (do not merge)

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -71,23 +71,30 @@ jobs:
 
         # TEMP: reduced for ARM64 race debugging — restore before merge.
         # Builds and runs ONLY the small asyncstresstest target (btl is
-        # header-only, so ninja compiles just that TU, not ase/avg/bqui) under
-        # ThreadSanitizer, which flags the whenall.h store-buffering race
-        # deterministically on the Apple-Silicon runner.
-        - name: Build (TSan, async stress only)
+        # header-only, so ninja compiles just that TU, not ase/avg/bqui). A
+        # separate ThreadSanitizer *compile* of the same target keeps the TSan
+        # annotation path building (it had bit-rotted). NOTE: TSan does not flag
+        # this bug — a store-buffering double-miss produces no conflicting
+        # access — so the functional stress test is the detector.
+        - name: Build (async stress only)
           run: |
             sudo rm -Rf /Library/Developer/CommandLineTools
             sudo xcode-select -s /Applications/Xcode.app
+            mkdir -p build/debug
+            cd build/debug
+            python3 ../meson/meson.py setup --buildtype=debug --wrap-mode=forcefallback ../..
+            ninja src/btl/asyncstresstest
+
+        - name: Build (TSan compile smoke test)
+          run: |
             mkdir -p build/tsan
             cd build/tsan
             python3 ../meson/meson.py setup --buildtype=debug --wrap-mode=forcefallback -Db_sanitize=thread ../..
             ninja src/btl/asyncstresstest
 
-        - name: Tests (TSan)
+        - name: Tests (async stress)
           run: |
-            # exitcode=66 makes a TSan-reported data race fail the job; do not
-            # halt on the first report so every racing site is shown.
-            TSAN_OPTIONS="halt_on_error=0 exitcode=66" ./build/tsan/src/btl/asyncstresstest
+            ./build/debug/src/btl/asyncstresstest
 
     build-win:
         name: "build-win (${{ matrix.compiler.name }})"

--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -85,7 +85,9 @@ jobs:
 
         - name: Tests (TSan)
           run: |
-            TSAN_OPTIONS="halt_on_error=1 exitcode=66" ./build/tsan/src/btl/asyncstresstest
+            # exitcode=66 makes a TSan-reported data race fail the job; do not
+            # halt on the first report so every racing site is shown.
+            TSAN_OPTIONS="halt_on_error=0 exitcode=66" ./build/tsan/src/btl/asyncstresstest
 
     build-win:
         name: "build-win (${{ matrix.compiler.name }})"

--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -27,6 +27,7 @@ jobs:
 
     build-linux:
         name: "build-linux (${{ matrix.compiler.CC }} ${{ matrix.compiler.config }})"
+        if: false # TEMP: reduced for ARM64 race debugging — restore before merge
         strategy:
             matrix:
                 compiler: [
@@ -68,21 +69,27 @@ jobs:
           run: |
             brew install python3 ninja
 
-        - name: Build
+        # TEMP: reduced for ARM64 race debugging — restore before merge.
+        # Builds and runs ONLY the small asyncstresstest target (btl is
+        # header-only, so ninja compiles just that TU, not ase/avg/bqui) under
+        # ThreadSanitizer, which flags the whenall.h store-buffering race
+        # deterministically on the Apple-Silicon runner.
+        - name: Build (TSan, async stress only)
           run: |
             sudo rm -Rf /Library/Developer/CommandLineTools
             sudo xcode-select -s /Applications/Xcode.app
-            mkdir -p build/release
-            cd build/release
-            python3 ../meson/meson.py setup --buildtype=release --wrap-mode=forcefallback ../..
-            ninja
+            mkdir -p build/tsan
+            cd build/tsan
+            python3 ../meson/meson.py setup --buildtype=debug --wrap-mode=forcefallback -Db_sanitize=thread ../..
+            ninja src/btl/asyncstresstest
 
-        - name: Tests
+        - name: Tests (TSan)
           run: |
-            ninja -C build/release test
+            TSAN_OPTIONS="halt_on_error=1 exitcode=66" ./build/tsan/src/btl/asyncstresstest
 
     build-win:
         name: "build-win (${{ matrix.compiler.name }})"
+        if: false # TEMP: reduced for ARM64 race debugging — restore before merge
         runs-on: "windows-2022"
         strategy:
             matrix:
@@ -165,7 +172,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [build-linux, build-macos, build-win]
+        needs: [build-macos] # TEMP: reduced for ARM64 race debugging — restore [build-linux, build-macos, build-win] before merge
         runs-on: "ubuntu-22.04"
         steps:
         - name: Verify all required jobs succeeded

--- a/src/btl/include/btl/future/futurecontrol.h
+++ b/src/btl/include/btl/future/futurecontrol.h
@@ -149,7 +149,6 @@ namespace btl::future
         {
             bool r = ready_.load(std::memory_order_acquire);
             TSAN_ANNOTATE_HAPPENS_AFTER(&value_);
-            TSAN_ANNOTATE_HAPPENS_AFTER(&value_.getReferenceForTsan());
             return r;
         }
 
@@ -211,7 +210,6 @@ namespace btl::future
             LockType lock(mutex_);
             value_ = std::move(value);
             TSAN_ANNOTATE_HAPPENS_BEFORE(&value_);
-            TSAN_ANNOTATE_HAPPENS_BEFORE(&value_.getReferenceForTsan());
             ready_.store(true, std::memory_order_release);
 
             if (callback_.has_value())

--- a/src/btl/include/btl/future/whenall.h
+++ b/src/btl/include/btl/future/whenall.h
@@ -86,17 +86,12 @@ namespace btl::future
 
             });
 
-            // Publish that registration is complete and, under the same lock a
-            // failing sibling uses, drop values_ if a failure has already been
-            // reported. Serialising the initialized_/values_ pair here (rather
-            // than handing them off through two independent atomics) closes the
-            // store-buffering window where init() and reportFailure() could
-            // each observe the other's flag as unset and *both* skip the reset,
-            // leaving a cancelled future's continuation to run.
-            std::unique_lock<SpinLock> lock(valuesMutex_);
-            initialized_ = true;
+            // TEMP(repro): reverted to the racy two-flag handshake to capture a
+            // red CI run. The fix restores the SpinLock serialisation below.
             if (failed_.load(std::memory_order_acquire))
                 values_.reset();
+
+            initialized_.store(true, std::memory_order_release);
         }
 
         void reportFailure(std::exception_ptr err)
@@ -107,8 +102,7 @@ namespace btl::future
             {
                 this->setFailure(std::move(err));
 
-                std::unique_lock<SpinLock> lock(valuesMutex_);
-                if (initialized_)
+                if (initialized_.load(std::memory_order_acquire))
                     values_.reset();
             }
         }
@@ -121,11 +115,6 @@ namespace btl::future
 
             if (count == 1)
             {
-                std::unique_lock<SpinLock> lock(valuesMutex_);
-
-                if (!values_)
-                    return;
-
                 std::apply([this](auto&&... values)
                     {
                         this->setValue(std::tuple_cat(
@@ -142,14 +131,10 @@ namespace btl::future
         }
 
     private:
-        // Serialises every access to values_ so exactly one thread ever drops
-        // it: init() completing, a sibling reporting failure, or the final
-        // value becoming ready. Without this the failed_/initialized_ handshake
-        // is a store-buffering race (both loads can miss on ARM64).
-        SpinLock valuesMutex_;
+        // TEMP(repro): racy two-flag members restored to reproduce red on CI.
         std::atomic_int count_;
         std::atomic_bool failed_ = false;
-        bool initialized_ = false;
+        std::atomic_bool initialized_ = false;
         std::optional<std::tuple<Ts...>> values_;
     };
 

--- a/src/btl/include/btl/future/whenall.h
+++ b/src/btl/include/btl/future/whenall.h
@@ -86,12 +86,17 @@ namespace btl::future
 
             });
 
-            // TEMP(repro): reverted to the racy two-flag handshake to capture a
-            // red CI run. The fix restores the SpinLock serialisation below.
+            // Publish that registration is complete and, under the same lock a
+            // failing sibling uses, drop values_ if a failure has already been
+            // reported. Serialising the initialized_/values_ pair here (rather
+            // than handing them off through two independent atomics) closes the
+            // store-buffering window where init() and reportFailure() could
+            // each observe the other's flag as unset and *both* skip the reset,
+            // leaving a cancelled future's continuation to run.
+            std::unique_lock<SpinLock> lock(valuesMutex_);
+            initialized_ = true;
             if (failed_.load(std::memory_order_acquire))
                 values_.reset();
-
-            initialized_.store(true, std::memory_order_release);
         }
 
         void reportFailure(std::exception_ptr err)
@@ -102,7 +107,8 @@ namespace btl::future
             {
                 this->setFailure(std::move(err));
 
-                if (initialized_.load(std::memory_order_acquire))
+                std::unique_lock<SpinLock> lock(valuesMutex_);
+                if (initialized_)
                     values_.reset();
             }
         }
@@ -115,6 +121,11 @@ namespace btl::future
 
             if (count == 1)
             {
+                std::unique_lock<SpinLock> lock(valuesMutex_);
+
+                if (!values_)
+                    return;
+
                 std::apply([this](auto&&... values)
                     {
                         this->setValue(std::tuple_cat(
@@ -131,10 +142,14 @@ namespace btl::future
         }
 
     private:
-        // TEMP(repro): racy two-flag members restored to reproduce red on CI.
+        // Serialises every access to values_ so exactly one thread ever drops
+        // it: init() completing, a sibling reporting failure, or the final
+        // value becoming ready. Without this the failed_/initialized_ handshake
+        // is a store-buffering race (both loads can miss on ARM64).
+        SpinLock valuesMutex_;
         std::atomic_int count_;
         std::atomic_bool failed_ = false;
-        std::atomic_bool initialized_ = false;
+        bool initialized_ = false;
         std::optional<std::tuple<Ts...>> values_;
     };
 

--- a/src/btl/include/btl/future/whenall.h
+++ b/src/btl/include/btl/future/whenall.h
@@ -2,11 +2,15 @@
 
 #include "future.h"
 
+#include <btl/spinlock.h>
 #include <btl/tupleforeach.h>
 #include <btl/typelist.h>
 
 #include <atomic>
 #include <exception>
+#include <mutex>
+#include <optional>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -82,10 +86,17 @@ namespace btl::future
 
             });
 
+            // Publish that registration is complete and, under the same lock a
+            // failing sibling uses, drop values_ if a failure has already been
+            // reported. Serialising the initialized_/values_ pair here (rather
+            // than handing them off through two independent atomics) closes the
+            // store-buffering window where init() and reportFailure() could
+            // each observe the other's flag as unset and *both* skip the reset,
+            // leaving a cancelled future's continuation to run.
+            std::unique_lock<SpinLock> lock(valuesMutex_);
+            initialized_ = true;
             if (failed_.load(std::memory_order_acquire))
                 values_.reset();
-
-            initialized_.store(true, std::memory_order_release);
         }
 
         void reportFailure(std::exception_ptr err)
@@ -96,7 +107,8 @@ namespace btl::future
             {
                 this->setFailure(std::move(err));
 
-                if (initialized_.load(std::memory_order_acquire))
+                std::unique_lock<SpinLock> lock(valuesMutex_);
+                if (initialized_)
                     values_.reset();
             }
         }
@@ -109,6 +121,11 @@ namespace btl::future
 
             if (count == 1)
             {
+                std::unique_lock<SpinLock> lock(valuesMutex_);
+
+                if (!values_)
+                    return;
+
                 std::apply([this](auto&&... values)
                     {
                         this->setValue(std::tuple_cat(
@@ -125,9 +142,14 @@ namespace btl::future
         }
 
     private:
+        // Serialises every access to values_ so exactly one thread ever drops
+        // it: init() completing, a sibling reporting failure, or the final
+        // value becoming ready. Without this the failed_/initialized_ handshake
+        // is a store-buffering race (both loads can miss on ARM64).
+        SpinLock valuesMutex_;
         std::atomic_int count_;
         std::atomic_bool failed_ = false;
-        std::atomic_bool initialized_ = false;
+        bool initialized_ = false;
         std::optional<std::tuple<Ts...>> values_;
     };
 

--- a/src/btl/meson.build
+++ b/src/btl/meson.build
@@ -27,3 +27,15 @@ btltest = executable('btltest',
   )
 
 test('btl', btltest, timeout : 1200, args: ['--gtest_output=xml'])
+
+# TEMP: dedicated stress target for the whenall.h store-buffering race
+# (ARM64-only; run under ThreadSanitizer on macOS CI). It is a small,
+# standalone TU so CI can build/run just this — btl is header-only, so
+# `ninja src/btl/asyncstresstest` avoids compiling ase/avg/bqui.
+# TODO before merge: keep as a bounded regression test or revert — see PR.
+asyncstresstest = executable('asyncstresstest',
+  'test/asyncstresstest.cpp',
+  dependencies: [libbtldep, gtestdep],
+  )
+
+test('asyncstress', asyncstresstest, timeout : 1200, args: ['--gtest_output=xml'])

--- a/src/btl/test/asyncstresstest.cpp
+++ b/src/btl/test/asyncstresstest.cpp
@@ -1,26 +1,24 @@
-// TEMP: dedicated stress harness for the whenAll cancel-on-failure race in
+// TEMP: stress/regression harness for the whenAll cancel-on-failure race in
 // btl/future/whenall.h. Restore/trim before merge — see the PR description.
 //
-// Two complementary detectors run over the same whenAllCancelOnFail scenario:
+// Scenario (the whenAllCancelOnFail case, hammered): whenAll(f1, f2) where f1
+// fails immediately and f2 sleeps, then runs a `.then` that sets a flag. f1's
+// failure must cancel f2 — whenAll drops its only strong reference to f2's
+// control (values_.reset()) so f2's continuation can never run.
 //
-//   1. A ThreadSanitizer detector (primary). whenAll(f1, f2, ...) where a
-//      sibling fails must drop values_ so the others' continuations never run.
-//      In the racy code that reset is performed by either init() (calling
-//      thread) or reportFailure() (pool thread), chosen through a two-flag
-//      store-buffering handshake. When init() and reportFailure() run truly
-//      concurrently they can *both* perform values_.reset(): two threads
-//      writing the same std::optional under only acquire/release ordering — a
-//      data race TSan reports. To make that concurrency likely, siblings fail
-//      immediately (no sleep) while whenAll is still registering callbacks, and
-//      many instances are constructed back-to-back. The fixed code serialises
-//      every values_ access under a spinlock, so TSan stays silent.
+// The sibling sleep is deliberately generous. A short sleep makes a *correct*
+// implementation leak too (a coarse reset-vs-completion timing race under CI
+// load), so it does not isolate the handshake defect; a wide margin lets a
+// correct reset always win, so an observed continuation is a genuine miss.
 //
-//   2. A functional detector (secondary, wide margin). A failing sibling must
-//      cancel a *sleeping* sibling before its `.then` runs. The sleep is made
-//      generous so a correct implementation always wins the cancellation with
-//      margin; an observed continuation means the reset was skipped. (A short
-//      sleep instead measures a coarser reset-vs-completion timing race that
-//      does not isolate the handshake, so a comfortable margin is used here.)
+// NOTE (honesty): the specific store-buffering *double-miss* in the racy code
+// (both init() and reportFailure() failing to observe the other's flag, so
+// values_ is never reset) is extremely rare — rarer than ~1/400 on the Apple-
+// Silicon CI runner — and produces no conflicting memory access, so
+// ThreadSanitizer does not flag it. This harness therefore serves mainly as a
+// regression guard for the fixed code; it did not, within a practical CI time
+// budget, produce a reliably RED signal that discriminates the racy code from
+// the fixed code. See the PR description for the full findings.
 
 #include <btl/future/whenall.h>
 #include <btl/future/future.h>
@@ -33,53 +31,21 @@
 #include <memory>
 #include <stdexcept>
 #include <thread>
-#include <vector>
 
 using namespace btl::future;
 using btl::async;
 
 namespace
 {
-    // TSan detector: maximise init()/reportFailure() concurrency so the racy
-    // two-flag handshake can drive both threads to reset values_ at once.
-    TEST(asyncStress, whenAllResetDataRace)
-    {
-        constexpr int kIterations = 20000;
-
-        for (int i = 0; i < kIterations; ++i)
-        {
-            // Several siblings that fail immediately, so a failure is reported
-            // from a pool thread while whenAll's init() is still iterating.
-            auto f1 = async([]() -> int
-                    {
-                        throw std::runtime_error("boom");
-                        return 1;
-                    });
-            auto f2 = async([]() -> int
-                    {
-                        throw std::runtime_error("boom");
-                        return 2;
-                    });
-            auto f3 = async([]() -> int { return 3; });
-
-            auto r = whenAll(std::move(f1), std::move(f2), std::move(f3));
-
-            try
-            {
-                std::move(r).get();
-            }
-            catch (std::runtime_error const&)
-            {
-            }
-        }
-    }
-
-    // f2 must still be sleeping when the failure is processed, so cancellation
-    // is unambiguously correct and wins with margin.
+    // Comfortably larger than the time for whenAll to construct and f1 to
+    // report its failure, so cancellation always has margin to win.
     constexpr auto kSiblingSleep = std::chrono::milliseconds(150);
 
+    // Returns true if f2's continuation leaked (ran despite f1 failing first).
     bool runOnce()
     {
+        // Heap-owned so the flag outlives this frame and a late (i.e.
+        // not-cancelled) continuation can still be observed setting it.
         auto called = std::make_shared<std::atomic_bool>(false);
 
         auto f1 = async([]() -> int
@@ -110,6 +76,7 @@ namespace
         }
         EXPECT_TRUE(threw);
 
+        // Wait out f2's sleep with margin so any surviving continuation has run.
         std::this_thread::sleep_for(kSiblingSleep + std::chrono::milliseconds(30));
 
         return called->load();
@@ -118,7 +85,7 @@ namespace
 
 TEST(asyncStress, whenAllCancelOnFail)
 {
-    constexpr int kIterations = 300;
+    constexpr int kIterations = 1000;
 
     int leaked = 0;
     for (int i = 0; i < kIterations; ++i)
@@ -127,6 +94,8 @@ TEST(asyncStress, whenAllCancelOnFail)
             ++leaked;
     }
 
+    // A correct whenAll cancels the sibling of a failed future before its
+    // `.then` runs, so `called` is never observed true.
     EXPECT_EQ(0, leaked)
         << "f2's continuation ran " << leaked << " / " << kIterations
         << " times despite f1 failing first — whenAll failed to cancel it.";

--- a/src/btl/test/asyncstresstest.cpp
+++ b/src/btl/test/asyncstresstest.cpp
@@ -1,13 +1,20 @@
-// TEMP: dedicated stress harness for the whenAll cancel-on-failure
-// store-buffering race in btl/future/whenall.h (ARM64-only under normal
-// timing; deterministic here under ThreadSanitizer). Restore/trim before
-// merge — see the PR description.
+// TEMP: dedicated stress harness for the whenAll cancel-on-failure race in
+// btl/future/whenall.h. Restore/trim before merge — see the PR description.
 //
-// The functional signal is: whenAll(f1, f2) where f1 fails immediately must
-// cancel f2 before f2's `.then` runs. If the SB handshake double-misses,
-// values_ is never reset, f2 survives, its `.then` fires, and `called`
-// becomes true. Under TSan the un-serialized access to values_ (init() vs
-// reportFailure() on two threads) is reported directly.
+// Scenario (the whenAllCancelOnFail case, hammered): whenAll(f1, f2) where f1
+// fails immediately and f2 sleeps, then runs a `.then` that sets a flag. f1's
+// failure must cancel f2 — whenAll drops its only strong reference to f2's
+// control (values_.reset()) so f2's continuation can never run. The reset is
+// handed between init() (calling thread) and reportFailure() (pool thread) via
+// a store-buffering handshake on two non-seq_cst atomics; when both loads miss,
+// neither resets values_, f2 survives, and its `.then` fires (the flag is set).
+//
+// One instance is exercised at a time (only f1 and f2 in flight), so neither
+// waits behind the other for a pool thread: f1 fails promptly while f2 is still
+// sleeping. A correct implementation therefore always cancels f2 with a wide
+// timing margin, and an observed set flag is a genuine missed reset — not a
+// benign race between two legitimately concurrent completions, nor thread-pool
+// starvation delaying f1's failure past f2's sleep.
 
 #include <btl/future/whenall.h>
 #include <btl/future/future.h>
@@ -17,6 +24,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <stdexcept>
 #include <thread>
 
@@ -25,37 +33,30 @@ using btl::async;
 
 namespace
 {
-    // One iteration of the whenAllCancelOnFail scenario. f1 fails immediately;
-    // f2 sleeps briefly and then runs a `.then`. Because f1 fails first,
-    // whenAll must drop its reference to f2 (values_.reset()) so f2's `.then`
-    // never runs. The sleep is what makes cancellation the *correct* outcome:
-    // f1's failure has time to reach whenAll before f2 finishes, so a `called`
-    // of true is a genuine defect (the reset was missed), not a benign race
-    // between two legitimately-concurrent completions.
-    //
-    // The reset is handed between init() (calling thread) and reportFailure()
-    // (pool thread) via a store-buffering handshake on two non-seq_cst
-    // atomics; when both loads miss, neither resets values_. On x86 the
-    // lock-prefixed CAS drains the store buffer so the miss is not observed;
-    // on ARM64 it is. Either way, ThreadSanitizer reports the un-serialized
-    // access to values_ deterministically.
+    // f2 must still be sleeping when f1's failure is processed, so cancellation
+    // is unambiguously the correct outcome and has a wide margin to win.
+    constexpr auto kSiblingSleep = std::chrono::milliseconds(40);
+
+    // Returns true if f2's continuation leaked (ran despite f1 failing first).
     bool runOnce()
     {
+        // Heap-owned so the flag outlives this frame and a late (i.e.
+        // not-cancelled) continuation can still be observed setting it.
+        auto called = std::make_shared<std::atomic_bool>(false);
+
         auto f1 = async([]() -> int
                 {
                     throw std::runtime_error("test error");
                     return 10;
                 });
 
-        std::atomic_bool called = false;
-
         auto f2 = async([]()
                 {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                    std::this_thread::sleep_for(kSiblingSleep);
                 })
-                .then([&called]()
+                .then([called]()
                 {
-                    called.store(true);
+                    called->store(true);
                 });
 
         auto r = whenAll(std::move(f1), std::move(f2));
@@ -69,13 +70,12 @@ namespace
         {
             threw = true;
         }
-
-        // Give any surviving (i.e. not-cancelled) f2 continuation time to run
-        // so a functional miss is observable even without TSan.
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
         EXPECT_TRUE(threw);
-        return called.load();
+
+        // Wait out f2's sleep with margin so a surviving continuation has run.
+        std::this_thread::sleep_for(kSiblingSleep + std::chrono::milliseconds(20));
+
+        return called->load();
     }
 } // namespace
 
@@ -90,8 +90,8 @@ TEST(asyncStress, whenAllCancelOnFail)
             ++leaked;
     }
 
-    // Under a correct implementation the failed future always cancels its
-    // sibling before the `.then` runs, so `called` is never observed true.
+    // A correct whenAll always cancels the sibling of a failed future before its
+    // `.then` runs, so `called` is never observed true.
     EXPECT_EQ(0, leaked)
         << "f2's continuation ran " << leaked << " / " << kIterations
         << " times despite f1 failing first — whenAll failed to cancel it.";

--- a/src/btl/test/asyncstresstest.cpp
+++ b/src/btl/test/asyncstresstest.cpp
@@ -35,7 +35,7 @@ namespace
 {
     // f2 must still be sleeping when f1's failure is processed, so cancellation
     // is unambiguously the correct outcome and has a wide margin to win.
-    constexpr auto kSiblingSleep = std::chrono::milliseconds(40);
+    constexpr auto kSiblingSleep = std::chrono::milliseconds(150);
 
     // Returns true if f2's continuation leaked (ran despite f1 failing first).
     bool runOnce()
@@ -81,7 +81,7 @@ namespace
 
 TEST(asyncStress, whenAllCancelOnFail)
 {
-    constexpr int kIterations = 3000;
+    constexpr int kIterations = 400;
 
     int leaked = 0;
     for (int i = 0; i < kIterations; ++i)

--- a/src/btl/test/asyncstresstest.cpp
+++ b/src/btl/test/asyncstresstest.cpp
@@ -1,20 +1,26 @@
 // TEMP: dedicated stress harness for the whenAll cancel-on-failure race in
 // btl/future/whenall.h. Restore/trim before merge — see the PR description.
 //
-// Scenario (the whenAllCancelOnFail case, hammered): whenAll(f1, f2) where f1
-// fails immediately and f2 sleeps, then runs a `.then` that sets a flag. f1's
-// failure must cancel f2 — whenAll drops its only strong reference to f2's
-// control (values_.reset()) so f2's continuation can never run. The reset is
-// handed between init() (calling thread) and reportFailure() (pool thread) via
-// a store-buffering handshake on two non-seq_cst atomics; when both loads miss,
-// neither resets values_, f2 survives, and its `.then` fires (the flag is set).
+// Two complementary detectors run over the same whenAllCancelOnFail scenario:
 //
-// One instance is exercised at a time (only f1 and f2 in flight), so neither
-// waits behind the other for a pool thread: f1 fails promptly while f2 is still
-// sleeping. A correct implementation therefore always cancels f2 with a wide
-// timing margin, and an observed set flag is a genuine missed reset — not a
-// benign race between two legitimately concurrent completions, nor thread-pool
-// starvation delaying f1's failure past f2's sleep.
+//   1. A ThreadSanitizer detector (primary). whenAll(f1, f2, ...) where a
+//      sibling fails must drop values_ so the others' continuations never run.
+//      In the racy code that reset is performed by either init() (calling
+//      thread) or reportFailure() (pool thread), chosen through a two-flag
+//      store-buffering handshake. When init() and reportFailure() run truly
+//      concurrently they can *both* perform values_.reset(): two threads
+//      writing the same std::optional under only acquire/release ordering — a
+//      data race TSan reports. To make that concurrency likely, siblings fail
+//      immediately (no sleep) while whenAll is still registering callbacks, and
+//      many instances are constructed back-to-back. The fixed code serialises
+//      every values_ access under a spinlock, so TSan stays silent.
+//
+//   2. A functional detector (secondary, wide margin). A failing sibling must
+//      cancel a *sleeping* sibling before its `.then` runs. The sleep is made
+//      generous so a correct implementation always wins the cancellation with
+//      margin; an observed continuation means the reset was skipped. (A short
+//      sleep instead measures a coarser reset-vs-completion timing race that
+//      does not isolate the handshake, so a comfortable margin is used here.)
 
 #include <btl/future/whenall.h>
 #include <btl/future/future.h>
@@ -27,21 +33,53 @@
 #include <memory>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 using namespace btl::future;
 using btl::async;
 
 namespace
 {
-    // f2 must still be sleeping when f1's failure is processed, so cancellation
-    // is unambiguously the correct outcome and has a wide margin to win.
+    // TSan detector: maximise init()/reportFailure() concurrency so the racy
+    // two-flag handshake can drive both threads to reset values_ at once.
+    TEST(asyncStress, whenAllResetDataRace)
+    {
+        constexpr int kIterations = 20000;
+
+        for (int i = 0; i < kIterations; ++i)
+        {
+            // Several siblings that fail immediately, so a failure is reported
+            // from a pool thread while whenAll's init() is still iterating.
+            auto f1 = async([]() -> int
+                    {
+                        throw std::runtime_error("boom");
+                        return 1;
+                    });
+            auto f2 = async([]() -> int
+                    {
+                        throw std::runtime_error("boom");
+                        return 2;
+                    });
+            auto f3 = async([]() -> int { return 3; });
+
+            auto r = whenAll(std::move(f1), std::move(f2), std::move(f3));
+
+            try
+            {
+                std::move(r).get();
+            }
+            catch (std::runtime_error const&)
+            {
+            }
+        }
+    }
+
+    // f2 must still be sleeping when the failure is processed, so cancellation
+    // is unambiguously correct and wins with margin.
     constexpr auto kSiblingSleep = std::chrono::milliseconds(150);
 
-    // Returns true if f2's continuation leaked (ran despite f1 failing first).
     bool runOnce()
     {
-        // Heap-owned so the flag outlives this frame and a late (i.e.
-        // not-cancelled) continuation can still be observed setting it.
         auto called = std::make_shared<std::atomic_bool>(false);
 
         auto f1 = async([]() -> int
@@ -72,8 +110,7 @@ namespace
         }
         EXPECT_TRUE(threw);
 
-        // Wait out f2's sleep with margin so a surviving continuation has run.
-        std::this_thread::sleep_for(kSiblingSleep + std::chrono::milliseconds(20));
+        std::this_thread::sleep_for(kSiblingSleep + std::chrono::milliseconds(30));
 
         return called->load();
     }
@@ -81,7 +118,7 @@ namespace
 
 TEST(asyncStress, whenAllCancelOnFail)
 {
-    constexpr int kIterations = 400;
+    constexpr int kIterations = 300;
 
     int leaked = 0;
     for (int i = 0; i < kIterations; ++i)
@@ -90,8 +127,6 @@ TEST(asyncStress, whenAllCancelOnFail)
             ++leaked;
     }
 
-    // A correct whenAll always cancels the sibling of a failed future before its
-    // `.then` runs, so `called` is never observed true.
     EXPECT_EQ(0, leaked)
         << "f2's continuation ran " << leaked << " / " << kIterations
         << " times despite f1 failing first — whenAll failed to cancel it.";

--- a/src/btl/test/asyncstresstest.cpp
+++ b/src/btl/test/asyncstresstest.cpp
@@ -1,0 +1,98 @@
+// TEMP: dedicated stress harness for the whenAll cancel-on-failure
+// store-buffering race in btl/future/whenall.h (ARM64-only under normal
+// timing; deterministic here under ThreadSanitizer). Restore/trim before
+// merge — see the PR description.
+//
+// The functional signal is: whenAll(f1, f2) where f1 fails immediately must
+// cancel f2 before f2's `.then` runs. If the SB handshake double-misses,
+// values_ is never reset, f2 survives, its `.then` fires, and `called`
+// becomes true. Under TSan the un-serialized access to values_ (init() vs
+// reportFailure() on two threads) is reported directly.
+
+#include <btl/future/whenall.h>
+#include <btl/future/future.h>
+#include <btl/async.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+
+using namespace btl::future;
+using btl::async;
+
+namespace
+{
+    // One iteration of the whenAllCancelOnFail scenario. f1 fails immediately;
+    // f2 sleeps briefly and then runs a `.then`. Because f1 fails first,
+    // whenAll must drop its reference to f2 (values_.reset()) so f2's `.then`
+    // never runs. The sleep is what makes cancellation the *correct* outcome:
+    // f1's failure has time to reach whenAll before f2 finishes, so a `called`
+    // of true is a genuine defect (the reset was missed), not a benign race
+    // between two legitimately-concurrent completions.
+    //
+    // The reset is handed between init() (calling thread) and reportFailure()
+    // (pool thread) via a store-buffering handshake on two non-seq_cst
+    // atomics; when both loads miss, neither resets values_. On x86 the
+    // lock-prefixed CAS drains the store buffer so the miss is not observed;
+    // on ARM64 it is. Either way, ThreadSanitizer reports the un-serialized
+    // access to values_ deterministically.
+    bool runOnce()
+    {
+        auto f1 = async([]() -> int
+                {
+                    throw std::runtime_error("test error");
+                    return 10;
+                });
+
+        std::atomic_bool called = false;
+
+        auto f2 = async([]()
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                })
+                .then([&called]()
+                {
+                    called.store(true);
+                });
+
+        auto r = whenAll(std::move(f1), std::move(f2));
+
+        bool threw = false;
+        try
+        {
+            std::move(r).get();
+        }
+        catch (std::runtime_error const&)
+        {
+            threw = true;
+        }
+
+        // Give any surviving (i.e. not-cancelled) f2 continuation time to run
+        // so a functional miss is observable even without TSan.
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        EXPECT_TRUE(threw);
+        return called.load();
+    }
+} // namespace
+
+TEST(asyncStress, whenAllCancelOnFail)
+{
+    constexpr int kIterations = 3000;
+
+    int leaked = 0;
+    for (int i = 0; i < kIterations; ++i)
+    {
+        if (runOnce())
+            ++leaked;
+    }
+
+    // Under a correct implementation the failed future always cancels its
+    // sibling before the `.then` runs, so `called` is never observed true.
+    EXPECT_EQ(0, leaked)
+        << "f2's continuation ran " << leaked << " / " << kIterations
+        << " times despite f1 failing first — whenAll failed to cancel it.";
+}


### PR DESCRIPTION
**WIP / debugging-in-progress — do NOT merge.** Attempt to reproduce and fix the rare, ARM64-only `whenAll` cancel-on-failure race on macOS CI.

## TL;DR (honest status)

- A **fix** is applied to `src/btl/include/btl/future/whenall.h` and CI is **green** on the Apple-Silicon runner: run https://github.com/samienne/reactive/actions/runs/29571044242 (`whenAllCancelOnFail` passes 1000 iterations).
- I could **not** produce a *reliably RED, fix-discriminating* reproduction on CI. The one red signal I got (leaks at a short cancellation margin) is a coarse timing artifact that fails **equally for the racy and the fixed code**, so it does not isolate the diagnosed defect. ThreadSanitizer does **not** flag this bug. Details below — please weigh this when reviewing whether the fix is warranted.

## Diagnosis (as handed to me, and what I found)

`whenAll(f1, f2)` must cancel the remaining siblings the instant any sibling fails, so their `.then` continuations never run. Cancellation = `values_.reset()` in `whenall.h`, handed between `init()` (calling thread) and `reportFailure()` (pool thread) via a **store-buffering handshake** on two atomics (`failed_`, `initialized_`), each side storing its own flag then loading the other's with `release`/`acquire` (not `seq_cst`). In theory both loads can miss on ARM64 → neither resets `values_` → the failed future's sibling survives and its `.then` runs.

`src/btl/include/btl/future/merge.h` (`MergedFuture`) has the **identical** handshake — noted for a follow-up, not fixed here.

## The fix

`whenall.h`: replace the two-flag handshake with a single owning happens-before chain — a per-`WhenAll` `SpinLock` guarding every access to `values_` (the `initialized_`/`values_` decision in `init()`, the reset in `reportFailure()`, the move-out in `reportValueReady()`). Exactly one site ever drops `values_`; no load can miss. All existing `btl` async tests still pass locally (clang-cl), including the original `whenAllCancelOnFail` and `mergeFail`.

Also fixed a **pre-existing** bit-rotted TSan annotation in `futurecontrol.h` (`value_.getReferenceForTsan()` — `value_` is a `std::variant` with no such member; only compiled under a TSan build, so it went unnoticed). Legitimate; can stay.

## What the CI iterations actually showed

The macOS job was temporarily reduced to build/run only a small dedicated `asyncstresstest` target (btl is header-only, so ninja compiles just that TU).

| commit | code | sibling sleep / iters | ARM64 result |
|---|---|---|---|
| repro | racy | 40ms / 3000 | **leaked 18** (red) — run 29569112794 |
| fix | fixed | 40ms / 3000 | **leaked 14** (red) — run 29569607152 |
| diag | fixed | 150ms / 400 | 0 (pass) — run 29570372847 |
| diag | racy | 150ms / 400 | 0 (pass) — run 29570560568 |
| diag | racy + TSan detector | (TSan) | 0 races, pass — run 29570804950 |
| final | fixed | 150ms / 1000 | **0 (pass, green)** — run 29571044242 |

Interpretation:
- At a **short** margin (40ms), *both* racy and fixed leak ~equally. That is a **reset-vs-sleep-completion timing race in the harness** under CI load (the sibling's continuation occasionally locks its control before the reset destroys it), independent of the flag handshake — so it does not validate the fix.
- At a **wide** margin (150ms), *both* racy and fixed pass over hundreds of iterations, because the store-buffering **double-miss** is rarer than that. A double-miss also produces **no conflicting memory access**, so **TSan reports nothing** (confirmed on CI).
- Net: I have a clean **green** with the fix, but no clean **red** that the fix flips. The diagnosed race is plausibly real (matches the "intermittent" nature of the original test) but is too rare to catch functionally within a practical CI time budget, and is invisible to TSan.

## TODO before merge

- **Restore `build-linux` and `build-win`** (remove the `if: false` TEMP guards) and restore `ci-success` `needs:` to `[build-linux, build-macos, build-win]`.
- Restore the `build-macos` job's normal full build + `ninja test` (currently reduced to the async-stress target: a debug run + a TSan compile-smoke).
- Decide whether to **keep `asyncstresstest`** (as a bounded regression test) or revert it. As-is it is a weak guard — it passes for both the racy and fixed code at the margin used.
- Decide whether the fix is worth keeping given it could not be tied to a reproduced failure; if kept, apply the same fix to `merge.h`.
- Keep the `futurecontrol.h` `getReferenceForTsan` fix (independently correct).

All TEMP changes carry `# TEMP: ... restore before merge` / `TODO before merge` markers. The intermediate `DIAG`/`TEMP(repro)` commits document the red/green experiments and can be squashed away.
