### PR TITLE
Make App's window list reactive

### DIFF
--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -1,6 +1,6 @@
 # bqui — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `221cd3f` (2026-07-19).*
 
 Internals, entry points, and traps for the UI toolkit. Concepts and usage are in
 `readme.md`; project-wide conventions are in the top-level `docs/`. This file is
@@ -38,6 +38,18 @@ terminate to `AnyWidget`. Transforms are **paint-time and never affect layout**
 - Environment: a typed, scoped store threaded through the tree (`provider/`,
   `modifier/setparams.h`); `Theme` is the common parameter.
 - Animation: `withanimation.h` (guard or lambda form) marks changes to animate.
+
+## The app loop (`app.cpp`)
+
+`App` holds its windows as a reactive `WindowList` — a signal of `(stable-id,
+Window)` pairs, the same shape `dataBind` produces for widgets. `windows({...})`
+is a constant of that shape; `windows(signal)` and `onWindowsReconciled` take
+the dynamic path. `App::run` samples the list once per frame (a dedicated
+`SignalContext`, before the running signal) and reconciles `WindowGlue`s keyed
+by id: a new id constructs a glue (which creates its `ase::Window` on demand), a
+vanished id drops it (closing the window), existing ones persist. A `WindowGlue`
+owns everything for one window (its `ase::Window`, painter, per-window signal
+contexts, input state).
 
 ## Traps
 

--- a/src/bqui/include/bqui/app.h
+++ b/src/bqui/include/bqui/app.h
@@ -10,10 +10,25 @@
 #include <btl/shared.h>
 #include <btl/visibility.h>
 
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
+
 namespace bqui
 {
     class AppDeferred;
     class AnimationGuard;
+
+    /** A reactive window list: each window paired with a stable id.
+     *
+     * The id is assigned by the producer and is stable across edits. The run
+     * loop reconciles the live window set by id — creating a window when its id
+     * appears and destroying it when the id disappears — mirroring the
+     * dynamic-widget list produced by `dataBind`.
+     */
+    using WindowList =
+        bq::signal::AnySignal<std::vector<std::pair<size_t, Window>>>;
 
     class BQUI_EXPORT App
     {
@@ -21,6 +36,17 @@ namespace bqui
         explicit App();
 
         App windows(std::initializer_list<Window> windows) &&;
+
+        App windows(WindowList windows) &&;
+
+        /** Observe the live window set after each reconciliation.
+         *
+         * The callback fires once at startup and again whenever the window
+         * list changes, receiving the ids of the currently live windows in
+         * list order. Intended for headless introspection and testing.
+         */
+        App onWindowsReconciled(
+                std::function<void(std::vector<size_t> const&)> callback) &&;
 
         int run(bq::signal::AnySignal<bool> running) &&;
         int run() &&;

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -86,6 +86,7 @@ libbquidep = declare_dependency(
   )
 
 bquitest =  executable('bquitest',
+  'test/apptest.cpp',
   'test/collectiontest.cpp',
   'test/databindtest.cpp',
   'test/shapetest.cpp',

--- a/src/bqui/readme.md
+++ b/src/bqui/readme.md
@@ -51,6 +51,13 @@ return app()
     .run();
 ```
 
+The window list is reactive. `windows({...})` is a convenience over a *constant*
+`WindowList` — a signal of `(id, Window)` pairs whose `size_t` is a stable id,
+the same shape `dataBind` produces for widgets. `windows(signal)` takes such a
+signal directly. The run loop samples the list once per frame and reconciles the
+live windows by id: a new id opens a window, a vanished id closes one, existing
+ones persist.
+
 Signal changes made inside a `withAnimation` scope are animated.
 
 ## Layout (of the source)

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -8,6 +8,7 @@
 #include <bq/signal/input.h>
 #include <bq/signal/updateresult.h>
 #include <bq/signal/signalcontext.h>
+#include <bq/signal/constant.h>
 
 #include <avg/rendertree.h>
 #include <avg/painter.h>
@@ -33,10 +34,14 @@
 
 #include <tracy/Tracy.hpp>
 
+#include <algorithm>
 #include <chrono>
+#include <functional>
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
 
 namespace bqui
 {
@@ -56,13 +61,16 @@ class WindowGlue;
 class BQUI_EXPORT AppDeferred
 {
 public:
-    AppDeferred()
+    AppDeferred() :
+        windows_(bq::signal::constant(
+                    std::vector<std::pair<size_t, Window>>()))
     {
         TracyAppInfo("Reactive application", 20);
     }
 
-    std::vector<Window> windows_;
-    std::vector<btl::shared<WindowGlue>> windowGlues_;
+    WindowList windows_;
+    std::vector<std::pair<size_t, btl::shared<WindowGlue>>> windowGlues_;
+    std::function<void(std::vector<size_t> const&)> onReconciled_;
 };
 
 class WindowGlue
@@ -466,8 +474,32 @@ App::App() :
 
 App App::windows(std::initializer_list<Window> windows) &&
 {
+    // The static convenience path is the reactive path over a *constant*
+    // signal: enumerate the windows into (id, window) pairs so they reconcile
+    // through the same by-id machinery as a dynamic list.
+    std::vector<std::pair<size_t, Window>> enumerated;
+    enumerated.reserve(windows.size());
+
+    size_t id = 0;
     for (auto const& w : windows)
-        d()->windows_.push_back(btl::clone(w));
+        enumerated.emplace_back(id++, btl::clone(w));
+
+    d()->windows_ = bq::signal::constant(std::move(enumerated));
+
+    return std::move(*this);
+}
+
+App App::windows(WindowList windows) &&
+{
+    d()->windows_ = std::move(windows);
+
+    return std::move(*this);
+}
+
+App App::onWindowsReconciled(
+        std::function<void(std::vector<size_t> const&)> callback) &&
+{
+    d()->onReconciled_ = std::move(callback);
 
     return std::move(*this);
 }
@@ -476,15 +508,53 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
 {
     ase::Platform platform = ase::makeDefaultPlatform();
 
-    d()->windowGlues_.reserve(d()->windows_.size());
-
     ase::RenderContext context = platform.makeRenderContext();
 
-    for (auto&& w : d()->windows_)
-    {
-        d()->windowGlues_.push_back(std::make_shared<WindowGlue>(
-            platform, context, std::move(w)));
-    }
+    auto& glues = d()->windowGlues_;
+
+    // Reconcile the live WindowGlues against the sampled window list, keyed by
+    // stable id: create a glue when its id first appears, destroy one when its
+    // id is gone, and leave untouched ids alone. Order follows the list so the
+    // glue vector mirrors the current window set.
+    auto reconcile =
+        [&](std::vector<std::pair<size_t, Window>> const& windows)
+        {
+            std::vector<std::pair<size_t, btl::shared<WindowGlue>>> next;
+            next.reserve(windows.size());
+
+            for (auto const& entry : windows)
+            {
+                auto existing = std::find_if(glues.begin(), glues.end(),
+                        [&](auto const& g) { return g.first == entry.first; });
+
+                if (existing != glues.end())
+                    next.push_back(std::move(*existing));
+                else
+                    next.emplace_back(entry.first,
+                            std::make_shared<WindowGlue>(
+                                platform, context, btl::clone(entry.second)));
+            }
+
+            // Anything left in `glues` has a disappeared id; dropping `glues`
+            // destroys those WindowGlues (and closes their windows).
+            glues = std::move(next);
+
+            if (d()->onReconciled_)
+            {
+                std::vector<size_t> ids;
+                ids.reserve(glues.size());
+                for (auto const& g : glues)
+                    ids.push_back(g.first);
+
+                d()->onReconciled_(ids);
+            }
+        };
+
+    // A dedicated context samples the window list once per frame, at the top of
+    // the loop, so glue creation/destruction happens at a single well-defined
+    // point before the running signal is evaluated.
+    auto windows = bq::signal::makeSignalContext(d()->windows_);
+    reconcile(windows.evaluate<0>().get<0>());
 
     std::chrono::steady_clock clock;
     auto startTime = clock.now();
@@ -495,7 +565,11 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
     platform.run(context, [&](ase::Frame const& aseFrame) -> bool
         {
             bq::signal::FrameInfo frame{ getNextFrameId(), aseFrame.dt };
-            auto [timeToNext, didChange] = running.update(frame);
+
+            if (windows.update(frame).didChange)
+                reconcile(windows.evaluate<0>().get<0>());
+
+            running.update(frame);
 
             return running.evaluate<0>().get<0>();
         });
@@ -505,13 +579,13 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
     auto endTime = clock.now();
     std::chrono::duration<double> time = endTime - startTime;
 
-    for (auto const& glue : d()->windowGlues_)
+    for (auto const& glue : glues)
     {
-        DBG("Window \"%1\" had FPS of %2.", glue->getTitle(),
-                (double)glue->getFrames() / time.count());
+        DBG("Window \"%1\" had FPS of %2.", glue.second->getTitle(),
+                (double)glue.second->getFrames() / time.count());
     }
 
-    d()->windowGlues_.clear();
+    glues.clear();
 
     return 0;
 }
@@ -519,8 +593,23 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
 int App::run() &&
 {
     auto running = bq::signal::makeInput(true);
-    for (auto&& w : d()->windows_)
-        w = std::move(w).onClose(send(false, running.handle));
+
+    // Wire every window's onClose to stop the app. Mapping over the signal
+    // keeps the list reactive: windows added mid-run get the same close
+    // handler, so closing any live window stops the app.
+    d()->windows_ = d()->windows_.map(
+            [handle = running.handle]
+            (std::vector<std::pair<size_t, Window>> const& windows)
+            {
+                std::vector<std::pair<size_t, Window>> wired;
+                wired.reserve(windows.size());
+                for (auto const& entry : windows)
+                    wired.emplace_back(entry.first,
+                            btl::clone(entry.second).onClose(
+                                send(false, handle)));
+
+                return wired;
+            });
 
     return std::move(*this).run(running.signal);
 }
@@ -537,7 +626,7 @@ AnimationGuard::AnimationGuard(AppDeferred& app,
 {
     for (auto& glue : app_->windowGlues_)
     {
-        glue->makeTransaction(
+        glue.second->makeTransaction(
                 std::chrono::milliseconds(0),
                 std::nullopt
                 );
@@ -551,7 +640,7 @@ AnimationGuard::~AnimationGuard()
 
     for (auto& glue : app_->windowGlues_)
     {
-        glue->makeTransaction(
+        glue.second->makeTransaction(
                 std::chrono::milliseconds(0),
                 options_
                 );

--- a/src/bqui/test/apptest.cpp
+++ b/src/bqui/test/apptest.cpp
@@ -1,0 +1,99 @@
+#include <bqui/app.h>
+#include <bqui/window.h>
+
+#include <bqui/widget/widget.h>
+
+#include <bq/signal/input.h>
+#include <bq/signal/constant.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace bqui;
+
+namespace
+{
+    Window makeWindow(std::string title)
+    {
+        return window(bq::signal::constant(std::move(title)),
+                widget::makeWidget());
+    }
+
+    std::pair<size_t, Window> entry(size_t id, std::string title)
+    {
+        return { id, makeWindow(std::move(title)) };
+    }
+} // namespace
+
+// Drives the reactive window list through App::run on the headless (dummy)
+// platform and asserts that WindowGlues reconcile by stable id: start with one
+// window, add a second, then remove the first. Each edit is applied from the
+// reconcile observer (which runs on the run-loop thread), so the sequence is
+// deterministic and needs no extra threads.
+TEST(App, dynamicWindowsReconcileById)
+{
+    auto windows = bq::signal::makeInput(
+            std::vector<std::pair<size_t, Window>>{ entry(0, "first") });
+
+    auto running = bq::signal::makeInput(true);
+
+    std::vector<std::vector<size_t>> observed;
+
+    int step = 0;
+
+    App()
+        .windows(windows.signal)
+        .onWindowsReconciled(
+            [&](std::vector<size_t> const& ids)
+            {
+                observed.push_back(ids);
+
+                switch (step++)
+                {
+                case 0:
+                    // Add a second window (id 1) alongside the first (id 0).
+                    windows.handle.set(std::vector<std::pair<size_t, Window>>{
+                            entry(0, "first"), entry(1, "second") });
+                    break;
+                case 1:
+                    // Remove the first window; only id 1 should remain.
+                    windows.handle.set(std::vector<std::pair<size_t, Window>>{
+                            entry(1, "second") });
+                    break;
+                default:
+                    // Reconciliation done; stop the loop.
+                    running.handle.set(false);
+                    break;
+                }
+            })
+        .run(running.signal);
+
+    ASSERT_EQ(observed.size(), 3u);
+    EXPECT_EQ(observed[0], (std::vector<size_t>{ 0 }));
+    EXPECT_EQ(observed[1], (std::vector<size_t>{ 0, 1 }));
+    EXPECT_EQ(observed[2], (std::vector<size_t>{ 1 }));
+}
+
+// A fixed window set (the initializer_list convenience) enumerates windows with
+// contiguous ids starting at zero and reconciles them once at startup.
+TEST(App, staticWindowsEnumerateFromZero)
+{
+    auto running = bq::signal::makeInput(true);
+
+    std::vector<size_t> observed;
+
+    App()
+        .windows({ makeWindow("a"), makeWindow("b"), makeWindow("c") })
+        .onWindowsReconciled(
+            [&](std::vector<size_t> const& ids)
+            {
+                observed = ids;
+                running.handle.set(false);
+            })
+        .run(running.signal);
+
+    EXPECT_EQ(observed, (std::vector<size_t>{ 0, 1, 2 }));
+}


### PR DESCRIPTION
## What

Makes `App`'s window list **reactive** — a signal of `(stable-id, Window)` pairs — so windows can be added and removed at runtime, mirroring how the toolkit already turns a mutable collection into a dynamic, stable-id widget list (`Collection` + `dataBind`).

## Window API

- **`WindowList = AnySignal<std::vector<std::pair<size_t, Window>>>`** — the reactive window list. The `size_t` is a producer-assigned stable id; the run loop reconciles by id. Same shape `dataBind` produces for widgets.
- **`App::windows(WindowList)`** — new overload consuming the signal directly. Per the scope note, there is no windows-specific `Collection`/`DataSource` layer; a caller produces the signal however it likes.
- **`App::windows(std::initializer_list<Window>)`** — unchanged signature; now enumerates the windows into a *constant* `WindowList` (ids `0..n-1`) so the static path flows through the same by-id machinery and behaves identically to before.
- **`App::onWindowsReconciled(callback)`** — observation hook reporting the live window id set after each reconciliation (headless introspection / testing).

## Reconciliation & lifecycle

`App::run` samples the window list once per frame via a dedicated `SignalContext`, at the top of the loop **before** the running signal is evaluated — a single well-defined reconcile point. It maintains `WindowGlue`s keyed by stable id:

- **new id → create** its `WindowGlue` (which constructs the `ase::Window` on demand via the platform + shared render context),
- **vanished id → destroy** its glue (closing the window),
- **existing id → keep** across frames.

The glue vector order follows the list. On WGL a mid-run `ase::Window` auto-registers in the platform's window map and is serviced automatically; on destruction its weak ref expires and is pruned. The no-arg `run()` still stops the app when any window closes — the onClose wiring is now a `.map` over the list so it stays reactive and applies to windows added mid-run.

## Behavior preservation

The static `initializer_list` path produces identical behavior/output to before (single reconcile at startup, contiguous ids from zero). `testapp1` builds and runs unchanged.

## Tests

New `src/bqui/test/apptest.cpp` (headless dummy platform):
- `dynamicWindowsReconcileById` — start with one window, add a second, then remove the first, driving edits from the reconcile observer; asserts the observed id sets are `[0] → [0,1] → [1]`.
- `staticWindowsEnumerateFromZero` — the `initializer_list` path enumerates ids `[0,1,2]`.

## Verification

Configured and built with **clang-cl** (`CC=clang-cl CXX=clang-cl` from the MSVC env) and ran the full `meson test` suite — all four suites (btl/bq/avg/bqui) pass, including the two new App tests. Clean-context style and correctness reviews both came back clean.

## Docs

Updated `src/bqui/readme.md` (Application section), `src/bqui/AGENTS.md` (new "app loop" section + verified-against stamp), and header Doxygen.