### PR TITLE
ArraySignal<T>, forEach, and the keyed layout operators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ system works*, not this file:
 - [`docs/decisions.md`](docs/decisions.md) — why non-obvious choices were made.
 - [`docs/reviewing.md`](docs/reviewing.md) — how the pre-merge review works (what to weight, known false-positives).
 
+`docs/design/` holds **forward-looking proposals** — agreed designs that are not
+built yet. They describe what does *not* exist, so never treat one as a
+description of the tree; each is deleted once its stable parts have moved into
+`conventions.md`/`decisions.md` and header Doxygen.
+
 API reference is **Doxygen in the public headers**, not Markdown. Do not
 transcribe signatures into any Markdown doc, and do not add comments in code
 that point at these docs (they rot). Docs point at code; code never points at

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -155,7 +155,7 @@ signal) or a signal-of-vector, and a **branch** is a list of children. This
 syntax must work:
 
 ```cpp
-ArraySignal<Widget> content = {
+ArraySignal<AnyWidget> content = {
     someWidget,
     getArraySignalOfWidgets(),
     { otherWidget, getMoreWidgets() }
@@ -177,22 +177,22 @@ since every accepted form converts to `ArraySignal<T>`.
 constructed**, and is scoped to it. Ids are unique within one `ArraySignal` and
 mean nothing outside it.
 
-This is a reversal of an earlier draft, which put the allocator at the *exit*
-because ids were the consumer's business — a consumer reconciled against them,
-so a consumer-scoped, deterministic id space was what tests could assert on. The
-operator set below removes that requirement: identity is carried by
-`KeyedArraySignal`, `extract` and `scatter` match within a single `ArraySignal`'s
-space, and **an id never reaches user code**. Once nobody outside can see an id,
-the natural owner of the id space is the array itself, and the tension the
-earlier draft was working around disappears with it.
+The reason this works is that **an id never reaches user code**. Identity is
+carried by `KeyedArraySignal`; `extract` and `scatter` match within a single
+`ArraySignal`'s space; nothing outside can observe, construct or compare an id.
+Once that is true, the array is the natural owner of the id space, and ownership
+can be settled at construction — each `ArraySignal` allocates in its own space as
+it is built, and `concat` re-namespaces children rather than needing a shared
+counter.
 
-That tension was real, so record why it no longer bites. A *consumer*-owned
-allocator cannot be satisfied at construction time: nested `ArraySignal`s are
-built before their parent, and the parent before it ever reaches a consumer, so
-there is no point during construction at which the consumer's allocator is in
-scope. An *array*-owned allocator has no such problem — each `ArraySignal`
-allocates in its own space as it is built, and concatenation re-namespaces
-children rather than needing a shared counter.
+> **Superseded position.** An earlier draft put the allocator at the *exit*,
+> because ids were then the consumer's business: a consumer reconciled against
+> them, so the id space had to be consumer-scoped and deterministic for tests to
+> assert on. That draft also recorded a real obstacle — a consumer-owned
+> allocator cannot be satisfied at construction time, since nested
+> `ArraySignal`s are built before their parent and the parent before it reaches
+> any consumer, so the consumer's allocator is never in scope. Both the
+> requirement and the obstacle came from ids being visible. They lapse together.
 
 Consequences:
 
@@ -211,14 +211,14 @@ Consequences:
   `src/bq/src/signal/datacontext.cpp:7-11`, remains the fallback if the scoped
   form proves unworkable.)
 
-**What still needs an id-revealing exit.** PR #99 gives `App` a window list of
-`AnySignal<std::vector<std::pair<size_t, Window>>>`, and `dataBind` already
-returns exactly that shape for widgets
-(`src/bqui/include/bqui/databind.h:22`). Those consumers reconcile against ids
-directly. Under this design they are served by `extract`/`scatter` like any
-other consumer — the reconcile *is* apply-once-per-identity — but if a raw
-id-pair exit survives for them, it reveals the `ArraySignal`'s own ids rather
-than minting a per-consumer space. See *Open questions*.
+**This rests on an unsettled question.** Two consumers hand `size_t` ids to
+their caller today: PR #99's `App` window list
+(`AnySignal<std::vector<std::pair<size_t, Window>>>`) and `dataBind`
+(`src/bqui/include/bqui/databind.h:22`). If identity truly never surfaces then
+**there is no id-pair exit at all**, and those consumers take an `ArraySignal`
+and use `forEach` instead of being handed a vector of pairs. That is a real
+change to the shape of PR #99, and it is not this document's call to make. See
+*Open questions*.
 
 ### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
@@ -299,17 +299,28 @@ functions for that reason, not for aesthetics.
 never obtains, so they are already out of reach. Only `extract` and `scatter` —
 which take or return an `ArraySignal` — need moving off the class.
 
-### The layering test
+### What holds the two layers together
 
-**`forEach` must be implementable in terms of the advanced operations.** If the
-basic layer needs machinery the advanced layer cannot express, the split is
-cosmetic and the "advanced" header is not actually the lower layer — it is a
-sibling, and the document should say so instead.
+The two layers are not stacked — `forEach` is not built out of `extract` and
+`scatter`, and it never could be: `extract` is fan-in, `scatter` is fan-out, and
+`forEach` is neither. Its content is the key→id diff plus a once-per-identity
+invocation.
 
-Concretely, what the test comes down to is that `forEach`'s
-once-per-identity delegate invocation and `extract`'s once-per-identity
-initialisation are **the same primitive**, used once for fan-out and once for
-fan-in. This is not yet demonstrated; see *Open questions*.
+What relates them is a **shared primitive underneath both**:
+
+> `forEach`'s once-per-identity delegate invocation and `extract`'s
+> once-per-identity initialisation must be **the same apply-once-per-identity
+> operation**, used once for fan-out and once for fan-in.
+
+That is the invariant to hold the implementation to. If the two end up with
+separate caching machinery, they will drift in exactly the way `layout()` and
+`dynamicBox` drifted, and the identity guarantees in this document will hold for
+one of them and not the other.
+
+(An earlier draft stated a stronger rule — that `forEach` must be *implementable
+in terms of* the advanced operations — as a test of whether the split was real.
+It does not survive scrutiny, for the reason in the first paragraph, and is
+withdrawn rather than kept with a caveat.)
 
 ## The operator set
 
@@ -378,6 +389,25 @@ with the hand-rolled form:
   a list from a different container type-checks perfectly.
 
 `scatter` does the match **once, in one pass**, at construction.
+
+### Why it is called `scatter` and not `mapWith`
+
+`mapWith` was considered and rejected. It is the more descriptive name — it says
+"`map`, plus something" and it would sit alphabetically and conceptually next to
+`map`, which is where the framing above wants it.
+
+That is precisely the problem. **The name is a mild deterrent, and that is the
+point.** `scatter` lives in the layout-implementor header; a caller who reaches
+for it usually wants `map` and does not yet know it. A name that reads as an
+obvious extension of `map` invites exactly the wrong traffic, whereas a slightly
+opaque one makes a reader stop and find out what it does — at which point they
+discover the header it lives in and the aggregate it needs, and the two-layer
+split has done its job.
+
+The cost is real (the name does not describe the operation from the caller's
+side; nothing is redistributed anywhere the caller can see) and is accepted. The
+descriptive framing lives in this document and belongs in the Doxygen; the
+identifier's job here is gatekeeping, not exposition.
 
 ### The distinguished type is what removes the hazard
 
@@ -796,15 +826,15 @@ survive membership changes to its siblings.
 
 ### First value wins, and it cannot be asserted
 
-With `ArraySignal<Widget>`, the delegate has already run by the time a second
-`Widget` value arrives at a fixed key. There is nothing to do with it: applying
-it means rebuilding, and rebuilding loses the state the whole design exists to
-protect. **The rule is that the first value wins; the key is the unit of
-change.**
+With `ArraySignal<AnyWidget>`, the delegate has already run by the time a second
+`AnyWidget` value arrives at a fixed key. There is nothing to do with it:
+applying it means rebuilding, and rebuilding loses the state the whole design
+exists to protect. **The rule is that the first value wins; the key is the unit
+of change.**
 
 Honesty about enforcement: **this cannot be asserted.**
 
-- `Widget` has no `operator==`, so "did the value actually change?" is not a
+- `AnyWidget` has no `operator==`, so "did the value actually change?" is not a
   question that can be asked.
 - Asserting merely on "the signal emitted again" would false-positive on any
   upstream that emits without a `check()` — which is most of them, since
@@ -927,6 +957,25 @@ Neither is a hard problem. Both exist **because `dynamicBox` is a second
 implementation of `layout()` that drifted** — every fix to one has to be
 remembered for the other, and it was not. One engine makes drift structurally
 impossible, which is worth more than either individual fix.
+
+### The unified engine takes `ArraySignal<AnyWidget>`
+
+**Settled.** Not `ArraySignal<Widget>` or any concrete widget type.
+
+- A layout's children are **differently typed by nature** — a label next to a
+  button next to a nested box — so a homogeneous array of a concrete widget type
+  could not hold them. Type erasure is not a compromise here; it is the only
+  thing that describes the input.
+- Both existing engines already take `AnyWidget` (`layout.h:33-34`,
+  `dynamicbox.h:23-24`), so nothing is lost and no caller changes shape.
+- `ArraySignal` is **type-erased regardless** (*There is deliberately no
+  `AnyArraySignal`*), so a concrete element type would buy no devirtualisation
+  even where the children happened to agree.
+
+The consequence for the `scatter` delegate is that it receives an
+`AnySignal<AnyWidget>` rather than a concrete widget type. That is enough: it
+needs `getSizeHint()` and `getGravity()`, which the erased interface provides,
+and those are exactly what `handleGravity` and the hint fan-in consume.
 
 ## Worked example: `dynamicBox`
 
@@ -1283,32 +1332,26 @@ Points the design does not yet settle. Flagged rather than guessed.
   introduced," and means a filtered-out widget silently loses its state. Decide
   whether `filter` evicts from the shared identity space or only masks its own
   output, and say which guarantee survives.
-- **Is `scatter` the right name?** "Scatter" implies a redistribution the caller
-  never sees — nothing is being spread anywhere from the caller's point of view;
-  the delegate simply receives one more argument. **`mapWith`** says what it does
-  and puts it next to `map`, which is where the *`scatter` is `map` with one
-  extra argument* framing wants it. `scatter` is used throughout this document
-  because that is the name the design was worked out under. Settle before the
-  header is written; renaming afterwards is churn.
-- **Does the layering test actually pass?** *The API surface* asserts that
-  `forEach` must be implementable in terms of `extract`/`scatter`, on pain of the
-  layering being cosmetic. That has **not been demonstrated.** `extract` is
-  fan-in and `scatter` is fan-out, while `forEach` is neither — its content is
-  the key→id diff plus once-per-identity invocation. The plausible resolution is
-  that the shared primitive is *apply-once-per-identity*, which `forEach` and
-  `extract` both use, and that the test should be restated in those terms.
-  Restate it or drop it; leaving an untested claim in a design document is worse
-  than either.
-- **Does a raw id-revealing exit survive at all?** *Identity is internal* argues
-  that nothing outside needs to see an id, which is what justifies moving the
-  allocator onto the `ArraySignal`. But PR #99's `App` window list and today's
-  `dataBind` both hand ids to their consumer. If both are rewritten onto
-  `extract`/`scatter` the question disappears; if either keeps an id-pair
-  signal, decide which layer's header it lives in and say what the ids mean.
-- **`ArraySignal<Widget>` versus `ArraySignal<AnyWidget>` for the layout API.**
-  *First value wins* is stated for `ArraySignal<Widget>`, but `layout()` and
-  `dynamicBox` both take `AnyWidget` today. Which one the unified engine accepts
-  affects whether the delegate can see a concrete builder type. Not settled here.
+- **Does any identity surface at the exit?** This is the one open question that
+  changes code outside this design, and it should be decided when PR #99 is
+  reworked rather than pre-empted here.
+
+  *Identity is internal* argues that nothing outside the `ArraySignal` needs to
+  see an id, and that is what justifies scoping the allocator to the array. Taken
+  to its conclusion it means **there is no id-pair exit at all**: `App` would
+  take an `ArraySignal<Window>` and use `forEach` — building a `WindowGlue` per
+  identity — instead of being handed
+  `AnySignal<vector<pair<size_t, Window>>>` and reconciling by hand. Likewise
+  `dataBind`'s consumers.
+
+  The alternative is that some consumer genuinely needs the ids, in which case
+  an id-revealing exit survives and two things must be settled with it: which
+  layer's header it lives in, and what an id *means* to a consumer given that it
+  is now the `ArraySignal`'s own number rather than one minted for that consumer
+  (in particular, whether it is stable enough to assert on in a test).
+
+  The two live consumers are PR #99's window list and `dataBind`
+  (`src/bqui/include/bqui/databind.h:22`).
 
 ## Implementation order
 
@@ -1333,6 +1376,81 @@ anything in `bqui` changes.
    `dataSourceFromCollection` here too, and port
    `src/bqui/test/databindtest.cpp:18` and `src/testapp1/adder.cpp:84`.
 
-Steps 3 and 4 are the ones that need tests written first: neither `dynamicBox`
-nor `uniformGrid` has any coverage today, so there is nothing to catch a
-regression in the rewrite.
+### The safety net for steps 3 and 4
+
+Steps 3 and 4 reimplement code that had no coverage at all. **PR #102 (branch
+`layout-tests`) is the start of that net** and should land before the rewrite
+does.
+
+It pins down *observable* geometry rather than internals: probe widgets carry a
+uniquely-identified `InputArea`, the layout is realised once through a single
+`SignalContext`, and the areas are looked up by id to recover both the size a
+child was allocated and where it was placed. Because input areas accumulate
+enclosing transforms on their way to the root `Instance`, this reads the geometry
+a child actually received — which is decided *outside* the child, by
+`handleGravity()` and `transformBuilder()` — rather than what the child asked
+for. The tests name only `hbox`, `vbox`, `mapObbs`, `AnyWidget`, `SizeHint` and
+`Instance`, so they survive a reimplementation.
+
+Seven tests cover `hbox` filler distribution (partial and full), `vbox`'s
+reversed y axis, `handleGravity` centering in an oversized slot, upward
+`SizeHint` aggregation, and `mapObbs` on both axes. They are mutation-verified:
+an off-by-one in the `mapObbs` accumulator turns five red *including the
+end-to-end probe tests*, and a doubled gravity offset turns exactly one red —
+the one that covers gravity — while leaving both isolated `mapObbs` tests green.
+That last result is the argument for the probe harness over testing
+`ObbMap`/`SizeHintMap` in isolation: the pure-maths tests alone would have missed
+it.
+
+Still uncovered, and worth adding before step 4 in particular: `stack`,
+`uniformGrid`, `dynamicBox`, nesting, zero- and one-child cases, degenerate
+hints, non-default gravity, and changing hints. `stack` and `uniformGrid` need
+nothing new from the harness; a dynamic child list needs the probe list built
+from a signal, and changing hints need `context.update()` between evaluations.
+
+### Hazards in `getSizes` for the rewrite
+
+`getSizes` (`box.h:24-52`) is the core of the placement maths and the unified
+engine will reimplement this path. Two properties of it are load-bearing by
+accident. Both were surfaced by PR #102 and re-verified against the current
+source.
+
+**It divides by zero on equal consecutive hint components, and only survives
+because of `std::min`'s argument order.** The multiplier loop computes
+`(size - prev) / (combined[i] - prev)` (`box.h:33-38`). The denominator is zero
+whenever two consecutive aggregate components are equal — which is the *common*
+case, not a corner one: any fixed-size child has a hint like `{{30, 30, 30}}`, so
+`combined[1] - combined[0]` is zero. The quotient is `±inf` (or `NaN` when the
+box is exactly the natural size, since the numerator is zero too), and it lands
+on the right answer only because:
+
+```cpp
+multiplier[i] = std::max(0.0f, std::min(1.0f, m));
+```
+
+`std::min(a, b)` returns `(b < a) ? b : a`. With `a = 1.0f` and `b = NaN`, the
+comparison is false, so it returns `1.0f` — the correct multiplier. Written the
+other way round, `std::min(m, 1.0f)` returns `NaN`, and `std::max(0.0f, NaN)`
+then returns `0.0f`: **every fixed-size child collapses to zero width.** The
+same reversal turns the `+inf` case into `0.0f` as well.
+
+So the clamp is not defensive code that happens to also handle the degenerate
+interval — it is the *only* thing handling it, and it does so through an
+unwritten dependency on operand order. A rewrite must handle the zero-width
+interval explicitly instead.
+
+**The output is not clamped against `size`.** The only bound on the total is that
+each multiplier is clamped to `[0, 1]`, which holds the sum to the aggregate
+maximum *provided every hint is monotonic* (`min ≤ preferred ≤ max`). Two
+consequences:
+
+- For well-formed hints, a box larger than the children's total maximum leaves
+  the remainder **unused** — children under-fill rather than overflow. That is
+  ordinary layout behaviour (fillers exist to absorb it), but it means a rewrite
+  must not assume `sum(getSizes(size, hints)) == size`.
+- For a **non-monotonic** hint the bound fails outright and children overflow the
+  box. A hint of `{{100, 0, 100}}` — minimum above preferred — gives
+  `multiplier = {1, 0, 1}` and a child size of `200` in a 200-wide box; two such
+  children total `400`. Nothing rejects such a hint today.
+
+Neither is fixed in PR #102, which deliberately changes no behaviour.

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -162,59 +162,63 @@ ArraySignal<Widget> content = {
 };
 ```
 
-Nesting is not a special case in the consumer: the consumer sees the exported
-`(id, value)` list and never walks the tree.
+Nesting is not a special case in the consumer: a consumer operates through
+`forEach`, `map`, `extract` and `scatter`, all of which see a flat sequence of
+identified elements, and never walks the tree.
 
-### It leaves the domain as `AnySignal<std::vector<std::pair<size_t, T>>>`
+Note that the *stated public requirement* is only that `{a, b, c}` compiles for
+values of `T`. The `initializer_list` element type being `ArraySignal<T>` rather
+than `T` is how that requirement is met **and** how nesting falls out for free,
+since every accepted form converts to `ArraySignal<T>`.
 
-The single exit from `ArraySignal<T>` back to `Signal` produces a signal of
-`(id, value)` pairs in list order. Consumers reconcile against the ids and never
-look at the tree.
+### Identity is internal, and the id space belongs to the `ArraySignal`
 
-This is not a new shape. `dataBind` already returns exactly it for widgets
-(`src/bqui/include/bqui/databind.h:22`), and the open PR #99 proposes
-`AnySignal<std::vector<std::pair<size_t, Window>>>` for `App`'s window list.
-`ArraySignal` generalises what those two arrived at independently.
+**Settled:** the id allocator is **constructed at the point the `ArraySignal` is
+constructed**, and is scoped to it. Ids are unique within one `ArraySignal` and
+mean nothing outside it.
 
-### Ids are assigned at the exit, by a scoped allocator
+This is a reversal of an earlier draft, which put the allocator at the *exit*
+because ids were the consumer's business — a consumer reconciled against them,
+so a consumer-scoped, deterministic id space was what tests could assert on. The
+operator set below removes that requirement: identity is carried by
+`KeyedArraySignal`, `extract` and `scatter` match within a single `ArraySignal`'s
+space, and **an id never reaches user code**. Once nobody outside can see an id,
+the natural owner of the id space is the array itself, and the tension the
+earlier draft was working around disappears with it.
 
-**Settled:** the allocator is constructed at the point the
-`AnySignal<std::vector<std::pair<size_t, T>>>` is constructed, and is a
-parameter of that operation. **Construction of a `ArraySignal` assigns no ids at
-all**; the exit does. So an id is a property of *one exit's* view of the tree,
-and the allocator's lifetime is the exit signal's lifetime.
+That tension was real, so record why it no longer bites. A *consumer*-owned
+allocator cannot be satisfied at construction time: nested `ArraySignal`s are
+built before their parent, and the parent before it ever reaches a consumer, so
+there is no point during construction at which the consumer's allocator is in
+scope. An *array*-owned allocator has no such problem — each `ArraySignal`
+allocates in its own space as it is built, and concatenation re-namespaces
+children rather than needing a shared counter.
 
-This resolves what would otherwise be a genuine tension. A consumer-owned
-allocator and a per-type constructor set cannot both be satisfied at
-construction time: nested `ArraySignal`s are built before their parent, and the
-parent before it ever reaches a consumer, so there is no point during
-construction at which the consumer's allocator is in scope. Making the allocator
-a parameter of the exit removes the problem instead of threading around it —
-`ArraySignal` values stay pure descriptions that can be built, stored, and passed
-anywhere, and nothing needs an ambient allocator.
+Consequences:
 
-Ids are **reused across re-exports**, so an item that survives a change keeps
-its id. This requires the allocator to be *stateful and durable* — it lives with
-the exit signal, not with a single evaluation.
+- Ids are **reused across evaluations**, so an item that survives a change keeps
+  its id. The allocator is therefore *stateful and durable*: it lives with the
+  `ArraySignal`'s durable state, not with a single evaluation.
+- **`forEach`'s key→id map lives in that same state.** It is not per-evaluation
+  state and it is not something a user-visible value carries. Which mechanism
+  holds it (a `DataType` slot in the `SignalContext`, or a control block with its
+  own id as `SharedControl` does) is an implementation choice; the requirement is
+  only that its lifetime match the `ArraySignal`'s.
+- Not a process-wide global, for the same two reasons as before: no global
+  mutable state to make thread-safe, and deterministic ids so that a test can
+  assert on the id set rather than on whatever the global counter happened to be
+  at. (A global atomic in the style of `bq::signal::makeUniqueId`,
+  `src/bq/src/signal/datacontext.cpp:7-11`, remains the fallback if the scoped
+  form proves unworkable.)
 
-Not a process-wide global, for two reasons: no global mutable state to make
-thread-safe, and **deterministic per-exit ids**, which is what lets a test
-assert on the id set — as PR #99's window tests do — instead of on whatever the
-global counter happened to be at. Ids only need to be unique *within one exit*,
-so a per-consumer allocator is sufficient. (A global atomic in the style of
-`bq::signal::makeUniqueId`, `src/bq/src/signal/datacontext.cpp:7`, remains the
-fallback if the scoped form proves unworkable — but the tension that motivated
-that escape hatch is now gone.)
-
-**Consequence for `forEach`'s key→id map.** That map is what makes an id
-survive, so it lives wherever the allocator lives: in the durable state hanging
-off the exit signal, created and destroyed with it. It is *not* per-evaluation
-state, and it is not something the `ArraySignal` value carries — a `ArraySignal` used
-by two exits legitimately has two independent id spaces and therefore two maps.
-Exactly which mechanism holds that state (a `DataType` slot in the
-`SignalContext`, or a control block with its own id, as `SharedControl` does) is
-an implementation choice; the requirement is only that its lifetime match the
-exit's.
+**What still needs an id-revealing exit.** PR #99 gives `App` a window list of
+`AnySignal<std::vector<std::pair<size_t, Window>>>`, and `dataBind` already
+returns exactly that shape for widgets
+(`src/bqui/include/bqui/databind.h:22`). Those consumers reconcile against ids
+directly. Under this design they are served by `extract`/`scatter` like any
+other consumer — the reconcile *is* apply-once-per-identity — but if a raw
+id-pair exit survives for them, it reveals the `ArraySignal`'s own ids rather
+than minting a per-consumer space. See *Open questions*.
 
 ### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
@@ -256,40 +260,151 @@ These are design constraints on the implementation, not incidental details.
   actually produces it rather than leaving it to whichever constructor happened
   to be a better match.
 
-## `ArraySignal` as a domain alongside `Signal`
+## The API surface: two layers
 
-`ArraySignal` is not a helper type bolted onto `Signal` — it is **its own domain**,
-with its own operations, entered and left by explicit boundary operations:
+Most callers need four things: build one, iterate it, concatenate, transform.
+Layout implementors need two more, and those two are sharp enough that an
+ordinary caller reaching for them is almost always a mistake. So the surface is
+split across **two headers**:
 
-```
-                forEach(collection, keyFn, delegate)
-    Signal  ──────────────────────────────────────────▶  ArraySignal
-            ◀──────────────────────────────────────────
-                        toSignal(allocator)
-```
+| Header | Namespace | Contents |
+| --- | --- | --- |
+| `<bq/signal/arraysignal.h>` | `bq::signal` | `ArraySignal<T>` and its constructors (`std::initializer_list`, `std::vector<T>`, `AnySignal<...>`); `forEach(keyFn, delegate)`; `concat`; `map` |
+| `<bq/signal/arraysignallayout.h>` | a nested namespace, e.g. `bq::signal::layout` | the free functions `extract` and `scatter`, plus `KeyedArraySignal<A>`'s operations |
 
-Naming this is worth doing because most of the structure is **already latent**
-in the design above. Making it explicit tells us which operations must exist,
-what their laws are, and — most usefully — what each one does to identity.
+### Why not the `src/`-vs-`include/` firewall
 
-### The operations
+The project's usual way to hide something is to keep it out of
+`src/<lib>/include/`, which makes it uncompilable from any other library
+(`docs/conventions.md`). **That mechanism cannot be used here.** `ArraySignal`
+lives in `bq`; layouts live in `bqui`; `bqui` can only include `<bq/...>` public
+headers. Anything internal to `bq` is unreachable from a layout, and layouts are
+precisely the code that needs `extract` and `scatter`. The firewall is
+inter-library, and this split is intra-audience — the wrong tool.
 
-- **`pure : T → ArraySignal<T>`** — the single-item constructor. Already in the
-  table above.
-- **Concatenation** — the `initializer_list` / `vector<ArraySignal<T>>`
-  constructor, with the empty list as identity. This is a **monoid**, and its
-  associativity law is not an abstraction: it is literally the brace-nesting
-  ergonomics we require, `{a, {b, c}} ≡ {a, b, c}`. The syntax goal and the
-  algebraic law are the same statement.
-- **`join : ArraySignal<ArraySignal<T>> → ArraySignal<T>`** — already latent. A branch
-  node *is* nesting, and collapsing the tree *is* join. It deserves a name
-  because `flatMap` then falls out as `map` followed by `join`, with no new
+So the separation is by **header and namespace**, which is advisory rather than
+enforced. That is the correct strength: an implementor who writes the extra
+include has declared intent, and grep finds every such site.
+
+### Why the advanced operations must be free functions
+
+In C++ a class's member functions are all declared in one class definition.
+There is no way to add members in a second header, and no way to make a member
+available only to code that opted in. **Gating the surface therefore requires
+that the gated operations not be members.** `extract` and `scatter` are free
+functions for that reason, not for aesthetics.
+
+`KeyedArraySignal` being a separate type does most of the work for free:
+`mapValues`, `mapKeyed` and `values` are members of a type an ordinary caller
+never obtains, so they are already out of reach. Only `extract` and `scatter` —
+which take or return an `ArraySignal` — need moving off the class.
+
+### The layering test
+
+**`forEach` must be implementable in terms of the advanced operations.** If the
+basic layer needs machinery the advanced layer cannot express, the split is
+cosmetic and the "advanced" header is not actually the lower layer — it is a
+sibling, and the document should say so instead.
+
+Concretely, what the test comes down to is that `forEach`'s
+once-per-identity delegate invocation and `extract`'s once-per-identity
+initialisation are **the same primitive**, used once for fan-out and once for
+fan-in. This is not yet demonstrated; see *Open questions*.
+
+## The operator set
+
+Two groups. The first is the everyday surface; the second is what a container
+implementation needs.
+
+### Basic
+
+- **`ArraySignal<T>{...}` / from `vector<T>` / from `AnySignal<...>`** — the
+  constructors. The single-item form is `pure : T → ArraySignal<T>`.
+- **`concat`** — the `initializer_list` / `vector<ArraySignal<T>>` form, with the
+  empty array as identity. This is a **monoid**, and its associativity law is not
+  an abstraction: it is literally the brace-nesting ergonomics we require,
+  `{a, {b, c}} ≡ {a, b, c}`. The syntax goal and the algebraic law are the same
+  statement.
+- **`map : (T → U) → ArraySignal<T> → ArraySignal<U>`** — a lawful functor,
+  value-level. See *`forEach` vs `map`*.
+- **`forEach(keyFn, delegate)`** — the keyed operator; identity-level.
+- **`join : ArraySignal<ArraySignal<T>> → ArraySignal<T>`** — latent in the tree
+  shape: a branch node *is* nesting, and collapsing the tree *is* join. Worth a
+  name because `flatMap` then falls out as `map` followed by `join`, with no new
   machinery.
-- **`map : (T → U) → ArraySignal<T> → ArraySignal<U>`** — a lawful functor. See the
-  caveat below: this is emphatically **not** the delegate form `forEach`
-  rejects.
 - **`filter`** — not required by anything here, but obviously wanted soon.
   Identity-preserving for the items that survive.
+
+### Advanced: the fan-in / fan-out pair
+
+- **`extract(f : T → AnySignal<A>) → KeyedArraySignal<A>`** — order-preserving
+  fan-in. `f` is applied **once per identity**, so the per-element signal it
+  returns is initialised once and thereafter merely updates. For a layout, `f` is
+  "give me this child's size hint".
+- **`mapValues(g : vector<A> → vector<B>, extras...) → KeyedArraySignal<B>`** —
+  the maths. `g` sees every child's value at once and returns one value per
+  child; identity rides along untouched. `extras...` are ambient signals injected
+  alongside the vector — for a layout, the container's own size. This is where a
+  layout's obb computation goes.
+- **`mapKeyed(vector<pair<Key, A>> → vector<pair<Key, B>>)`** — the same, for
+  computations that **reorder or drop**. `Key` is opaque: comparable and hashable,
+  and otherwise meaningless. Nothing may be inferred from its value, its ordering
+  relative to other keys, or its stability across runs.
+- **`values() → AnySignal<vector<A>>`** — the one-way escape back to a plain
+  signal, discarding identity. **Every** layout needs it, for upward size-hint
+  propagation: the container's own hint is a pure function of its children's
+  hints and has no per-child result to scatter back.
+- **`scatter(keyed, f) → ArraySignal<U>`** — fan-out, where `f` is
+  `(AnySignal<T>, AnySignal<B>) -> U`: exactly `map`'s delegate plus the
+  identity-matched slice of the aggregate. For a layout, `f` is "build this child
+  against the obb that was computed for it".
+
+### `scatter` is `map` with one extra, identity-matched argument
+
+That is the sentence that makes the operator obvious. `map` gives the delegate
+the element's own value; `scatter` gives it the element's own value *and* the
+element's own share of a previously computed aggregate.
+
+It can be hand-rolled as `map` plus an id lookup — that is exactly what
+`dynamicBox` does today, at `dynamicbox.h:108-122`, where each child maps the
+shared obb list and linearly searches it for its own id. Three things are wrong
+with the hand-rolled form:
+
+- **It is O(n) per element per emission**, so O(n²) per layout change.
+- **Missing entries are undefined.** `dynamicBox` asserts and returns a
+  default-constructed `avg::Obb` (`dynamicbox.h:118-119`) — in release, a
+  zero-sized box, silently.
+- **Nothing stops a lookup in a foreign id space.** The ids are plain `size_t`;
+  a list from a different container type-checks perfectly.
+
+`scatter` does the match **once, in one pass**, at construction.
+
+### The distinguished type is what removes the hazard
+
+The aggregate could have been a plain `AnySignal<vector<pair<Id, A>>>`. Making it
+a **distinguished type** — `KeyedArraySignal<A>` — is what turns the matching
+hazard into a compile error:
+
+- Only something `extract` produced can be scattered back.
+- Ids never surface, so nothing can be keyed on them by accident and no caller
+  can invent one.
+- The alignment invariant is **carried by the type** rather than by
+  `assert(obbs.size() == builders.size())` (`dynamicbox.h:70`).
+
+That last point is the whole argument for a new type rather than a type alias.
+
+### Multi-value `ArraySignal` was considered and rejected
+
+`Signal<Ts...>` is variadic, and mirroring that with `ArraySignal<Ts...>` was
+considered, mainly to avoid making callers write `std::pair` when an element
+naturally carries two things.
+
+That motivation **evaporated once `scatter` took a function**: the delegate
+receives two separate signal arguments, so the common case — value plus
+aggregate slice — never needed a pair in the first place. The general case is
+recovered with a `makePair`-style helper at the call site. Variadic
+`ArraySignal` would multiply every operator signature above for a problem that
+no longer exists.
 
 ### The identity algebra
 
@@ -300,26 +415,21 @@ to reason from when asking "will this rebuild?":
 | Operation | Effect on identity |
 | --- | --- |
 | `pure` | **creates** one id |
-| concatenation / nesting | **namespaces** children — child ids stay distinct, order is preserved |
+| `concat` / nesting | **namespaces** children — child ids stay distinct, order is preserved |
 | `map` | **preserves** — same ids, transformed values |
 | `filter` | **preserves** for survivors; dropped items' ids are evicted |
 | `join` / `flatMap` | **namespaces** inner ids into the outer id space |
 | `forEach` | **creates** ids, derived from keys |
-| `toSignal` | **reveals** ids; creates nothing |
+| `extract` | **preserves** — the `KeyedArraySignal` carries the input's ids |
+| `mapValues` | **preserves** — identity rides along, values change |
+| `mapKeyed` | **preserves** for the keys the function returns; others are dropped |
+| `values` | **discards** — the result is a plain signal with no identity |
+| `scatter` | **preserves** — re-enters `ArraySignal` with the ids it matched on |
 
 Read it as a single rule: **only `pure` and `forEach` mint identity.**
-Everything else either carries identity through unchanged or re-namespaces it
-without inventing any. That is what makes it possible to look at a pipeline and
-say whether a given item will keep its state.
-
-One clarification the table needs, given that ids are assigned at the exit:
-inside the domain, identity is **symbolic** — a position in the tree, or a key —
-and it is `toSignal` that resolves each symbolic identity to a concrete
-`size_t`. "`pure` creates an id" means it introduces a new identity that the
-exit will number; "`map` preserves ids" means it does not disturb the symbolic
-identities, so the same items get the same numbers as they would have without
-it. The two statements — "construction assigns no ids" and "`map` preserves
-ids" — are consistent only under this reading, so state it in the Doxygen too.
+Everything else either carries identity through unchanged, re-namespaces it
+without inventing any, or drops it entirely (`values`). That is what makes it
+possible to look at a pipeline and say whether a given item will keep its state.
 
 ### The boundary is asymmetric
 
@@ -331,34 +441,32 @@ values with no notion of which value "is" which across a change. Identity has to
 come from somewhere, and only the caller knows what makes two items the same
 thing. Hence `forEach` takes a `keyFn`.
 
-Leaving is free because by then the ids exist; `toSignal` only has to *reveal*
-them, and its allocator parameter is about which id space to reveal them in, not
-about inventing identity.
+Leaving is free because by then the identities exist and `values()` merely
+forgets them. Forgetting needs no information; remembering does.
 
 This is the one-sentence answer to "why does `forEach` need a key function and
-the exit does not?"
+`values()` does not?"
 
-### Naming: `join`/`flatten` vs `toSignal`
+### Naming: `join` vs `values`
 
 Two distinct collapses exist and must not share a name:
 
-- **`join`** (or `flatten`) — `ArraySignal<ArraySignal<T>> → ArraySignal<T>`. Stays
-  inside the domain; collapses nesting.
-- **`toSignal(allocator)`** — `ArraySignal<T> → AnySignal<vector<pair<size_t, T>>>`.
-  Leaves the domain; assigns and reveals ids.
+- **`join`** (or `flatten`) — `ArraySignal<ArraySignal<T>> → ArraySignal<T>`.
+  Stays inside the domain; collapses nesting; identity survives.
+- **`values()`** — `KeyedArraySignal<A> → AnySignal<vector<A>>`. Leaves the
+  domain; identity is discarded.
 
-`resolve(allocator)` is an acceptable alternative for the second. What is not
-acceptable is calling both of them `flatten`, which is the natural drift given
-that both "flatten" something — and which would make every sentence about ids
-ambiguous. Earlier drafts of this document used "flatten" for the exit; that
-usage is retired.
+What is not acceptable is calling both of them `flatten`, which is the natural
+drift given that both "flatten" something — and which would make every sentence
+about identity ambiguous. Earlier drafts used "flatten" for the exit; that usage
+is retired.
 
 ### One operation, three call sites: apply-once-per-id
 
 The pattern **build once per id → cache the result → reuse it on later
 emissions** currently exists in three places:
 
-1. `dynamicBox` caches built elements by id (`dynamicbox.h:104-159`).
+1. `dynamicBox` caches built elements by id (`dynamicbox.h:85-141`).
 2. `App`'s window reconcile in PR #99: create a `WindowGlue` on a new id,
    destroy it when the id vanishes, keep it otherwise.
 3. `forEach` would be the third.
@@ -380,29 +488,46 @@ Semantics, fixed to match the rest of the design:
 - A **re-appearing key rebuilds.** There is no resurrection of evicted state; a
   key that goes away and comes back is a new item, exactly as a changed key is.
 
-### `.map` is value-level; the build delegate is structure-level
+## `forEach` vs `map` — the central distinction
 
-This looks contradictory and is the most important caveat in the document: a
-`(T) -> U` function is **banned** as the `forEach` delegate and **fine** as
-`.map`. Same signature — different role.
+Both take a function from an element to something else. They are not
+interchangeable, and confusing them is the single easiest way to write code that
+looks right and silently throws away user state.
 
-- **`.map(f)` is value-level.** It is implemented as a per-element `sig.map(f)`,
-  so the `Map` node is created **once per identity**, and on a value change `f`
-  re-runs *inside* the already-built signal graph. Nothing is constructed, so
-  nothing is destroyed. Lawful functor, no state loss.
-- **The build delegate is structure-level.** Its `f` *constructs* something
-  stateful — a widget with an input, a stream fold, a window. Re-invoking it
-  means a rebuild, and a rebuild is what destroys state (see *Rationale*).
+- **`forEach` is identity-level.** Its delegate is `(AnySignal<T>) -> U`, and it
+  is invoked **once per key**. It is *not* re-invoked when the item's value
+  changes — the new value arrives through the signal the delegate already holds.
+  Nothing is constructed on a value change, so nothing is destroyed. **This is
+  what preserves widget state.**
+- **`map` is value-level.** Its function is `T -> U`, re-run on every value
+  change. Implemented as a per-element `sig.map(f)`, so the `Map` node is created
+  once per identity and `f` re-runs *inside* the already-built graph. Perfect for
+  data; ruinous for widgets, because building a widget here reconstructs it — and
+  everything it holds — on every change.
 
-The rule to hold onto:
+The rule, stated plainly, is the one sentence to carry out of this document:
 
-> **`.map` for transforming values; the `(AnySignal<T>) -> U` build form for
-> constructing stateful things.**
+> **Transform data in `map`; build widgets in `forEach`.**
 
 The type system cannot tell these apart — `(T) -> U` is `(T) -> U` whether it
 adds one to a number or spins up a text field with a cursor — so the
-documentation has to. A `.map` whose function constructs a widget is the
-footgun; that is the one thing to say in the Doxygen for `map`.
+documentation has to. A `map` whose function constructs a widget is the footgun;
+that is the one thing to say in the Doxygen for `map`.
+
+### Why `map` stays public
+
+The tempting safety move is to hide `map` and let `forEach` cover everything.
+That is worse. `forEach` **mints an identity** for every element, and an identity
+is a commitment: a key to compute, a key→id entry to keep, an eviction rule to
+reason about. Forcing a pure `T -> U` data transform through `forEach` pays all
+of that for something that has no state to preserve, and — more importantly —
+teaches callers that `forEach` is the default, which makes the identity-level /
+value-level distinction invisible exactly where it matters.
+
+`map` is public because the choice between the two must be *made*, not defaulted
+into.
+
+### `map` with extra signals
 
 ### `map` with extra signals
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -825,6 +825,196 @@ freely on per-element signals — it takes advantage of `operator==` where the t
 has one and passes silently through where it does not. See *Skipping repeats* above
 for the details and for the usability trap in that silence.
 
+## One layout engine
+
+This is the headline finding, and it was not the goal when the design started.
+`bqui` has **two** layout engines: the static one (`layout()`, used by `box`,
+`stack` and `uniformGrid`) and the dynamic one (`dynamicBox`, used by `hbox` and
+`vbox` when the child list is a signal). The operator set above does not add a
+third. It **collapses the two into one**.
+
+### `layout()`'s own type aliases already are this API
+
+`src/bqui/include/bqui/widget/layout.h` declares exactly two things a layout must
+supply:
+
+```cpp
+// layout.h:11-13
+using ObbMap = btl::Function<
+    std::vector<avg::Obb>(ase::Vector2f size,
+            std::vector<SizeHint> const&)>;
+
+// layout.h:22-24
+using SizeHintMap = btl::Function<
+    SizeHint(std::vector<SizeHint> const&)
+    >;
+```
+
+Read those against the operator set:
+
+| `layout()` alias | Operator |
+| --- | --- |
+| `ObbMap` — `(Vector2f, vector<SizeHint>) -> vector<Obb>` | `mapValues(g, size)` — `g` is `vector<A> -> vector<B>`, `size` is the ambient extra |
+| `SizeHintMap` — `vector<SizeHint> -> SizeHint` | `values().map(...)` |
+
+`ObbMap` is `mapValues` with the container size as the injected extra, down to
+the argument order. `SizeHintMap` is `values()` followed by an ordinary
+`Signal::map`. The abstraction was not invented for this design; it was already
+sitting in the static engine's signature, un-named and un-reused.
+
+`layout()`'s implementation completes the picture: it fans in with
+`bq::signal::combine` over the children's hints (`layout.cpp:21-26`), computes
+once (`layout.cpp:31`), and fans out per child (`layout.cpp:34-55`). That is
+`extract`, `mapValues`, `scatter`, hand-written for the static case.
+
+### The static engine expresses nothing the dynamic one cannot — the tuple path is dead
+
+There is one thing the static engine could in principle do that a homogeneous
+`ArraySignal<T>` cannot: hold children of **heterogeneous types** in a
+`std::tuple`, keeping each child's concrete type through the layout. `box.h`
+contains the machinery for it:
+
+- `accumulateSizeHintsTuple` (`box.h:116-121`), returning
+  `AccumulateSizeHint<dir, std::tuple<Ts...>>`.
+- `MapObbs<dir>` (`box.h:163-202`), a struct whose `operator()` is templated on
+  the hint container and flattens it with `btl::forEach`.
+
+**Both are dead code.** A repo-wide search for either name over all `.h`, `.hpp`
+and `.cpp` files returns only their own definitions — `box.h:117` and `box.h:164`
+— and nothing else in the tree. `box()` uses the vector forms
+(`accumulateSizeHints<dir>` and `&mapObbs<dir>`, `box.h:238`); so do `stack`
+(`stack.cpp:25`) and `uniformGrid` (`uniformgrid.cpp:82-86`).
+
+So the only capability the static path has over a unified engine is one **no
+caller uses**. That removes the last reason to keep two implementations.
+
+### Cost: the static path is lighter at construction, not at steady state
+
+The fair objection is that a static list should not pay for identity it does not
+need. The honest accounting:
+
+- **Construction.** The unified engine costs one extra node in the graph and N
+  key allocations. Once.
+- **Steady state.** For a never-changing membership, `extract`'s `Join`
+  initialises its inner signal once and thereafter behaves as a plain `combine` —
+  the re-initialisation branch at `join.h:88-92` is only taken when the *outer*
+  signal changes, and for fixed membership it never does. `scatter` matches
+  identity once at construction, not per emission. **Per frame, both paths do the
+  same work.**
+
+A per-frame cost would be a real argument against unifying. A one-off
+construction cost is not.
+
+### Safety: keyed fan-out removes two unchecked arity contracts
+
+The static path fans out with `obbs.at(index)` on a captured index
+(`layout.cpp:37-47`). `at()` throws rather than corrupting, but the contract —
+"the obb vector has one entry per builder, in builder order" — is unchecked at
+the type level and is asserted nowhere. It is the same unchecked contract as
+`dynamicBox`'s `assert(obbs.size() == builders.size())` (`dynamicbox.h:70`),
+written a different way.
+
+Keyed fan-out removes both: `scatter` cannot be handed an aggregate that did not
+come from the matching `extract`.
+
+### The maintenance argument is the strongest one
+
+`dynamicBox` is missing `handleGravity()`. `layout()` applies it to every child
+(`layout.cpp:84-87`); `dynamicBox` does not apply it anywhere. `dynamicBox` also
+has the element-cache correctness bug described under *Rationale*.
+
+Neither is a hard problem. Both exist **because `dynamicBox` is a second
+implementation of `layout()` that drifted** — every fix to one has to be
+remembered for the other, and it was not. One engine makes drift structurally
+impossible, which is worth more than either individual fix.
+
+## Worked example: `dynamicBox`
+
+`dynamicBox` is ~150 lines of `dynamicbox.h`. Under the operator set it is
+roughly 15. The mapping, stage by stage:
+
+| Current implementation | Becomes |
+| --- | --- |
+| Apply `BuildParams` to each child widget (`dynamicbox.h:28-40`) | `map` |
+| Fan in each builder's size hint (`dynamicbox.h:42-53`) | `extract(&Builder::getSizeHint)` |
+| Container hint from children's hints (`dynamicbox.h:55-59`) | `values().map(accumulateSizeHints<dir>)` |
+| Obb computation (`dynamicbox.h:63-65`) | `mapValues(&mapObbs<dir>, size)` |
+| Re-key obbs positionally back onto builder ids (`dynamicbox.h:66-82`) | **deleted** — identity is carried by `KeyedArraySignal` |
+| `withPrevious` element cache and per-child id lookup (`dynamicbox.h:85-141`) | `scatter` |
+| Fan in each element's instance (`dynamicbox.h:143-156`) | `extract(&Element::getInstance).values()` |
+
+Two of those rows are the interesting ones.
+
+**The re-keying block disappears entirely.** `dynamicbox.h:66-82` exists only to
+re-attach ids that were dropped when the hints were fanned in: it asserts the two
+vectors are the same length and zips them by position. That is the alignment
+invariant being re-established by hand after having been thrown away. `extract`
+never throws it away, so there is nothing to re-establish.
+
+**The element cache becomes an operator.** `dynamicbox.h:85-141` is a
+`withPrevious` fold that, for each incoming builder id, linearly scans the
+previous result for a match, reuses it if found, and otherwise builds a new
+element whose obb comes from an O(n) search of the shared obb list
+(`dynamicbox.h:108-122`). That is apply-once-per-identity plus identity-matched
+fan-out, hand-rolled — `scatter`.
+
+### The missing `handleGravity()` is fixed structurally
+
+`layout()` pipes every child through `modifier::handleGravity()` before building
+it (`layout.cpp:84-87`). `dynamicBox` does not, so a gravity set on a child of an
+`hbox`/`vbox` with a dynamic child list is silently ignored.
+
+Unifying fixes this by construction rather than by remembering to add a line.
+`handleGravity` is a three-pass negotiation — it asks the child for
+`getWidth()`, clamps against the outer width, asks `getHeightForWidth()` with the
+result, clamps again, then asks `getWidthForHeight()` and clamps a third time
+(`handlegravity.h:16-34`) — and then offsets by the child's gravity
+(`handlegravity.h:37-46`). Its inputs are the child's own size hint, the outer
+size assigned to it, and the child's gravity.
+
+The `scatter` delegate has all three: the child's value (hence its builder, hence
+`getSizeHint()` and `getGravity()`), and the identity-matched obb, which *is* the
+assigned outer size. So `handleGravity` composes into the delegate with nothing
+threaded around.
+
+## Layout audit
+
+Every collection layout in `bqui` was checked against the operator set. All of
+them are expressible. Recording the audit is worth more than recording the
+conclusion, because several of them *look* like counterexamples.
+
+The reason none of them is: the apparent difficulties all live **inside the
+`vector<A> -> vector<B>` function body**, and `mapValues` takes an arbitrary
+function. No primitive beyond it is needed.
+
+| Apparent difficulty | Where it actually lives |
+| --- | --- |
+| The prefix scan with a running accumulator in `mapObbs`, with the y-axis running backwards (`box.h:213-230`) | A local `float acc` in a loop. No `scan` primitive needed. |
+| `getSizes` computes a container-level aggregate — the three-element `multiplier` — and then redistributes it per child (`box.h:24-52`) | One function that already receives every child's hint at once. That is exactly the `mapValues` shape. |
+| A second fan-in round *inside* the hint computation: `AccumulateSizeHint::getHeightForWidth` re-queries every child at its resolved width, zipping via a mutable counter (`box.h:70-90`) | Inside the `SizeHint` value, not in the signal graph. |
+| The lazy, re-entrant `SizeHint` (`AccumulateSizeHint`, `box.h:54-107`; `StackSizeHint`, `stacksizehint.h:8-15`) that the parent may re-query at arbitrary widths | The laziness is **inside the value**. The child hints are captured synchronously when the aggregate is built; re-querying never touches the signal graph. |
+| `stack` needs zero per-child data downward but all of it upward (`stack.cpp:12-25`) | `values()` for the upward direction; a `mapValues` that returns the same obb for every child for the downward one. |
+
+Two layouts actively shaped the design:
+
+- **`uniformGrid` carries per-child non-hint metadata.** Each child has a grid
+  `Cell` (`uniformgrid.cpp:21-22`), and the cells live in a **parallel vector**
+  held in correspondence with the widgets by an invariant that only
+  `UniformGrid::cell()` maintains. The obb map then captures `cells` and iterates
+  it positionally (`uniformgrid.cpp:55-80`) — a second unchecked alignment
+  contract, distinct from the hint one. An `ArraySignal` element that carries its
+  own metadata dissolves both the parallel vector and the invariant.
+- **`scrollView` composes children with synthetic extras.** Its final layout is
+  `vbox({ hbox({view, vScrollBar}), hbox({hScrollBar, hfiller | setSizeHint}) })`
+  (`scrollview.cpp:136-141`) — the filler has no corresponding input child at
+  all. This is what makes **`concat` load-bearing rather than theoretical**: a
+  container must be able to place framework-supplied children alongside the
+  caller's without them sharing an identity space.
+
+**Not collection layouts, and out of scope:** `bin`, `scrollView` itself,
+`background`/`foreground` (`modifier/background.h:13-18`) and `scrollBar`. They
+take a fixed number of children with fixed roles and stay exactly as they are.
+
 ## What this supersedes
 
 The existing pipeline, and what `forEach` does instead:

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -529,8 +529,6 @@ into.
 
 ### `map` with extra signals
 
-### `map` with extra signals
-
 `arraySignal.map(f, sig1, sig2)` — where `f` receives the item's value plus the
 current values of those signals — should be supported. It is **`combine` sugar
 per element**: the node is still created once per identity, and only values
@@ -617,9 +615,11 @@ section is that argument, and it is the most important part of this document.
 - **A changed key means a new item.** The old key vanishes, so its id is evicted
   and its item removed; the new key is new, so it gets a new id and the delegate
   runs. This is a consequence of the rule above, not a separate one.
-- **Eviction is strict.** When an item disappears its key→id mapping is dropped
-  immediately; the resulting `ArraySignal` is a strict 1:1 mapping of the source
-  array, with no lingering entries for items that might come back.
+- **Eviction is strict, and evicted items are destroyed.** When an item
+  disappears its key→id mapping is dropped immediately and whatever the delegate
+  built for it is destroyed — no retention, no pool, no resurrection. The
+  resulting `ArraySignal` is a strict 1:1 mapping of the source array. A key that
+  goes away and comes back is a new item, exactly as a changed key is.
 - **Duplicate keys**: assert in debug. In release, tolerate gracefully — the
   result may be suboptimal (an item may lose its identity and be rebuilt) but it
   must not crash, corrupt the mapping, or drop items. The concrete release rule
@@ -682,6 +682,148 @@ a comparison. The project targets **C++17**, so the design must not depend on
 that, and the silent-no-op trap is real for us today. Noted only so that the
 ergonomics are understood to improve on their own if the standard level ever
 moves.
+
+## Contracts and traps
+
+Each of these is a rule an implementor or a caller can get wrong without any
+diagnostic firing. They are separated out so they can be lifted into
+`docs/conventions.md` verbatim when this lands.
+
+### `mapValues`: same size, positionally aligned, against the *current* input
+
+**Contract.** The vector `g` returns must have the same size as the vector it was
+given, and its element *i* must correspond to input element *i*. The input is the
+current membership, not the membership at the time the node was built.
+
+**Enforcement** is the size check — exactly the strength of today's
+`assert(obbs.size() == builders.size())` (`dynamicbox.h:70`). This design does
+**not** claim to make the contract statically checkable, and it would be
+dishonest to imply it does.
+
+What improves is *where* the assumption lives. Today it spans a re-keying step,
+a `withPrevious` element cache and a per-child id lookup, so a violation can be
+introduced in any of three places and only shows up at the assert. Under
+`mapValues` the assumption is confined to **one pure function that holds both
+vectors at once** — it can be read, unit-tested, and reasoned about without a
+signal graph.
+
+Positional alignment is exactly right for a layout, because a layout function is
+order-preserving and same-size *by construction*: one obb per child, in child
+order. When a computation genuinely reorders or drops elements, that is what
+`mapKeyed` is for — reach for it rather than trying to smuggle a permutation
+through `mapValues`.
+
+### Folding over a `KeyedArraySignal` is position-keyed, and positions are not stable
+
+This is the trap most likely to be walked into, because the code that walks into
+it looks like an obvious optimisation.
+
+`withPrevious` hands the fold a `prev` vector alongside the current one. Those
+two vectors are aligned **by position**, and position is not stable across a
+membership change: after an insert at the front, or a reorder, current slot *i*
+and previous slot *i* are different elements.
+
+So the natural optimisation — "reuse the previous obb for any element whose hint
+did not change" — compares element X's *current* hint against element Y's
+*previous* one. The sizes match. The assert passes. The layout is quietly wrong
+for a frame, and then usually right again, which is the worst possible failure
+signature.
+
+**Frame this as a correspondence bug, not a timing one.** Nothing arrived late;
+every value in both vectors is current-frame. What is wrong is *which element
+each slot refers to*. Waiting a frame, adding a `check()`, or forcing an extra
+update pass fixes nothing.
+
+The two correct forms:
+
+- **Fold per element, after `scatter`** — each element's fold sees only its own
+  history, so there is no correspondence to get wrong.
+- **Use `mapKeyed`** — the key travels with the value, so the fold can match on
+  it explicitly.
+
+### There is no frame-lag hazard
+
+Worth stating positively, because it is the first objection anyone raises about
+splitting a layout into fan-in, compute and fan-out nodes.
+
+`extract → mapValues → scatter` is **acyclic**. Every node in it settles within
+one update pass, so the arity the `scatter` sees is always the arity the
+`extract` produced. There is no frame in which the aggregate is stale with
+respect to membership.
+
+Two clarifications that prevent this from being over-claimed:
+
+- **Cycles do cause cross-frame variation, and they are pre-existing and
+  orthogonal.** `scrollView` seeds `viewSize` as an input with a placeholder
+  (`scrollview.cpp:33`) and feeds the measured size back through
+  `modifier::trackSize(viewSize.handle)` (`scrollview.cpp:83`). That loop settles
+  over frames today and will continue to. It is not introduced by this design and
+  is not fixed by it.
+- **A stale ambient input yields wrong *values*, never wrong *arity*.** Arity
+  comes from membership and propagates synchronously through the whole chain; the
+  `extras...` of `mapValues` only feed the maths. So the failure mode of a cycle
+  is a frame of wrong sizes, not a mismatched fan-out.
+
+**Do not claim animation causes lag.** `avg::Animated<T>` is an ordinary value as
+far as the signal system is concerned — it propagates like any other value, and
+the interpolation happens in the render tree at draw time. It introduces no
+signal-graph delay.
+
+### Once-per-identity initialisation is load-bearing
+
+`extract`'s "`f` is applied once per identity" is not an optimisation. It is what
+stops a sibling insert from resetting surviving children.
+
+The mechanism to be careful of is `bq::signal::Join`. Its `update` re-evaluates
+the outer signal and, **when the outer changed, discards and re-initialises the
+inner signal and its data**:
+
+```cpp
+// src/bq/include/bq/signal/join.h:85-97
+if (r.didChange)
+{
+    data.innerSignal = makeInnerSignal(sig_.evaluate(context, data.outerData));
+    data.innerData = data.innerSignal.initialize(context, frame);
+}
+```
+
+A naive fan-in — `builders.map(...combine...).join()`, which is what `dynamicBox`
+writes at `dynamicbox.h:42-53` — puts membership in the outer signal. Any change
+to membership therefore re-initialises *every* child's inner signal, resetting
+whatever `DataType` state hangs off it. `extract` must not be built that way: the
+per-identity signal has to be created once, when the identity appears, and
+survive membership changes to its siblings.
+
+### First value wins, and it cannot be asserted
+
+With `ArraySignal<Widget>`, the delegate has already run by the time a second
+`Widget` value arrives at a fixed key. There is nothing to do with it: applying
+it means rebuilding, and rebuilding loses the state the whole design exists to
+protect. **The rule is that the first value wins; the key is the unit of
+change.**
+
+Honesty about enforcement: **this cannot be asserted.**
+
+- `Widget` has no `operator==`, so "did the value actually change?" is not a
+  question that can be asked.
+- Asserting merely on "the signal emitted again" would false-positive on any
+  upstream that emits without a `check()` — which is most of them, since
+  `tryCheck()` is a silent no-op for non-comparable types.
+
+This is not new behaviour. It is today's silent `continue` in `dynamicBox`'s
+element cache (`dynamicbox.h:105-106`) promoted from an undocumented accident to
+a **stated contract**. The improvement is that a caller who needs a widget to
+change now has a correct expression of it — change the key — instead of a
+behaviour that appears to work and does not.
+
+### `tryCheck()` where it helps, silently nothing where it does not
+
+`Check` suppresses the *change notification*, not the value: its `update()`
+downgrades `didChange` to `false` when the newly evaluated value compares equal
+to the cached one (`src/bq/include/bq/signal/check.h:44-59`). Use `.tryCheck()`
+freely on per-element signals — it takes advantage of `operator==` where the type
+has one and passes silently through where it does not. See *Skipping repeats* above
+for the details and for the usability trap in that silence.
 
 ## What this supersedes
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,13 +1,20 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: proposal — not implemented.** Nothing described here exists in the
-> tree yet. This document is the agreed design, recorded so the implementation
-> has a target and so the reasoning survives. Once it is built, the stable parts
-> move to their normal homes — the model and its traps to
-> `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
-> contract to Doxygen in the new public headers — and this file goes away.
+> **Status: steps 1 and 2 implemented in `bq`; steps 3 and 4 not started.**
+> `ArraySignal<T>`, `forEach`, `map`, `concat`, `KeyedArraySignal<A>`,
+> `extract`, `mapValues`, `mapKeyed`, `values` and `scatter` live in
+> `src/bq/include/bq/signal/arraysignal.h` and `arraysignallayout.h`, covered by
+> `src/bq/test/arraysignaltest.cpp`. Nothing in `bqui` has changed: `layout()`
+> and `dynamicBox` are untouched. This document remains the design record until
+> the `bqui` work lands, at which point the stable parts move to their normal
+> homes — the model and its traps to `docs/conventions.md`, the settled *why* to
+> `docs/decisions.md`, and the API contract to the Doxygen already in the new
+> headers — and this file goes away.
+>
+> Where building it contradicted the design, this document has been corrected
+> rather than the implementation bent to fit; see *What building it changed*.
 
-*Last verified against `93357c3` (2026-07-19).*
+*Last verified against `2c6969c` (2026-07-20).*
 
 ## The problem
 
@@ -46,6 +53,97 @@ Two payoffs beyond the code sharing:
   `uniformGrid` and `dynamicBox` become one implementation rather than two that
   drift apart. That finding is the headline of this document; see *One layout
   engine*.
+
+## What building it changed
+
+The `bq` half was built against this document. Most of it survived contact
+unaltered. These points did not, and the document has been corrected here and
+in the sections they belong to.
+
+**`extract`'s function takes the element's signal, not its value.** The design
+said `f : T → AnySignal<A>`. That cannot be applied once per identity: reaching
+a `T` means evaluating the element's signal, and a signal can only be evaluated
+inside a `SignalContext`, which an operator does not have when it builds the
+graph. Written as `value.map(f).join()` it becomes exactly the `Join` hazard the
+design exists to avoid. So `f` is `AnySignal<T> → AnySignal<A>`, matching
+`forEach`'s delegate and the shared apply-once-per-identity primitive. A plain
+`T → A` is also accepted and is mapped over the element's value, since that form
+has no state to preserve and no hazard.
+
+**`mapValues` calls `g(extras..., values)`.** The design described `g` as
+`vector<A> → vector<B>` "with extras injected alongside", while also claiming it
+matches `ObbMap`'s `(Vector2f, vector<SizeHint>) → vector<Obb>` *down to the
+argument order*. Those disagree. The argument-order claim is the load-bearing
+one — it is what lets an existing `ObbMap` be passed straight in — so the extras
+come first.
+
+**Identity is namespaced by allocator, not by rewriting ids.** An `ArrayId` is
+an id space plus an index, and the space is a distinct object per array. `concat`
+therefore needs no re-namespacing pass: its children's ids are already distinct
+because their spaces are. The cost is that an id embeds a pointer, so **ids are
+not reproducible between runs** — which retires this document's argument that a
+scoped allocator gives "dense, deterministic ids so that a test can assert on the
+id set". A test can assert that two ids differ, or that an id survived a change;
+it cannot assert on the id set itself. That is no loss, because ids never surface.
+
+**The duplicate-key release rule is settled, and is better than "suboptimal".**
+Each occurrence of a repeated key is disambiguated by its occurrence index, so
+the entry is `(key, n)`. The first occurrence keeps `(key, 0)` and every later
+one keeps its own stable entry. Nothing is dropped, nothing churns, and the
+1:1 mapping holds. Debug still asserts, because duplicate keys almost always
+mean the caller keyed on the wrong thing. The candidate rule in *Open questions*
+— fresh ids per export for the duplicates — is superseded; it was strictly worse.
+
+**`share()` is the mechanism that defeats the `Join` hazard.** The design said
+`extract` "must not be built" on `map(...).join()` without saying what to build
+instead. The answer is that the per-identity signal is `.share()`d before it is
+cached. `SharedControl` keys its per-context state by a `btl::UniqueId` in the
+`DataContext` (`sharedcontrol.h:147-155`), so when `Join::update` re-initialises
+the inner signal it *finds the existing state* rather than building fresh. The
+fan-in above it is still `combine(...).join()`; what changed is that
+re-initialising it is now harmless. Dropping that one `.share()` turns the
+sibling-state test red and nothing else.
+
+**Element equality is identity-only.** An element sequence compares equal when
+the ids match, whatever the values do. That makes the sequence
+equality-comparable, so `tryCheck()` on it means precisely "membership is
+unchanged" and suppresses the change notification — which is what keeps a value
+change from re-initialising the fan-in at all.
+
+**The once-per-identity cache lives with the operator, not in the context.**
+Everything it holds is an immutable description — a signal, or the value a
+delegate built — so it is context-independent, and a mutex-guarded control block
+owned by the operator is enough. The known limitation is that realising the *same*
+`ArraySignal` in two `SignalContext`s whose membership diverges makes the two
+evict each other's entries. That is churn, not corruption, and no consumer does
+it today.
+
+**`scatter` drops elements whose identity is not in the aggregate.** This
+follows from `mapKeyed` being allowed to drop keys. The alternative — handing
+the delegate a slice that does not exist — has no well-defined value.
+
+**Two pre-existing `bq` bugs had to be fixed to build this at all.** Both are in
+`join`, and both meant `join()` silently or loudly failed on a type-erased
+signal:
+
+- `Signal::join()` instantiated `Join<TStorage>`, and `TStorage` is `void` for an
+  `AnySignal`. It now uses `StorageType`, which is the same type for every
+  concrete signal and the erased storage for an `AnySignal`.
+- `detail::toSignal` was an overload pair: a forwarding `toSignal(T&&)` that
+  wraps a value in a `constant`, and a `toSignal(Signal<T, Ts...>)` that passes a
+  signal through. For an `AnySignal` the forwarding overload wins — it is an exact
+  match, while the other needs a derived-to-base conversion — so `join()` on a
+  signal whose value was an `AnySignal` wrapped it in a `constant` and did not
+  join. It is now one function with an `if constexpr`.
+
+**Not implemented, and why.** `join`/`flatMap` and `filter` are listed in the
+operator set but nothing here needs them, and `filter`'s eviction semantics are
+an unresolved open question. The `AnySignal<ArraySignal<T>>` reactive-subtree
+constructor is not implemented either: *Open questions* records that the design
+does not yet agree with itself about whether it is a third identity-minting site,
+and it should be reconciled before it is built. `map` with extra signals waits on
+`Signal::map` gaining that form first, as the design requires. The defaulted
+delegate is not offered, so its return type never arises.
 
 ## Naming
 
@@ -204,12 +302,14 @@ Consequences:
   holds it (a `DataType` slot in the `SignalContext`, or a control block with its
   own id as `SharedControl` does) is an implementation choice; the requirement is
   only that its lifetime match the `ArraySignal`'s.
-- Not a process-wide global, for the same two reasons as before: no global
-  mutable state to make thread-safe, and deterministic ids so that a test can
-  assert on the id set rather than on whatever the global counter happened to be
-  at. (A global atomic in the style of `bq::signal::makeUniqueId`,
-  `src/bq/src/signal/datacontext.cpp:7-11`, remains the fallback if the scoped
-  form proves unworkable.)
+- Not a process-wide global: there is no global mutable state to make
+  thread-safe, and each array's counter starts from the same place, so an
+  array's ids do not depend on what else the process built first.
+- **As built, an id is an id space plus an index**, and the space is the unit of
+  distinctness — `concat` composes arrays without rewriting any id. Because the
+  space is identified by its address, ids are *not* reproducible between runs.
+  An earlier draft argued the opposite as a benefit; see *What building it
+  changed*.
 
 **This rests on an unsettled question.** Two consumers hand `size_t` ids to
 their caller today: PR #99's `App` window list
@@ -348,15 +448,18 @@ implementation needs.
 
 ### Advanced: the fan-in / fan-out pair
 
-- **`extract(f : T → AnySignal<A>) → KeyedArraySignal<A>`** — order-preserving
-  fan-in. `f` is applied **once per identity**, so the per-element signal it
-  returns is initialised once and thereafter merely updates. For a layout, `f` is
-  "give me this child's size hint".
-- **`mapValues(g : vector<A> → vector<B>, extras...) → KeyedArraySignal<B>`** —
-  the maths. `g` sees every child's value at once and returns one value per
-  child; identity rides along untouched. `extras...` are ambient signals injected
-  alongside the vector — for a layout, the container's own size. This is where a
-  layout's obb computation goes.
+- **`extract(f : AnySignal<T> → AnySignal<A>) → KeyedArraySignal<A>`** —
+  order-preserving fan-in. `f` is applied **once per identity**, so the
+  per-element signal it returns is initialised once and thereafter merely
+  updates. For a layout, `f` is "give me this child's size hint". A plain
+  `T → A` is accepted too and is mapped over the element's value; a
+  `T → AnySignal<A>` is not, for the reason in *What building it changed*.
+- **`mapValues(g : (extras..., vector<A>) → vector<B>, extras...) →
+  KeyedArraySignal<B>`** — the maths. `g` sees every child's value at once and
+  returns one value per child; identity rides along untouched. `extras...` are
+  ambient signals injected alongside the vector — for a layout, the container's
+  own size — and they are passed to `g` first, so an existing `ObbMap` is a `g`
+  unaltered. This is where a layout's obb computation goes.
 - **`mapKeyed(vector<pair<Key, A>> → vector<pair<Key, B>>)`** — the same, for
   computations that **reorder or drop**. `Key` is opaque: comparable and hashable,
   and otherwise meaningless. Nothing may be inferred from its value, its ordering
@@ -634,11 +737,11 @@ section is that argument, and it is the most important part of this document.
   re-invoked because a value changed — a value change arrives through the
   `AnySignal<T>` the delegate already holds. This is the whole point.
 - **The delegate is the last parameter** so it can be defaulted when only keying
-  is wanted. *Wrinkle to settle:* with a signal-taking delegate, the identity
-  default gives `U = AnySignal<T>`, so the defaulted call yields
-  `ArraySignal<AnySignal<T>>` rather than `ArraySignal<T>`. That is defensible but not
-  obviously what a caller expects; decide at implementation time whether the
-  default unwraps it, or whether the defaulted overload is simply not offered.
+  is wanted. No default is offered: with a signal-taking delegate the identity
+  default gives `U = AnySignal<T>`, so the defaulted call would yield
+  `ArraySignal<AnySignal<T>>` rather than `ArraySignal<T>` — defensible, but not
+  what a caller expects. Requiring the delegate costs a caller who only wants
+  keying one identity lambda and keeps the result type obvious.
 - **`keyFn` runs for every item whenever the array signal changes.** The
   algorithm computes the new key set, drops the ids whose keys are absent, and
   preserves the id for every key that is still present.
@@ -650,10 +753,12 @@ section is that argument, and it is the most important part of this document.
   built for it is destroyed — no retention, no pool, no resurrection. The
   resulting `ArraySignal` is a strict 1:1 mapping of the source array. A key that
   goes away and comes back is a new item, exactly as a changed key is.
-- **Duplicate keys**: assert in debug. In release, tolerate gracefully — the
-  result may be suboptimal (an item may lose its identity and be rebuilt) but it
-  must not crash, corrupt the mapping, or drop items. The concrete release rule
-  is still open (see *Open questions*).
+- **Duplicate keys**: assert in debug. In release, each occurrence of a repeated
+  key is disambiguated by its occurrence index, so the internal entry is
+  `(key, n)`. Every occurrence keeps a stable identity of its own: nothing is
+  dropped, nothing churns, and the 1:1 mapping holds. The cost is only that two
+  items the caller considers the same are two items here — which is what keying
+  them the same was already claiming.
 - **The delegate is run by the generic apply-once-per-id operation** described
   above, not by machinery of its own; `forEach` supplies the key→id mapping and
   delegates the caching to it.
@@ -820,9 +925,24 @@ if (r.didChange)
 A naive fan-in — `builders.map(...combine...).join()`, which is what `dynamicBox`
 writes at `dynamicbox.h:42-53` — puts membership in the outer signal. Any change
 to membership therefore re-initialises *every* child's inner signal, resetting
-whatever `DataType` state hangs off it. `extract` must not be built that way: the
-per-identity signal has to be created once, when the identity appears, and
-survive membership changes to its siblings.
+whatever `DataType` state hangs off it.
+
+**How `extract` survives this.** The fan-in is still `combine(...).join()`; what
+makes it safe is that the per-identity signal is created once, when the identity
+appears, and is `.share()`d before it is cached. `SharedControl` keys its
+per-context state by a `btl::UniqueId` in the `DataContext`
+(`sharedcontrol.h:147-155`), so a re-initialisation *finds* that state instead of
+building fresh. The positional `DataType` tree — the thing `Join` actually
+discards — is below the shared node and is never re-entered.
+
+Two things follow, and both are worth stating because they are easy to undo by
+accident:
+
+- **Every per-identity signal must be shared.** An unshared one has only
+  positional `DataType` state, which is exactly what a sibling insert resets.
+- **The element sequence must not report a change when only a value changed**,
+  or the re-initialisation happens every frame. That is what identity-only
+  element equality plus `tryCheck()` buys.
 
 ### First value wins, and it cannot be asserted
 
@@ -1295,21 +1415,13 @@ consumer-side reconcile. See *Open questions*.
 
 Points the design does not yet settle. Flagged rather than guessed.
 
-- **The defaulted delegate's return type.** As noted above, defaulting a
-  `(AnySignal<T>) -> U` delegate to identity yields `ArraySignal<AnySignal<T>>`,
-  not `ArraySignal<T>`. Decide whether to unwrap it, to require the delegate, or to
-  offer the default only where `ArraySignal<AnySignal<T>>` is what the consumer
-  wants.
-- **`{x}` — one-element list or single item?** They export the same list, so the
-  choice is about which constructor wins and what the error messages say. Pick
-  one and write the test.
-- **Duplicate-key tolerance is under-specified.** "Suboptimal but not
-  catastrophic" needs a concrete rule. *Candidate:* the first occurrence keeps
-  the id; subsequent duplicates get fresh ids on each export, and therefore
-  rebuild. That satisfies "must not fail catastrophically" and keeps the 1:1
-  mapping, at the cost of churn for the duplicates. Not adopted — state the rule
-  before implementing, so the release behaviour is testable rather than
-  accidental.
+- **The defaulted delegate's return type.** *Settled by omission:* the delegate
+  is required, so the question does not arise. Revisit only if a caller wants
+  keying without building.
+- **`{x}` — one-element list or single item?** *Settled:* the
+  `std::initializer_list<ArraySignal<T>>` constructor wins in braced
+  initialisation, so `{x}` is a one-element list. It exports the same sequence
+  the single item would, so nothing observable turns on it.
 - **Whether `Collection<T>` and `DataSource<T>` are removed or kept.** `forEach`
   supersedes the *plumbing*; `Collection` remains a reasonable mutable source.
   Note that `Collection`'s ids are pointer values, so a `Collection` source must
@@ -1358,13 +1470,13 @@ Points the design does not yet settle. Flagged rather than guessed.
 Four steps, in this order. The first two are the `bq` core and can land before
 anything in `bqui` changes.
 
-1. **`ArraySignal<T>` core** — the type, its constructors, the tree, `concat`,
-   `join`, `map`, the scoped id allocator, and the generic apply-once-per-identity
-   operation.
-2. **`forEach`, `KeyedArraySignal`, and the advanced layer** — the keyed operator
-   plus `extract`, `mapValues`, `mapKeyed`, `values` and `scatter` in the
-   layout-implementor header. `forEach` and `extract` must share the
-   apply-once-per-identity primitive from step 1.
+1. **`ArraySignal<T>` core** — ✅ done, except `join`/`flatMap` and the
+   `AnySignal<ArraySignal<T>>` constructor. The type, its constructors, the
+   tree, `concat`, `map`, the scoped id allocator, and the generic
+   apply-once-per-identity operation.
+2. **`forEach`, `KeyedArraySignal`, and the advanced layer** — ✅ done.
+   `forEach` and `extract` share the apply-once-per-identity primitive from
+   step 1.
 3. **Unify `layout()`** — reimplement `layout()` over `extract`/`mapValues`/
    `scatter`, keeping its existing `SizeHintMap`/`ObbMap` signature so `box`,
    `stack` and `uniformGrid` are unaffected. Delete the dead heterogeneous tuple
@@ -1402,11 +1514,22 @@ That last result is the argument for the probe harness over testing
 `ObbMap`/`SizeHintMap` in isolation: the pure-maths tests alone would have missed
 it.
 
-Still uncovered, and worth adding before step 4 in particular: `stack`,
-`uniformGrid`, `dynamicBox`, nesting, zero- and one-child cases, degenerate
-hints, non-default gravity, and changing hints. `stack` and `uniformGrid` need
-nothing new from the harness; a dynamic child list needs the probe list built
-from a signal, and changing hints need `context.update()` between evaluations.
+**PR #103 (branch `layout-tests-breadth`) extends it to 24 tests**, adding
+`stack`, `uniformGrid`, `dynamicBox` (initial, add, remove, and reorder with
+stable keys), nesting, and degenerate hints.
+
+Two of those tests pin behaviour that is **current but not correct**, because the
+rewrite will change it:
+
+- `uniformGrid`'s size hint ignores `cell.w` and `cell.h`.
+- `dynamicBox` never applies `handleGravity()`.
+
+Steps 3 and 4 will therefore turn those two red **by design**. That is the
+rewrite working, not a regression — update the tests to the new behaviour rather
+than restoring the old.
+
+Still uncovered: zero- and one-child cases, non-default gravity, and changing
+hints. Changing hints need `context.update()` between evaluations.
 
 ### Hazards in `getSizes` for the rewrite
 
@@ -1415,29 +1538,27 @@ engine will reimplement this path. Two properties of it are load-bearing by
 accident. Both were surfaced by PR #102 and re-verified against the current
 source.
 
-**It divides by zero on equal consecutive hint components, and only survives
-because of `std::min`'s argument order.** The multiplier loop computes
+**It divides by zero on equal consecutive hint components, but the result is not
+observable for monotonic hints.** The multiplier loop computes
 `(size - prev) / (combined[i] - prev)` (`box.h:33-38`). The denominator is zero
 whenever two consecutive aggregate components are equal — which is the *common*
 case, not a corner one: any fixed-size child has a hint like `{{30, 30, 30}}`, so
-`combined[1] - combined[0]` is zero. The quotient is `±inf` (or `NaN` when the
-box is exactly the natural size, since the numerator is zero too), and it lands
-on the right answer only because:
+`combined[1] - combined[0]` is zero. The quotient is `±inf`, or `NaN` when the
+box is exactly the natural size and the numerator is zero too.
 
-```cpp
-multiplier[i] = std::max(0.0f, std::min(1.0f, m));
-```
+Nothing downstream sees it. A zero *combined* interval is a sum of non-negative
+per-child intervals, so when the denominator is zero every child's interval at
+that index is zero as well — the multiplier is scaling zero, and its value cannot
+matter.
 
-`std::min(a, b)` returns `(b < a) ? b : a`. With `a = 1.0f` and `b = NaN`, the
-comparison is false, so it returns `1.0f` — the correct multiplier. Written the
-other way round, `std::min(m, 1.0f)` returns `NaN`, and `std::max(0.0f, NaN)`
-then returns `0.0f`: **every fixed-size child collapses to zero width.** The
-same reversal turns the `+inf` case into `0.0f` as well.
-
-So the clamp is not defensive code that happens to also handle the degenerate
-interval — it is the *only* thing handling it, and it does so through an
-unwritten dependency on operand order. A rewrite must handle the zero-width
-interval explicitly instead.
+**The `std::min` argument order is not load-bearing.** An earlier draft of this
+document reasoned from the arithmetic that `std::max(0.0f, std::min(1.0f, m))`
+survives `NaN` only because `std::min` returns its first argument on an unordered
+comparison, and that reversing the operands would collapse every fixed-size child
+to zero width. PR #103 applied that exact mutation, rebuilt, and all 24 layout
+tests stayed green. The claim was wrong and is withdrawn; a rewrite is free to
+write the clamp either way, though it should still avoid the division rather than
+rely on the arithmetic being harmless.
 
 **The output is not clamped against `size`.** The only bound on the total is that
 each multiplier is clamped to `[0, 1]`, which holds the sum to the aggregate
@@ -1451,6 +1572,7 @@ consequences:
 - For a **non-monotonic** hint the bound fails outright and children overflow the
   box. A hint of `{{100, 0, 100}}` — minimum above preferred — gives
   `multiplier = {1, 0, 1}` and a child size of `200` in a 200-wide box; two such
-  children total `400`. Nothing rejects such a hint today.
+  children total `400`. Nothing rejects such a hint today. PR #103 pins this as
+  current behaviour in `mapObbsOverflowsOnNonMonotonicHints`.
 
-Neither is fixed in PR #102, which deliberately changes no behaviour.
+Neither is fixed in PR #102 or #103, which deliberately change no behaviour.

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -102,7 +102,7 @@ reorders. This is the *only* place identity is needed, because "which item is
 this?" no longer has a positional answer. `forEach` is what supplies it.
 
 `ArraySignal<T>` expresses both. Its literal forms (a value, a signal, a nested
-braced list) are value-dynamic. Structural dynamism enters a `ArraySignal` only
+braced list) are value-dynamic. Structural dynamism enters an `ArraySignal` only
 through `forEach` — or through the reactive-subtree constructor, which is
 structural dynamism at the coarsest possible granularity (the whole subtree is
 replaced).
@@ -115,7 +115,7 @@ replaced).
 
 A `ArraySignal<T>` is an **immutable value**. It has no `push_back`, no `erase`, no
 mutation of any kind. Dynamism flows *in* from upstream: a `Collection<T>`
-converted into a `ArraySignal<T>` stays live because the conversion produced a
+converted into an `ArraySignal<T>` stays live because the conversion produced a
 signal that the collection drives — mutating the collection changes the
 `ArraySignal`'s signal, not the `ArraySignal` object.
 
@@ -565,7 +565,7 @@ the item's *construction* does. The two cover different needs.
 
 **Constraint:** `ArraySignal::map` must **mirror `Signal::map` exactly** — same
 argument order, same arity handling, same name. The symmetry between the two
-domains is the payoff of this whole framing; a `ArraySignal::map` that takes extra
+domains is the payoff of this whole framing; an `ArraySignal::map` that takes extra
 signals while `Signal::map` does not would break it at the first thing anyone
 tries.
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,4 +1,4 @@
-# Design: `DynArray<T>` and `forEach`
+# Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
 > **Status: proposal — not implemented.** Nothing described here exists in the
 > tree yet. This document is the agreed design, recorded so the implementation
@@ -7,7 +7,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new public headers — and this file goes away.
 
-*Written against `221cd3f` (2026-07-19).*
+*Last verified against `93357c3` (2026-07-19).*
 
 ## The problem
 
@@ -20,20 +20,72 @@ existing answer — `Collection` + `dataSourceFromCollection` + `dataBind` +
 container, it is not composable, and it lives in `bqui` where only widgets can
 use it.
 
-This design replaces that pipeline with two pieces:
+This design replaces that pipeline with three pieces:
 
-- **`DynArray<T>`** — a value in `bq` describing a list whose contents and
+- **`ArraySignal<T>`** — a value in `bq` describing a list whose contents and
   structure may both be dynamic. It is the *input* type a list-consuming API
   accepts.
-- **`forEach`** — the keyed operator that turns a changing collection into a
-  `DynArray<U>` with stable per-item identity, invoking a delegate once per new
+- **`forEach`** — the keyed operator that turns a changing collection into an
+  `ArraySignal<U>` with stable per-item identity, invoking a delegate once per new
   item rather than once per change.
+- **`KeyedArraySignal<A>`** plus the free functions `extract` and `scatter` — the
+  fan-in / fan-out pair that lets a *container* compute over all of its children
+  at once and hand each child its own share of the result, without ever exposing
+  an identity.
 
-`DynArray` is best understood as **its own domain alongside `Signal`**, entered
-by `forEach` and left by `toSignal`; that framing is developed below and is what
-tells us which operations must exist and what each does to identity. It also
-fixes a real bug: `dynamicBox` today supports dynamic *membership* only, and
-silently ignores a changed widget for an existing item.
+`ArraySignal` is best understood as **its own domain alongside `Signal`**, entered
+by `forEach` and left by `values`; that framing is developed below and is what
+tells us which operations must exist and what each does to identity.
+
+Two payoffs beyond the code sharing:
+
+- It **fixes a real bug**: `dynamicBox` today supports dynamic *membership* only,
+  and silently ignores a changed widget for an existing item.
+- It **unifies the static and dynamic layout engines**. `layout()`'s own type
+  aliases turn out to be this API already, so `hbox`, `vbox`, `stack`,
+  `uniformGrid` and `dynamicBox` become one implementation rather than two that
+  drift apart. That finding is the headline of this document; see *One layout
+  engine*.
+
+## Naming
+
+The type was called `DynArray<T>` in earlier drafts. It is now **`ArraySignal<T>`**,
+and the keyed aggregate is **`KeyedArraySignal<A>`**.
+
+`DynArray` reads like a mutable container — `std::dynarray` was a proposed
+`std::vector` sibling — and that mis-sells the type completely: it is immutable,
+it carries no storage the caller can poke at, and it belongs in the same
+category as `Signal`. Naming it `ArraySignal` puts it there.
+
+### There is deliberately no `AnyArraySignal`
+
+In `bq::signal` the `Any` prefix means **type-erased**: `Signal<TStorage, Ts...>`
+carries its storage type in the type (`signal.h:160`) and `AnySignal<Ts...>`
+erases it (`signal.h:372`, a class deriving from `Signal<void, Ts...>`). The
+storage-typed form exists so a chain of combinators stays free of virtual
+dispatch.
+
+`ArraySignal` is **type-erased by construction** and never wants a storage-typed
+twin. An array is heap-backed anyway: the per-element indirection that
+storage-typing avoids for `Signal` is already paid here, so a
+`Signal`-style split would buy nothing and double the surface. **Do not add an
+`AnyArraySignal` alias, and do not "restore the symmetry" with `Signal` by
+introducing a storage parameter.** The asymmetry is the decision, not an
+oversight.
+
+### `KeyedArraySignal` is a sibling, not a subtype
+
+`KeyedArraySignal<A>` is **not** an `ArraySignal<A>` with extra fields, and there
+is no subtyping between them. It is a separate type with a different operation
+set:
+
+- `ArraySignal<T>` is **per-element**: `forEach`, `map`, `concat`.
+- `KeyedArraySignal<A>` is **whole-vector**: `mapValues`, `mapKeyed`, `values`.
+
+Reaching for `forEach` on a `KeyedArraySignal` is the natural mistake and it
+will not compile — deliberately. A `KeyedArraySignal` exists to be operated on
+*as a vector*, because that is what a layout computation needs; it re-enters the
+per-element world only through `scatter`.
 
 ## The framing: two kinds of dynamism
 
@@ -49,23 +101,23 @@ machinery is needed, and none should be paid for.
 reorders. This is the *only* place identity is needed, because "which item is
 this?" no longer has a positional answer. `forEach` is what supplies it.
 
-`DynArray<T>` expresses both. Its literal forms (a value, a signal, a nested
-braced list) are value-dynamic. Structural dynamism enters a `DynArray` only
+`ArraySignal<T>` expresses both. Its literal forms (a value, a signal, a nested
+braced list) are value-dynamic. Structural dynamism enters a `ArraySignal` only
 through `forEach` — or through the reactive-subtree constructor, which is
 structural dynamism at the coarsest possible granularity (the whole subtree is
 replaced).
 
-## `DynArray<T>`
+## `ArraySignal<T>`
 
-`DynArray<T>` lives in `bq`. It has no UI dependency; `bqui` merely consumes it.
+`ArraySignal<T>` lives in `bq`. It has no UI dependency; `bqui` merely consumes it.
 
 ### It is a description, not a container
 
-A `DynArray<T>` is an **immutable value**. It has no `push_back`, no `erase`, no
+A `ArraySignal<T>` is an **immutable value**. It has no `push_back`, no `erase`, no
 mutation of any kind. Dynamism flows *in* from upstream: a `Collection<T>`
-converted into a `DynArray<T>` stays live because the conversion produced a
+converted into a `ArraySignal<T>` stays live because the conversion produced a
 signal that the collection drives — mutating the collection changes the
-`DynArray`'s signal, not the `DynArray` object.
+`ArraySignal`'s signal, not the `ArraySignal` object.
 
 This is the same discipline as the rest of the toolkit (`docs/architecture.md`):
 descriptions are immutable values, state lives upstream.
@@ -73,7 +125,7 @@ descriptions are immutable values, state lives upstream.
 ### A constructor per supported type — deliberately not a variant
 
 The natural implementation is `std::variant` over the accepted forms. We are
-**not** doing that. Instead `DynArray<T>` gets one converting constructor per
+**not** doing that. Instead `ArraySignal<T>` gets one converting constructor per
 supported source type:
 
 | Constructor takes | Meaning |
@@ -81,9 +133,9 @@ supported source type:
 | `T` (or anything convertible to `T`) | a single constant item |
 | `AnySignal<T>` | a single item whose value varies |
 | `AnySignal<std::vector<T>>` | a varying list of items |
-| `std::initializer_list<DynArray<T>>` | a fixed list of children |
-| `std::vector<DynArray<T>>` | ditto, built at runtime |
-| `AnySignal<DynArray<T>>` | a reactive subtree (see below) |
+| `std::initializer_list<ArraySignal<T>>` | a fixed list of children |
+| `std::vector<ArraySignal<T>>` | ditto, built at runtime |
+| `AnySignal<ArraySignal<T>>` | a reactive subtree (see below) |
 
 Two reasons. First, **acceptance is precisely controlled**: each form is opted
 into by writing a constructor, so an accidentally-convertible type cannot slip
@@ -97,15 +149,15 @@ representation is free to change.
 
 ### It is a uniform recursive tree
 
-Because *everything* converts to `DynArray<T>`, including a braced list of
-`DynArray<T>`, the type is a tree: a **leaf** is a single item (constant or
+Because *everything* converts to `ArraySignal<T>`, including a braced list of
+`ArraySignal<T>`, the type is a tree: a **leaf** is a single item (constant or
 signal) or a signal-of-vector, and a **branch** is a list of children. This
 syntax must work:
 
 ```cpp
-DynArray<Widget> content = {
+ArraySignal<Widget> content = {
     someWidget,
-    getDynArrayOfWidgets(),
+    getArraySignalOfWidgets(),
     { otherWidget, getMoreWidgets() }
 };
 ```
@@ -115,30 +167,30 @@ Nesting is not a special case in the consumer: the consumer sees the exported
 
 ### It leaves the domain as `AnySignal<std::vector<std::pair<size_t, T>>>`
 
-The single exit from `DynArray<T>` back to `Signal` produces a signal of
+The single exit from `ArraySignal<T>` back to `Signal` produces a signal of
 `(id, value)` pairs in list order. Consumers reconcile against the ids and never
 look at the tree.
 
 This is not a new shape. `dataBind` already returns exactly it for widgets
 (`src/bqui/include/bqui/databind.h:22`), and the open PR #99 proposes
 `AnySignal<std::vector<std::pair<size_t, Window>>>` for `App`'s window list.
-`DynArray` generalises what those two arrived at independently.
+`ArraySignal` generalises what those two arrived at independently.
 
 ### Ids are assigned at the exit, by a scoped allocator
 
 **Settled:** the allocator is constructed at the point the
 `AnySignal<std::vector<std::pair<size_t, T>>>` is constructed, and is a
-parameter of that operation. **Construction of a `DynArray` assigns no ids at
+parameter of that operation. **Construction of a `ArraySignal` assigns no ids at
 all**; the exit does. So an id is a property of *one exit's* view of the tree,
 and the allocator's lifetime is the exit signal's lifetime.
 
 This resolves what would otherwise be a genuine tension. A consumer-owned
 allocator and a per-type constructor set cannot both be satisfied at
-construction time: nested `DynArray`s are built before their parent, and the
+construction time: nested `ArraySignal`s are built before their parent, and the
 parent before it ever reaches a consumer, so there is no point during
 construction at which the consumer's allocator is in scope. Making the allocator
 a parameter of the exit removes the problem instead of threading around it —
-`DynArray` values stay pure descriptions that can be built, stored, and passed
+`ArraySignal` values stay pure descriptions that can be built, stored, and passed
 anywhere, and nothing needs an ambient allocator.
 
 Ids are **reused across re-exports**, so an item that survives a change keeps
@@ -157,14 +209,14 @@ that escape hatch is now gone.)
 **Consequence for `forEach`'s key→id map.** That map is what makes an id
 survive, so it lives wherever the allocator lives: in the durable state hanging
 off the exit signal, created and destroyed with it. It is *not* per-evaluation
-state, and it is not something the `DynArray` value carries — a `DynArray` used
+state, and it is not something the `ArraySignal` value carries — a `ArraySignal` used
 by two exits legitimately has two independent id spaces and therefore two maps.
 Exactly which mechanism holds that state (a `DataType` slot in the
 `SignalContext`, or a control block with its own id, as `SharedControl` does) is
 an implementation choice; the requirement is only that its lifetime match the
 exit's.
 
-### The reactive subtree: `AnySignal<DynArray<T>>`
+### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
 This constructor makes a whole subtree swappable — conditional branches, a
 section of a list that changes shape wholesale. The rule on swap:
@@ -184,16 +236,16 @@ keys are actually known.
 These are design constraints on the implementation, not incidental details.
 
 - **The "convertible to `T`" constructor must be SFINAE-constrained.** An
-  unconstrained `template <typename U> DynArray(U&&)` is a better match than the
-  copy and move constructors for a non-const lvalue `DynArray`, and it will also
+  unconstrained `template <typename U> ArraySignal(U&&)` is a better match than the
+  copy and move constructors for a non-const lvalue `ArraySignal`, and it will also
   swallow `AnySignal<T>` and braced lists that were meant for the dedicated
   constructors. Constrain it on `std::is_convertible_v<U, T>` *and* exclude
-  `DynArray` itself and every other accepted form. This is the single most
+  `ArraySignal` itself and every other accepted form. This is the single most
   likely way to get a mysterious compile error or a silently wrong overload.
 
-- **Prefer an explicit `std::initializer_list<DynArray<T>>` constructor.** In
+- **Prefer an explicit `std::initializer_list<ArraySignal<T>>` constructor.** In
   braced initialisation an `initializer_list` constructor wins over everything
-  else, so relying on a `vector<DynArray<T>>` constructor to catch braces is a
+  else, so relying on a `vector<ArraySignal<T>>` constructor to catch braces is a
   trap — the `initializer_list` form must exist, and the `vector` form is the
   runtime-built sibling, not a substitute.
 
@@ -204,14 +256,14 @@ These are design constraints on the implementation, not incidental details.
   actually produces it rather than leaving it to whichever constructor happened
   to be a better match.
 
-## `DynArray` as a domain alongside `Signal`
+## `ArraySignal` as a domain alongside `Signal`
 
-`DynArray` is not a helper type bolted onto `Signal` — it is **its own domain**,
+`ArraySignal` is not a helper type bolted onto `Signal` — it is **its own domain**,
 with its own operations, entered and left by explicit boundary operations:
 
 ```
                 forEach(collection, keyFn, delegate)
-    Signal  ──────────────────────────────────────────▶  DynArray
+    Signal  ──────────────────────────────────────────▶  ArraySignal
             ◀──────────────────────────────────────────
                         toSignal(allocator)
 ```
@@ -222,18 +274,18 @@ what their laws are, and — most usefully — what each one does to identity.
 
 ### The operations
 
-- **`pure : T → DynArray<T>`** — the single-item constructor. Already in the
+- **`pure : T → ArraySignal<T>`** — the single-item constructor. Already in the
   table above.
-- **Concatenation** — the `initializer_list` / `vector<DynArray<T>>`
+- **Concatenation** — the `initializer_list` / `vector<ArraySignal<T>>`
   constructor, with the empty list as identity. This is a **monoid**, and its
   associativity law is not an abstraction: it is literally the brace-nesting
   ergonomics we require, `{a, {b, c}} ≡ {a, b, c}`. The syntax goal and the
   algebraic law are the same statement.
-- **`join : DynArray<DynArray<T>> → DynArray<T>`** — already latent. A branch
+- **`join : ArraySignal<ArraySignal<T>> → ArraySignal<T>`** — already latent. A branch
   node *is* nesting, and collapsing the tree *is* join. It deserves a name
   because `flatMap` then falls out as `map` followed by `join`, with no new
   machinery.
-- **`map : (T → U) → DynArray<T> → DynArray<U>`** — a lawful functor. See the
+- **`map : (T → U) → ArraySignal<T> → ArraySignal<U>`** — a lawful functor. See the
   caveat below: this is emphatically **not** the delegate form `forEach`
   rejects.
 - **`filter`** — not required by anything here, but obviously wanted soon.
@@ -290,9 +342,9 @@ the exit does not?"
 
 Two distinct collapses exist and must not share a name:
 
-- **`join`** (or `flatten`) — `DynArray<DynArray<T>> → DynArray<T>`. Stays
+- **`join`** (or `flatten`) — `ArraySignal<ArraySignal<T>> → ArraySignal<T>`. Stays
   inside the domain; collapses nesting.
-- **`toSignal(allocator)`** — `DynArray<T> → AnySignal<vector<pair<size_t, T>>>`.
+- **`toSignal(allocator)`** — `ArraySignal<T> → AnySignal<vector<pair<size_t, T>>>`.
   Leaves the domain; assigns and reveals ids.
 
 `resolve(allocator)` is an acceptable alternative for the second. What is not
@@ -311,7 +363,7 @@ emissions** currently exists in three places:
    destroy it when the id vanishes, keep it otherwise.
 3. `forEach` would be the third.
 
-Three hand-rolled copies of one algorithm is two too many. **`DynArray` should
+Three hand-rolled copies of one algorithm is two too many. **`ArraySignal` should
 own a generic "apply `f` once per id, cache the result, reuse on later
 emissions" operation**, and all three collapse onto it.
 
@@ -354,7 +406,7 @@ footgun; that is the one thing to say in the Doxygen for `map`.
 
 ### `map` with extra signals
 
-`dynArray.map(f, sig1, sig2)` — where `f` receives the item's value plus the
+`arraySignal.map(f, sig1, sig2)` — where `f` receives the item's value plus the
 current values of those signals — should be supported. It is **`combine` sugar
 per element**: the node is still created once per identity, and only values
 recompute. It introduces **no new footgun class**, because the dangerous case is
@@ -388,26 +440,26 @@ the item's *construction* does. The two cover different needs.
   today is `a.merge(b, c).map(f)` — which is exactly the sugar being proposed,
   spelled out.
 
-**Constraint:** `DynArray::map` must **mirror `Signal::map` exactly** — same
+**Constraint:** `ArraySignal::map` must **mirror `Signal::map` exactly** — same
 argument order, same arity handling, same name. The symmetry between the two
-domains is the payoff of this whole framing; a `DynArray::map` that takes extra
+domains is the payoff of this whole framing; a `ArraySignal::map` that takes extra
 signals while `Signal::map` does not would break it at the first thing anyone
 tries.
 
 Since `Signal::map` does **not** currently take extra signals, that constraint
 argues for **adding the extra-signals form to `Signal::map` first** (as sugar
-over `merge().map()`), and only then giving `DynArray::map` the matching shape.
+over `merge().map()`), and only then giving `ArraySignal::map` the matching shape.
 Doing it the other way round would make the two domains diverge exactly where
 the framing promises they agree.
 
 ## `forEach`
 
 ```
-forEach(collection, keyFn, delegate) -> DynArray<U>
+forEach(collection, keyFn, delegate) -> ArraySignal<U>
 ```
 
 `forEach` is the producer of structural dynamism, the **entry** into the
-`DynArray` domain, and the replacement for the `Collection` / `DataSource` /
+`ArraySignal` domain, and the replacement for the `Collection` / `DataSource` /
 `dataBind` plumbing. It is the only operation other than `pure` that mints
 identity.
 
@@ -431,7 +483,7 @@ section is that argument, and it is the most important part of this document.
 - **The delegate is the last parameter** so it can be defaulted when only keying
   is wanted. *Wrinkle to settle:* with a signal-taking delegate, the identity
   default gives `U = AnySignal<T>`, so the defaulted call yields
-  `DynArray<AnySignal<T>>` rather than `DynArray<T>`. That is defensible but not
+  `ArraySignal<AnySignal<T>>` rather than `ArraySignal<T>`. That is defensible but not
   obviously what a caller expects; decide at implementation time whether the
   default unwraps it, or whether the defaulted overload is simply not offered.
 - **`keyFn` runs for every item whenever the array signal changes.** The
@@ -441,7 +493,7 @@ section is that argument, and it is the most important part of this document.
   and its item removed; the new key is new, so it gets a new id and the delegate
   runs. This is a consequence of the rule above, not a separate one.
 - **Eviction is strict.** When an item disappears its key→id mapping is dropped
-  immediately; the resulting `DynArray` is a strict 1:1 mapping of the source
+  immediately; the resulting `ArraySignal` is a strict 1:1 mapping of the source
   array, with no lingering entries for items that might come back.
 - **Duplicate keys**: assert in debug. In release, tolerate gracefully — the
   result may be suboptimal (an item may lose its identity and be rebuilt) but it
@@ -540,7 +592,7 @@ identity supplied by a key function instead of by the collection.
 **`dynamicBox`** (`src/bqui/include/bqui/dynamicbox.h:23`, the implementation
 behind `hbox`/`vbox` — `src/bqui/src/widget/hbox.cpp:18`,
 `src/bqui/src/widget/vbox.cpp:20`) consumes that exported signal. It keeps its
-job: `toSignal` on a `DynArray<AnyWidget>` produces the very signal it already
+job: `toSignal` on a `ArraySignal<AnyWidget>` produces the very signal it already
 takes, so it needs at most an overload. What it should shed is its build-cache (below).
 
 Existing callers are `src/bqui/test/databindtest.cpp:18` and
@@ -728,7 +780,7 @@ above and is not merely a cleanup.
 
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
-stable id. It is expected to be reworked onto `DynArray<Window>`, with `App`
+stable id. It is expected to be reworked onto `ArraySignal<Window>`, with `App`
 owning the id allocator.
 
 ## Open questions
@@ -736,9 +788,9 @@ owning the id allocator.
 Points the design does not yet settle. Flagged rather than guessed.
 
 - **The defaulted delegate's return type.** As noted above, defaulting a
-  `(AnySignal<T>) -> U` delegate to identity yields `DynArray<AnySignal<T>>`,
-  not `DynArray<T>`. Decide whether to unwrap it, to require the delegate, or to
-  offer the default only where `DynArray<AnySignal<T>>` is what the consumer
+  `(AnySignal<T>) -> U` delegate to identity yields `ArraySignal<AnySignal<T>>`,
+  not `ArraySignal<T>`. Decide whether to unwrap it, to require the delegate, or to
+  offer the default only where `ArraySignal<AnySignal<T>>` is what the consumer
   wants.
 - **`{x}` — one-element list or single item?** They export the same list, so the
   choice is about which constructor wins and what the error messages say. Pick
@@ -755,11 +807,11 @@ Points the design does not yet settle. Flagged rather than guessed.
   Note that `Collection`'s ids are pointer values, so a `Collection` source must
   either feed its ids through as keys or be keyed on item content.
 - **The reactive subtree looks like a third minting site.** The identity algebra
-  says only `pure` and `forEach` mint identity, but the `AnySignal<DynArray<T>>`
+  says only `pure` and `forEach` mint identity, but the `AnySignal<ArraySignal<T>>`
   constructor hands out **fresh ids on every swap**. Either that constructor is
   an acknowledged third minting site — in which case the table needs a row and
   the "single rule" needs rewording — or the swap should be modelled as `join`
-  over a signal-of-`DynArray`, with the fresh ids coming from re-entering the
+  over a signal-of-`ArraySignal`, with the fresh ids coming from re-entering the
   new subtree's own `pure`s. The second is tidier and probably intended, but it
   is not what the current wording says. Reconcile before implementing.
 - **`filter` and the apply-once-per-id cache disagree about eviction.** Two
@@ -777,7 +829,7 @@ Points the design does not yet settle. Flagged rather than guessed.
 
 Two commits, in this order:
 
-1. **`DynArray<T>` core** — the type, its constructors, the tree, `join`,
+1. **`ArraySignal<T>` core** — the type, its constructors, the tree, `join`,
    `toSignal` and the scoped id allocator, and the generic apply-once-per-id
    operation. Independently useful: `App::windows` can consume it before
    `forEach` exists.

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -653,7 +653,7 @@ T>>>` before `forEach` sees it. With that comes a warning worth stating loudly:
 The semantics, verified:
 
 - `check()` exists **only** when the signal's value type is equality-comparable
-  (`btl::IsEqualityComparable`, `src/btl/include/btl/typetraits.h:78`); calling
+  (`btl::IsEqualityComparable`, `src/btl/include/btl/typetraits.h:82-89`); calling
   it on a non-comparable type is a hard "no member named `check`" error.
 - `tryCheck()` exists always. When the type is comparable it *is* `check()`;
   when it is not, it is a **silent passthrough** returning an equivalent signal
@@ -661,7 +661,7 @@ The semantics, verified:
 - What `Check` suppresses is the **change notification**, not the value: its
   `update()` downgrades the inner signal's `didChange` to `false` when the newly
   evaluated value compares equal to the cached one
-  (`src/bq/include/bq/signal/check.h:44`). `nextUpdate` passes through.
+  (`src/bq/include/bq/signal/check.h:44-59`). `nextUpdate` passes through.
 - Comparison of a multi-value `SignalResult<Ts...>` is **all-or-nothing**, not
   per element (`src/bq/include/bq/signal/signalresult.h:117`): the trait is true
   only if every `T` is comparable, and a change in any element propagates all of
@@ -1024,7 +1024,7 @@ lock-guarded container whose writer API (`pushBack`, `update`, `erase`, `swap`,
 `move`, `sort` — `collection.h:307-461`) mutates the vector under a spin lock and
 synchronously invokes registered callbacks. Each item's `size_t` id is the
 address of its heap-allocated value —
-`reinterpret_cast<size_t>(iter_->ptr())` (`collection.h:138-141`) — which is
+`reinterpret_cast<size_t>(iter_->ptr())` (`collection.h:140`) — which is
 stable across reallocation but **not reproducible between runs**. That is
 another argument for a scoped allocator with dense, deterministic ids: a test
 can assert on the id set. `forEach` accepts a `Collection<T>` directly, so it
@@ -1046,11 +1046,12 @@ shape (`databind.h:22`). `forEach` is the same operator with the delegate
 generalised to any `U`, the source generalised past `DataSource`, and the
 identity supplied by a key function instead of by the collection.
 
-**`dynamicBox`** (`src/bqui/include/bqui/dynamicbox.h:23`, the implementation
-behind `hbox`/`vbox` — `src/bqui/src/widget/hbox.cpp:18`,
-`src/bqui/src/widget/vbox.cpp:20`) consumes that exported signal. It keeps its
-job: `toSignal` on a `ArraySignal<AnyWidget>` produces the very signal it already
-takes, so it needs at most an overload. What it should shed is its build-cache (below).
+**`dynamicBox`** (`src/bqui/include/bqui/dynamicbox.h:23`, the signal-taking
+overload of `hbox`/`vbox` — `src/bqui/src/widget/hbox.cpp:18`,
+`src/bqui/src/widget/vbox.cpp:20`) **goes away entirely.** Earlier drafts kept it
+and merely gave it an overload; the *One layout engine* finding supersedes that.
+`hbox`/`vbox` take an `ArraySignal<AnyWidget>`, and both the static and the
+dynamic case run through the single unified `layout()`.
 
 Existing callers are `src/bqui/test/databindtest.cpp:18` and
 `src/testapp1/adder.cpp:84`; both are `Collection` → `dataSourceFromCollection`
@@ -1083,7 +1084,7 @@ Per-context state is looked up by exactly that id:
 and, on a miss, creates fresh state (`src/bq/include/bq/signal/input.h:126-131`);
 `SharedControl::initialize` does the same (`sharedcontrol.h:148-154`).
 `DataContext::findData` is a plain map lookup keyed by `DataId = btl::UniqueId`
-(`src/bq/include/bq/signal/datacontext.h:79-100`).
+(`src/bq/include/bq/signal/datacontext.h:78-100`).
 
 So: **a new control block is a new id is a miss in `findData` is fresh state.**
 State is keyed by object identity, and rebuilding destroys that identity by
@@ -1098,9 +1099,10 @@ there." It does not work, and there is already a live demonstration.
 `dynamicBox` rebuilds its children inside a `.map()` — `std::move(widget.second)(params)`
 invokes each child's whole build function (`src/bqui/include/bqui/dynamicbox.h:35`).
 That map node is created **once**, when `WindowGlue` constructs its
-`SignalContext` (`src/bqui/src/app.cpp:81-84`, member declared at `:438-439`),
+`SignalContext` (`src/bqui/src/app.cpp:81-83`, member declared at `:438-439`),
 and that context lives for the entire run — it is pumped once per frame at
-`app.cpp:269` and torn down only at `app.cpp:509`. So every list change
+`app.cpp:269` and torn down only when its `WindowGlue` is destroyed
+(`app.cpp:251`, `app.cpp:514`). So every list change
 re-executes the build inside the *same*, never-reinitialised context, and the
 rebuilt children still get fresh state. The context is shared; the *ids* are
 not, because the rebuild constructed new controls.
@@ -1140,7 +1142,7 @@ Streams are the worst case. An `iterate` fold and the `pipe` feeding it are
 separate nodes; nothing guarantees they are preserved or recreated together, so
 a structural match can preserve one and recreate the other — a fold reading from
 a pipe that no longer feeds it. The type check in `findData`
-(`datacontext.h:87-93`) does not save this: it only catches collisions between
+(`datacontext.h:88-94`) does not save this: it only catches collisions between
 *differently*-typed data, and same-shaped list items are the same type by
 construction.
 
@@ -1169,8 +1171,8 @@ values through a handle, never rebuild.
 **`dynamicBox` caches the built element by item id.** Its `withPrevious` fold
 keeps, for each id present in the new builder list, the element it built
 previously, and only constructs an element for ids it has not seen
-(`src/bqui/include/bqui/dynamicbox.h:104-159` — the `prev.first == id` hit at
-`:116-120` reuses the old element and `continue`s at `:123`).
+(`src/bqui/include/bqui/dynamicbox.h:85-141` — the `prev.first == id` hit at
+`:97-102` reuses the old element and `continue`s at `:105-106`).
 
 `forEach` formalises exactly this pattern and moves it below the UI layer, where
 it works for any `U` rather than only for widgets.
@@ -1182,7 +1184,7 @@ This is a correctness finding, not just a design argument.
 `dynamicBox`'s cache is keyed by id and consulted *before* anything looks at the
 widget. For each entry in the incoming builder list it searches the previous
 result for the same id; on a hit it reuses the old element and `continue`s
-(`src/bqui/include/bqui/dynamicbox.h:113-124`). The builder that stage 1 just
+(`src/bqui/include/bqui/dynamicbox.h:94-106`). The builder that stage 1 just
 produced from the *current* widget is dropped on the floor.
 
 So if an existing id's **widget changes** — same item, different widget — the
@@ -1223,22 +1225,22 @@ here; noted so the option stays visible.
 **`dynamicBox` wastes work.** Its two stages disagree. Stage 1 (widget →
 builder, `dynamicbox.h:28-40`) re-invokes **every** child's build function on
 **every** list change, allocating throwaway inputs, pipes, and ids. Stage 2
-(builder → element, `dynamicbox.h:104-159`) then caches by id, so for every
+(builder → element, `dynamicbox.h:85-141`) then caches by id, so for every
 pre-existing item the builder stage 1 just produced is dropped unused at the
-`continue` on `dynamicbox.h:123-124`. The cache makes `dynamicBox` *correct*,
+`continue` on `dynamicbox.h:105-106`. The cache makes `dynamicBox` *correct*,
 not *cheap*: one insert costs an O(n) build-and-discard. `.share()`
 (`dynamicbox.h:40`) bounds it to once per changed frame, but not per changed
-item. Worth cleaning up when this area is reworked; `forEach` removes the reason
-for the pattern entirely. (Related, and cheap to fix while there: the per-id
-`hints` signal at `dynamicbox.h:55-72` is computed, `.share()`d, and never used.)
-This is the *performance* half of the same cache; the correctness half — that
-the discarded builder may carry a genuinely changed widget — is in *Rationale*
-above and is not merely a cleanup.
+item. This is the *performance* half of the same cache; the correctness half —
+that the discarded builder may carry a genuinely changed widget — is in
+*Rationale* above and is not merely a cleanup. Both are moot once `dynamicBox`
+is deleted in favour of the unified engine.
 
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
-stable id. It is expected to be reworked onto `ArraySignal<Window>`, with `App`
-owning the id allocator.
+stable id. It is expected to be reworked onto `ArraySignal<Window>`. Note that
+`App` no longer owns an id allocator under this design — the `ArraySignal` does —
+so the rework is `extract`/`scatter` over the window list rather than a
+consumer-side reconcile. See *Open questions*.
 
 ## Open questions
 
@@ -1281,14 +1283,56 @@ Points the design does not yet settle. Flagged rather than guessed.
   introduced," and means a filtered-out widget silently loses its state. Decide
   whether `filter` evicts from the shared identity space or only masks its own
   output, and say which guarantee survives.
+- **Is `scatter` the right name?** "Scatter" implies a redistribution the caller
+  never sees — nothing is being spread anywhere from the caller's point of view;
+  the delegate simply receives one more argument. **`mapWith`** says what it does
+  and puts it next to `map`, which is where the *`scatter` is `map` with one
+  extra argument* framing wants it. `scatter` is used throughout this document
+  because that is the name the design was worked out under. Settle before the
+  header is written; renaming afterwards is churn.
+- **Does the layering test actually pass?** *The API surface* asserts that
+  `forEach` must be implementable in terms of `extract`/`scatter`, on pain of the
+  layering being cosmetic. That has **not been demonstrated.** `extract` is
+  fan-in and `scatter` is fan-out, while `forEach` is neither — its content is
+  the key→id diff plus once-per-identity invocation. The plausible resolution is
+  that the shared primitive is *apply-once-per-identity*, which `forEach` and
+  `extract` both use, and that the test should be restated in those terms.
+  Restate it or drop it; leaving an untested claim in a design document is worse
+  than either.
+- **Does a raw id-revealing exit survive at all?** *Identity is internal* argues
+  that nothing outside needs to see an id, which is what justifies moving the
+  allocator onto the `ArraySignal`. But PR #99's `App` window list and today's
+  `dataBind` both hand ids to their consumer. If both are rewritten onto
+  `extract`/`scatter` the question disappears; if either keeps an id-pair
+  signal, decide which layer's header it lives in and say what the ids mean.
+- **`ArraySignal<Widget>` versus `ArraySignal<AnyWidget>` for the layout API.**
+  *First value wins* is stated for `ArraySignal<Widget>`, but `layout()` and
+  `dynamicBox` both take `AnyWidget` today. Which one the unified engine accepts
+  affects whether the delegate can see a concrete builder type. Not settled here.
 
 ## Implementation order
 
-Two commits, in this order:
+Four steps, in this order. The first two are the `bq` core and can land before
+anything in `bqui` changes.
 
-1. **`ArraySignal<T>` core** — the type, its constructors, the tree, `join`,
-   `toSignal` and the scoped id allocator, and the generic apply-once-per-id
-   operation. Independently useful: `App::windows` can consume it before
-   `forEach` exists.
-2. **`forEach`** — the keyed operator on top, plus the retirement path for
-   `dataBind` / `dataSourceFromCollection` / `dynamicBox`'s caching layer.
+1. **`ArraySignal<T>` core** — the type, its constructors, the tree, `concat`,
+   `join`, `map`, the scoped id allocator, and the generic apply-once-per-identity
+   operation.
+2. **`forEach`, `KeyedArraySignal`, and the advanced layer** — the keyed operator
+   plus `extract`, `mapValues`, `mapKeyed`, `values` and `scatter` in the
+   layout-implementor header. `forEach` and `extract` must share the
+   apply-once-per-identity primitive from step 1.
+3. **Unify `layout()`** — reimplement `layout()` over `extract`/`mapValues`/
+   `scatter`, keeping its existing `SizeHintMap`/`ObbMap` signature so `box`,
+   `stack` and `uniformGrid` are unaffected. Delete the dead heterogeneous tuple
+   path (`accumulateSizeHintsTuple`, `MapObbs`) at the same time, since nothing
+   in the unified engine can use it.
+4. **Delete `dynamicBox`** — `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
+   route to the unified `layout()`. This is where the missing `handleGravity()`
+   and the element-cache bug disappear. Retire `dataBind` /
+   `dataSourceFromCollection` here too, and port
+   `src/bqui/test/databindtest.cpp:18` and `src/testapp1/adder.cpp:84`.
+
+Steps 3 and 4 are the ones that need tests written first: neither `dynamicBox`
+nor `uniformGrid` has any coverage today, so there is nothing to catch a
+regression in the rewrite.

--- a/docs/design/dynarray.md
+++ b/docs/design/dynarray.md
@@ -29,6 +29,12 @@ This design replaces that pipeline with two pieces:
   `DynArray<U>` with stable per-item identity, invoking a delegate once per new
   item rather than once per change.
 
+`DynArray` is best understood as **its own domain alongside `Signal`**, entered
+by `forEach` and left by `toSignal`; that framing is developed below and is what
+tells us which operations must exist and what each does to identity. It also
+fixes a real bug: `dynamicBox` today supports dynamic *membership* only, and
+silently ignores a changed widget for an existing item.
+
 ## The framing: two kinds of dynamism
 
 This split is the load-bearing idea; everything else follows from it.
@@ -104,35 +110,59 @@ DynArray<Widget> content = {
 };
 ```
 
-Nesting is not a special case in the consumer: the consumer sees the flattened
-form and never walks the tree.
+Nesting is not a special case in the consumer: the consumer sees the exported
+`(id, value)` list and never walks the tree.
 
-### It flattens to `AnySignal<std::vector<std::pair<size_t, T>>>`
+### It leaves the domain as `AnySignal<std::vector<std::pair<size_t, T>>>`
 
-The single lowering of a `DynArray<T>` is a signal of `(id, value)` pairs in
-list order. Consumers reconcile against the ids and never look at the tree.
+The single exit from `DynArray<T>` back to `Signal` produces a signal of
+`(id, value)` pairs in list order. Consumers reconcile against the ids and never
+look at the tree.
 
 This is not a new shape. `dataBind` already returns exactly it for widgets
 (`src/bqui/include/bqui/databind.h:22`), and the open PR #99 proposes
 `AnySignal<std::vector<std::pair<size_t, Window>>>` for `App`'s window list.
 `DynArray` generalises what those two arrived at independently.
 
-### Ids come from a scoped allocator
+### Ids are assigned at the exit, by a scoped allocator
 
-Ids are minted by an **allocator owned by the consumer** — `App` owns the one
-used for the window list — and are **reused across re-flattens**, so an item
-that survives a change keeps its id.
+**Settled:** the allocator is constructed at the point the
+`AnySignal<std::vector<std::pair<size_t, T>>>` is constructed, and is a
+parameter of that operation. **Construction of a `DynArray` assigns no ids at
+all**; the exit does. So an id is a property of *one exit's* view of the tree,
+and the allocator's lifetime is the exit signal's lifetime.
+
+This resolves what would otherwise be a genuine tension. A consumer-owned
+allocator and a per-type constructor set cannot both be satisfied at
+construction time: nested `DynArray`s are built before their parent, and the
+parent before it ever reaches a consumer, so there is no point during
+construction at which the consumer's allocator is in scope. Making the allocator
+a parameter of the exit removes the problem instead of threading around it —
+`DynArray` values stay pure descriptions that can be built, stored, and passed
+anywhere, and nothing needs an ambient allocator.
+
+Ids are **reused across re-exports**, so an item that survives a change keeps
+its id. This requires the allocator to be *stateful and durable* — it lives with
+the exit signal, not with a single evaluation.
 
 Not a process-wide global, for two reasons: no global mutable state to make
-thread-safe, and **deterministic per-tree ids**, which is what lets a test
+thread-safe, and **deterministic per-exit ids**, which is what lets a test
 assert on the id set — as PR #99's window tests do — instead of on whatever the
-global counter happened to be at. Ids only need to be unique *within one tree*,
-so a per-consumer allocator is sufficient.
+global counter happened to be at. Ids only need to be unique *within one exit*,
+so a per-consumer allocator is sufficient. (A global atomic in the style of
+`bq::signal::makeUniqueId`, `src/bq/src/signal/datacontext.cpp:7`, remains the
+fallback if the scoped form proves unworkable — but the tension that motivated
+that escape hatch is now gone.)
 
-If the scoped allocator proves too awkward to thread through — it must reach
-every nested `DynArray` construction — falling back to a global atomic
-(mirroring `bq::signal::makeUniqueId`, `src/bq/src/signal/datacontext.cpp:7`) is
-an acceptable retreat. It is the fallback, not the plan.
+**Consequence for `forEach`'s key→id map.** That map is what makes an id
+survive, so it lives wherever the allocator lives: in the durable state hanging
+off the exit signal, created and destroyed with it. It is *not* per-evaluation
+state, and it is not something the `DynArray` value carries — a `DynArray` used
+by two exits legitimately has two independent id spaces and therefore two maps.
+Exactly which mechanism holds that state (a `DataType` slot in the
+`SignalContext`, or a control block with its own id, as `SharedControl` does) is
+an implementation choice; the requirement is only that its lifetime match the
+exit's.
 
 ### The reactive subtree: `AnySignal<DynArray<T>>`
 
@@ -169,10 +199,206 @@ These are design constraints on the implementation, not incidental details.
 
 - **Define `{}` and `{x}` deliberately.** `{}` must mean *the empty list*, not a
   default-constructed `T` — say so and test it. `{x}` is ambiguous between "a
-  one-element list containing `x`" and "the single item `x`"; the two flatten
-  identically, so pick one reading, document it, and make sure the overload set
+  one-element list containing `x`" and "the single item `x`"; the two export the
+  same list, so pick one reading, document it, and make sure the overload set
   actually produces it rather than leaving it to whichever constructor happened
   to be a better match.
+
+## `DynArray` as a domain alongside `Signal`
+
+`DynArray` is not a helper type bolted onto `Signal` — it is **its own domain**,
+with its own operations, entered and left by explicit boundary operations:
+
+```
+                forEach(collection, keyFn, delegate)
+    Signal  ──────────────────────────────────────────▶  DynArray
+            ◀──────────────────────────────────────────
+                        toSignal(allocator)
+```
+
+Naming this is worth doing because most of the structure is **already latent**
+in the design above. Making it explicit tells us which operations must exist,
+what their laws are, and — most usefully — what each one does to identity.
+
+### The operations
+
+- **`pure : T → DynArray<T>`** — the single-item constructor. Already in the
+  table above.
+- **Concatenation** — the `initializer_list` / `vector<DynArray<T>>`
+  constructor, with the empty list as identity. This is a **monoid**, and its
+  associativity law is not an abstraction: it is literally the brace-nesting
+  ergonomics we require, `{a, {b, c}} ≡ {a, b, c}`. The syntax goal and the
+  algebraic law are the same statement.
+- **`join : DynArray<DynArray<T>> → DynArray<T>`** — already latent. A branch
+  node *is* nesting, and collapsing the tree *is* join. It deserves a name
+  because `flatMap` then falls out as `map` followed by `join`, with no new
+  machinery.
+- **`map : (T → U) → DynArray<T> → DynArray<U>`** — a lawful functor. See the
+  caveat below: this is emphatically **not** the delegate form `forEach`
+  rejects.
+- **`filter`** — not required by anything here, but obviously wanted soon.
+  Identity-preserving for the items that survive.
+
+### The identity algebra
+
+The functor and monoid laws say the operations compose predictably. The more
+actionable guarantee is what each operation does to **ids** — this is the table
+to reason from when asking "will this rebuild?":
+
+| Operation | Effect on identity |
+| --- | --- |
+| `pure` | **creates** one id |
+| concatenation / nesting | **namespaces** children — child ids stay distinct, order is preserved |
+| `map` | **preserves** — same ids, transformed values |
+| `filter` | **preserves** for survivors; dropped items' ids are evicted |
+| `join` / `flatMap` | **namespaces** inner ids into the outer id space |
+| `forEach` | **creates** ids, derived from keys |
+| `toSignal` | **reveals** ids; creates nothing |
+
+Read it as a single rule: **only `pure` and `forEach` mint identity.**
+Everything else either carries identity through unchanged or re-namespaces it
+without inventing any. That is what makes it possible to look at a pipeline and
+say whether a given item will keep its state.
+
+One clarification the table needs, given that ids are assigned at the exit:
+inside the domain, identity is **symbolic** — a position in the tree, or a key —
+and it is `toSignal` that resolves each symbolic identity to a concrete
+`size_t`. "`pure` creates an id" means it introduces a new identity that the
+exit will number; "`map` preserves ids" means it does not disturb the symbolic
+identities, so the same items get the same numbers as they would have without
+it. The two statements — "construction assigns no ids" and "`map` preserves
+ids" — are consistent only under this reading, so state it in the Doxygen too.
+
+### The boundary is asymmetric
+
+Entering the domain **requires a key**; leaving it is free.
+
+That asymmetry is not an accident of the API — it is forced. The `Signal` domain
+does not carry identity: `AnySignal<std::vector<T>>` is a changing sequence of
+values with no notion of which value "is" which across a change. Identity has to
+come from somewhere, and only the caller knows what makes two items the same
+thing. Hence `forEach` takes a `keyFn`.
+
+Leaving is free because by then the ids exist; `toSignal` only has to *reveal*
+them, and its allocator parameter is about which id space to reveal them in, not
+about inventing identity.
+
+This is the one-sentence answer to "why does `forEach` need a key function and
+the exit does not?"
+
+### Naming: `join`/`flatten` vs `toSignal`
+
+Two distinct collapses exist and must not share a name:
+
+- **`join`** (or `flatten`) — `DynArray<DynArray<T>> → DynArray<T>`. Stays
+  inside the domain; collapses nesting.
+- **`toSignal(allocator)`** — `DynArray<T> → AnySignal<vector<pair<size_t, T>>>`.
+  Leaves the domain; assigns and reveals ids.
+
+`resolve(allocator)` is an acceptable alternative for the second. What is not
+acceptable is calling both of them `flatten`, which is the natural drift given
+that both "flatten" something — and which would make every sentence about ids
+ambiguous. Earlier drafts of this document used "flatten" for the exit; that
+usage is retired.
+
+### One operation, three call sites: apply-once-per-id
+
+The pattern **build once per id → cache the result → reuse it on later
+emissions** currently exists in three places:
+
+1. `dynamicBox` caches built elements by id (`dynamicbox.h:104-159`).
+2. `App`'s window reconcile in PR #99: create a `WindowGlue` on a new id,
+   destroy it when the id vanishes, keep it otherwise.
+3. `forEach` would be the third.
+
+Three hand-rolled copies of one algorithm is two too many. **`DynArray` should
+own a generic "apply `f` once per id, cache the result, reuse on later
+emissions" operation**, and all three collapse onto it.
+
+Layering survives this cleanly, which is the point worth stating: `bq` cannot
+know how to build a widget or open a window, but it does not need to. "Apply
+once per identity" is entirely generic; the widget-specific or window-specific
+function stays at the call site in `bqui`. This is the same split that lets
+`map` live in `bq` while the mapped function is the caller's.
+
+Semantics, fixed to match the rest of the design:
+
+- The cached value is **evicted when its id disappears** — consistent with the
+  strict 1:1 mapping `forEach` guarantees.
+- A **re-appearing key rebuilds.** There is no resurrection of evicted state; a
+  key that goes away and comes back is a new item, exactly as a changed key is.
+
+### `.map` is value-level; the build delegate is structure-level
+
+This looks contradictory and is the most important caveat in the document: a
+`(T) -> U` function is **banned** as the `forEach` delegate and **fine** as
+`.map`. Same signature — different role.
+
+- **`.map(f)` is value-level.** It is implemented as a per-element `sig.map(f)`,
+  so the `Map` node is created **once per identity**, and on a value change `f`
+  re-runs *inside* the already-built signal graph. Nothing is constructed, so
+  nothing is destroyed. Lawful functor, no state loss.
+- **The build delegate is structure-level.** Its `f` *constructs* something
+  stateful — a widget with an input, a stream fold, a window. Re-invoking it
+  means a rebuild, and a rebuild is what destroys state (see *Rationale*).
+
+The rule to hold onto:
+
+> **`.map` for transforming values; the `(AnySignal<T>) -> U` build form for
+> constructing stateful things.**
+
+The type system cannot tell these apart — `(T) -> U` is `(T) -> U` whether it
+adds one to a number or spins up a text field with a cursor — so the
+documentation has to. A `.map` whose function constructs a widget is the
+footgun; that is the one thing to say in the Doxygen for `map`.
+
+### `map` with extra signals
+
+`dynArray.map(f, sig1, sig2)` — where `f` receives the item's value plus the
+current values of those signals — should be supported. It is **`combine` sugar
+per element**: the node is still created once per identity, and only values
+recompute. It introduces **no new footgun class**, because the dangerous case is
+already covered by the rule above ("don't construct in `.map`") and is
+unaffected by how many values `f` receives.
+
+The cost is worth stating: a shared signal feeding `n` items fans out to O(n)
+value recomputations when it changes. That is inherent, not a design flaw — all
+`n` outputs genuinely depend on it. It is a reason to reach for the alternative
+below when the dependency is not really per-item, not a reason to omit the
+feature.
+
+**The complement, not the alternative.** Capturing signals in the lambda and
+returning something that *observes* them is the **structure-level** form: the
+signal is wired into the item once, at build time, and changes flow through the
+existing graph rather than through a recomputation of `f`. Use `map`-with-extra-
+signals when the item's *value* depends on them; use capture-and-observe when
+the item's *construction* does. The two cover different needs.
+
+**What `bq` has today**, verified:
+
+- `Signal::map` takes **only** a function — `map(TFunc&& func)`, in `const&` and
+  `&&` overloads (`src/bq/include/bq/signal/signal.h:225-237`). There is **no**
+  extra-signals form.
+- `combine` is homogeneous and vector-shaped: `combine(std::vector<AnySignal<T>>)
+  → AnySignal<std::vector<T>>` (`src/bq/include/bq/signal/combine.h:73`). It
+  fuses N signals *of the same type*.
+- The heterogeneous fuse is `merge`, variadic over signal types, as a free
+  function (`src/bq/include/bq/signal/merge.h:104`) and a member
+  (`signal.h:307-310`). So the way to write "map over these extra signals"
+  today is `a.merge(b, c).map(f)` — which is exactly the sugar being proposed,
+  spelled out.
+
+**Constraint:** `DynArray::map` must **mirror `Signal::map` exactly** — same
+argument order, same arity handling, same name. The symmetry between the two
+domains is the payoff of this whole framing; a `DynArray::map` that takes extra
+signals while `Signal::map` does not would break it at the first thing anyone
+tries.
+
+Since `Signal::map` does **not** currently take extra signals, that constraint
+argues for **adding the extra-signals form to `Signal::map` first** (as sugar
+over `merge().map()`), and only then giving `DynArray::map` the matching shape.
+Doing it the other way round would make the two domains diverge exactly where
+the framing promises they agree.
 
 ## `forEach`
 
@@ -180,8 +406,10 @@ These are design constraints on the implementation, not incidental details.
 forEach(collection, keyFn, delegate) -> DynArray<U>
 ```
 
-`forEach` is the producer of structural dynamism, and the replacement for the
-`Collection` / `DataSource` / `dataBind` plumbing.
+`forEach` is the producer of structural dynamism, the **entry** into the
+`DynArray` domain, and the replacement for the `Collection` / `DataSource` /
+`dataBind` plumbing. It is the only operation other than `pure` that mints
+identity.
 
 **collection** accepts `std::vector<T>`, `AnySignal<std::vector<T>>`, an
 initializer list, or the existing `Collection<T>`.
@@ -205,7 +433,7 @@ section is that argument, and it is the most important part of this document.
   default gives `U = AnySignal<T>`, so the defaulted call yields
   `DynArray<AnySignal<T>>` rather than `DynArray<T>`. That is defensible but not
   obviously what a caller expects; decide at implementation time whether the
-  default flattens, or whether the defaulted overload is simply not offered.
+  default unwraps it, or whether the defaulted overload is simply not offered.
 - **`keyFn` runs for every item whenever the array signal changes.** The
   algorithm computes the new key set, drops the ids whose keys are absent, and
   preserves the id for every key that is still present.
@@ -217,7 +445,11 @@ section is that argument, and it is the most important part of this document.
   array, with no lingering entries for items that might come back.
 - **Duplicate keys**: assert in debug. In release, tolerate gracefully — the
   result may be suboptimal (an item may lose its identity and be rebuilt) but it
-  must not crash, corrupt the mapping, or drop items.
+  must not crash, corrupt the mapping, or drop items. The concrete release rule
+  is still open (see *Open questions*).
+- **The delegate is run by the generic apply-once-per-id operation** described
+  above, not by machinery of its own; `forEach` supplies the key→id mapping and
+  delegates the caching to it.
 
 ### No index is passed to the delegate
 
@@ -267,6 +499,13 @@ demands comparability. Note also that `tryCheck()` on a non-comparable type is
 adds `.tryCheck()` expecting deduplication gets nothing and no warning. Worth a
 Doxygen note on `tryCheck` when this lands.
 
+C++20's defaulted `operator==` and `operator<=>` would soften this considerably
+— a user could opt a type into deduplication with one line rather than writing
+a comparison. The project targets **C++17**, so the design must not depend on
+that, and the silent-no-op trap is real for us today. Noted only so that the
+ergonomics are understood to improve on their own if the standard level ever
+moves.
+
 ## What this supersedes
 
 The existing pipeline, and what `forEach` does instead:
@@ -293,16 +532,16 @@ from the array signal, so any `AnySignal<vector<T>>` is a source, and the six
 event kinds collapse into one code path.
 
 **`dataBind`** (`src/bqui/include/bqui/databind.h:22`) is `forEach` specialised
-to `DataSource` and hard-wired to `AnyWidget`. It returns exactly the flattened
+to `DataSource` and hard-wired to `AnyWidget`. It returns exactly the exported
 shape (`databind.h:22`). `forEach` is the same operator with the delegate
 generalised to any `U`, the source generalised past `DataSource`, and the
 identity supplied by a key function instead of by the collection.
 
 **`dynamicBox`** (`src/bqui/include/bqui/dynamicbox.h:23`, the implementation
 behind `hbox`/`vbox` — `src/bqui/src/widget/hbox.cpp:18`,
-`src/bqui/src/widget/vbox.cpp:20`) consumes that flattened signal. It keeps its
-job: `DynArray<AnyWidget>` flattens to the very signal it already takes, so it
-needs at most an overload. What it should shed is its build-cache (below).
+`src/bqui/src/widget/vbox.cpp:20`) consumes that exported signal. It keeps its
+job: `toSignal` on a `DynArray<AnyWidget>` produces the very signal it already
+takes, so it needs at most an overload. What it should shed is its build-cache (below).
 
 Existing callers are `src/bqui/test/databindtest.cpp:18` and
 `src/testapp1/adder.cpp:84`; both are `Collection` → `dataSourceFromCollection`
@@ -427,6 +666,40 @@ previously, and only constructs an element for ids it has not seen
 `forEach` formalises exactly this pattern and moves it below the UI layer, where
 it works for any `U` rather than only for widgets.
 
+### `dynamicBox` supports dynamic membership only — and `forEach` fixes it
+
+This is a correctness finding, not just a design argument.
+
+`dynamicBox`'s cache is keyed by id and consulted *before* anything looks at the
+widget. For each entry in the incoming builder list it searches the previous
+result for the same id; on a hit it reuses the old element and `continue`s
+(`src/bqui/include/bqui/dynamicbox.h:113-124`). The builder that stage 1 just
+produced from the *current* widget is dropped on the floor.
+
+So if an existing id's **widget changes** — same item, different widget — the
+cache hits, the new widget is discarded, and **the change is silently ignored**.
+No assert, no diagnostic, no visible failure: the old widget simply stays on
+screen. `dynamicBox` presents itself as a container of dynamic widgets, but what
+it actually supports is dynamic **membership**. Items can come and go; an item's
+widget cannot change.
+
+And it **cannot do better as written**. The only way to honour the new widget is
+to use the new builder — that is, to rebuild — and rebuilding is exactly what
+destroys the item's state (the whole of this section). Ignoring the change and
+losing the user's typing are the only two options on offer. The cache picks the
+first, which is the less bad one, but both are wrong.
+
+`forEach`'s `(AnySignal<T>) -> U` **closes the hole** rather than choosing
+between the two failures. The widget is built once per identity, and value
+changes flow *through the item signal into the already-built widget* instead of
+arriving as a replacement widget that has to be either applied or discarded.
+There is nothing left to ignore, because a changed value never presents itself
+as a new widget in the first place.
+
+That makes `forEach` a **fix**, not merely a tidier factoring of the same
+behaviour — and it is the reason this work is worth doing beyond the
+code-sharing argument.
+
 ## Future directions (explicitly out of scope)
 
 **Widgets carry no identity field.** `Widget`, `Builder`, and `Element` have no
@@ -449,6 +722,9 @@ not *cheap*: one insert costs an O(n) build-and-discard. `.share()`
 item. Worth cleaning up when this area is reworked; `forEach` removes the reason
 for the pattern entirely. (Related, and cheap to fix while there: the per-id
 `hints` signal at `dynamicbox.h:55-72` is computed, `.share()`d, and never used.)
+This is the *performance* half of the same cache; the correctness half — that
+the discarded builder may carry a genuinely changed widget — is in *Rationale*
+above and is not merely a cleanup.
 
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
@@ -461,39 +737,49 @@ Points the design does not yet settle. Flagged rather than guessed.
 
 - **The defaulted delegate's return type.** As noted above, defaulting a
   `(AnySignal<T>) -> U` delegate to identity yields `DynArray<AnySignal<T>>`,
-  not `DynArray<T>`. Decide whether to flatten, to require the delegate, or to
+  not `DynArray<T>`. Decide whether to unwrap it, to require the delegate, or to
   offer the default only where `DynArray<AnySignal<T>>` is what the consumer
   wants.
-- **`{x}` — one-element list or single item?** They flatten identically, so the
+- **`{x}` — one-element list or single item?** They export the same list, so the
   choice is about which constructor wins and what the error messages say. Pick
   one and write the test.
-- **Where the id allocator is threaded.** "Owned by the consumer" is clear for
-  `App`, but a `DynArray<T>` is constructed *before* it reaches a consumer, and
-  nested `DynArray`s are constructed before their parent. Either flattening —
-  not construction — assigns ids (the allocator is a parameter of `flatten`), or
-  construction needs an ambient allocator. The first is cleaner and is the
-  assumption the rest of this document makes; confirm it survives contact with
-  `forEach`, which must remember key→id across flattens and therefore needs
-  somewhere durable to keep that map.
-- **Where `forEach`'s key→id map lives.** It is per-`forEach`-node state that
-  must survive across updates, which in this architecture means a `DataType` in
-  the `SignalContext` or a control block with an id. Which one is not decided,
-  and it interacts with the previous point.
 - **Duplicate-key tolerance is under-specified.** "Suboptimal but not
-  catastrophic" needs a concrete rule — e.g. first occurrence wins the id,
-  subsequent duplicates get fresh ids each flatten (and therefore rebuild).
-  State the rule so the release behaviour is testable rather than accidental.
+  catastrophic" needs a concrete rule. *Candidate:* the first occurrence keeps
+  the id; subsequent duplicates get fresh ids on each export, and therefore
+  rebuild. That satisfies "must not fail catastrophically" and keeps the 1:1
+  mapping, at the cost of churn for the duplicates. Not adopted — state the rule
+  before implementing, so the release behaviour is testable rather than
+  accidental.
 - **Whether `Collection<T>` and `DataSource<T>` are removed or kept.** `forEach`
   supersedes the *plumbing*; `Collection` remains a reasonable mutable source.
   Note that `Collection`'s ids are pointer values, so a `Collection` source must
   either feed its ids through as keys or be keyed on item content.
+- **The reactive subtree looks like a third minting site.** The identity algebra
+  says only `pure` and `forEach` mint identity, but the `AnySignal<DynArray<T>>`
+  constructor hands out **fresh ids on every swap**. Either that constructor is
+  an acknowledged third minting site — in which case the table needs a row and
+  the "single rule" needs rewording — or the swap should be modelled as `join`
+  over a signal-of-`DynArray`, with the fresh ids coming from re-entering the
+  new subtree's own `pure`s. The second is tidier and probably intended, but it
+  is not what the current wording says. Reconcile before implementing.
+- **`filter` and the apply-once-per-id cache disagree about eviction.** Two
+  rules collide when an item is filtered out and later filtered back in.
+  Upstream, `forEach`'s key→id map still holds the item (it never left the
+  *source* array), so its identity is unchanged. Downstream, the cache evicted
+  the built value when the id vanished from its input, and "a re-appearing key
+  rebuilds." The result is that the delegate re-runs for an id that was never
+  retired — which contradicts "the delegate is invoked only when a new id is
+  introduced," and means a filtered-out widget silently loses its state. Decide
+  whether `filter` evicts from the shared identity space or only masks its own
+  output, and say which guarantee survives.
 
 ## Implementation order
 
 Two commits, in this order:
 
-1. **`DynArray<T>` core** — the type, its constructors, the tree, flattening,
-   and the scoped id allocator. Independently useful: `App::windows` can consume
-   it before `forEach` exists.
+1. **`DynArray<T>` core** — the type, its constructors, the tree, `join`,
+   `toSignal` and the scoped id allocator, and the generic apply-once-per-id
+   operation. Independently useful: `App::windows` can consume it before
+   `forEach` exists.
 2. **`forEach`** — the keyed operator on top, plus the retirement path for
    `dataBind` / `dataSourceFromCollection` / `dynamicBox`'s caching layer.

--- a/docs/design/dynarray.md
+++ b/docs/design/dynarray.md
@@ -1,0 +1,499 @@
+# Design: `DynArray<T>` and `forEach`
+
+> **Status: proposal — not implemented.** Nothing described here exists in the
+> tree yet. This document is the agreed design, recorded so the implementation
+> has a target and so the reasoning survives. Once it is built, the stable parts
+> move to their normal homes — the model and its traps to
+> `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
+> contract to Doxygen in the new public headers — and this file goes away.
+
+*Written against `221cd3f` (2026-07-19).*
+
+## The problem
+
+A widget list whose *membership* changes at runtime cannot be expressed as a
+plain derivation. Deriving `vector<AnyWidget>` from `vector<T>` rebuilds every
+widget on every change, and rebuilding a widget destroys its state: the text a
+user typed, a cursor position, an animation in flight, a stream fold. The
+existing answer — `Collection` + `dataSourceFromCollection` + `dataBind` +
+`dynamicBox` — works, but it is a special-purpose pipeline bolted to one widget
+container, it is not composable, and it lives in `bqui` where only widgets can
+use it.
+
+This design replaces that pipeline with two pieces:
+
+- **`DynArray<T>`** — a value in `bq` describing a list whose contents and
+  structure may both be dynamic. It is the *input* type a list-consuming API
+  accepts.
+- **`forEach`** — the keyed operator that turns a changing collection into a
+  `DynArray<U>` with stable per-item identity, invoking a delegate once per new
+  item rather than once per change.
+
+## The framing: two kinds of dynamism
+
+This split is the load-bearing idea; everything else follows from it.
+
+**Value dynamism** — the structure is fixed and the contents change. A list of
+three `AnySignal<T>` leaves is value-dynamic: there are always exactly three
+items, in the same order, and each one's value varies over time. Identity is
+**stable by construction** — item *k* is item *k* forever — so no identity
+machinery is needed, and none should be paid for.
+
+**Structural dynamism** — membership itself changes: the list grows, shrinks, or
+reorders. This is the *only* place identity is needed, because "which item is
+this?" no longer has a positional answer. `forEach` is what supplies it.
+
+`DynArray<T>` expresses both. Its literal forms (a value, a signal, a nested
+braced list) are value-dynamic. Structural dynamism enters a `DynArray` only
+through `forEach` — or through the reactive-subtree constructor, which is
+structural dynamism at the coarsest possible granularity (the whole subtree is
+replaced).
+
+## `DynArray<T>`
+
+`DynArray<T>` lives in `bq`. It has no UI dependency; `bqui` merely consumes it.
+
+### It is a description, not a container
+
+A `DynArray<T>` is an **immutable value**. It has no `push_back`, no `erase`, no
+mutation of any kind. Dynamism flows *in* from upstream: a `Collection<T>`
+converted into a `DynArray<T>` stays live because the conversion produced a
+signal that the collection drives — mutating the collection changes the
+`DynArray`'s signal, not the `DynArray` object.
+
+This is the same discipline as the rest of the toolkit (`docs/architecture.md`):
+descriptions are immutable values, state lives upstream.
+
+### A constructor per supported type — deliberately not a variant
+
+The natural implementation is `std::variant` over the accepted forms. We are
+**not** doing that. Instead `DynArray<T>` gets one converting constructor per
+supported source type:
+
+| Constructor takes | Meaning |
+| --- | --- |
+| `T` (or anything convertible to `T`) | a single constant item |
+| `AnySignal<T>` | a single item whose value varies |
+| `AnySignal<std::vector<T>>` | a varying list of items |
+| `std::initializer_list<DynArray<T>>` | a fixed list of children |
+| `std::vector<DynArray<T>>` | ditto, built at runtime |
+| `AnySignal<DynArray<T>>` | a reactive subtree (see below) |
+
+Two reasons. First, **acceptance is precisely controlled**: each form is opted
+into by writing a constructor, so an accidentally-convertible type cannot slip
+in, and the error message when something is not accepted names the type rather
+than a variant alternative list. Second, **braces stay clean** — a variant
+parameter forces the caller to name the alternative at every call site, which
+defeats the whole point of a braced literal.
+
+The public surface is deliberately just the constructors; the internal
+representation is free to change.
+
+### It is a uniform recursive tree
+
+Because *everything* converts to `DynArray<T>`, including a braced list of
+`DynArray<T>`, the type is a tree: a **leaf** is a single item (constant or
+signal) or a signal-of-vector, and a **branch** is a list of children. This
+syntax must work:
+
+```cpp
+DynArray<Widget> content = {
+    someWidget,
+    getDynArrayOfWidgets(),
+    { otherWidget, getMoreWidgets() }
+};
+```
+
+Nesting is not a special case in the consumer: the consumer sees the flattened
+form and never walks the tree.
+
+### It flattens to `AnySignal<std::vector<std::pair<size_t, T>>>`
+
+The single lowering of a `DynArray<T>` is a signal of `(id, value)` pairs in
+list order. Consumers reconcile against the ids and never look at the tree.
+
+This is not a new shape. `dataBind` already returns exactly it for widgets
+(`src/bqui/include/bqui/databind.h:22`), and the open PR #99 proposes
+`AnySignal<std::vector<std::pair<size_t, Window>>>` for `App`'s window list.
+`DynArray` generalises what those two arrived at independently.
+
+### Ids come from a scoped allocator
+
+Ids are minted by an **allocator owned by the consumer** — `App` owns the one
+used for the window list — and are **reused across re-flattens**, so an item
+that survives a change keeps its id.
+
+Not a process-wide global, for two reasons: no global mutable state to make
+thread-safe, and **deterministic per-tree ids**, which is what lets a test
+assert on the id set — as PR #99's window tests do — instead of on whatever the
+global counter happened to be at. Ids only need to be unique *within one tree*,
+so a per-consumer allocator is sufficient.
+
+If the scoped allocator proves too awkward to thread through — it must reach
+every nested `DynArray` construction — falling back to a global atomic
+(mirroring `bq::signal::makeUniqueId`, `src/bq/src/signal/datacontext.cpp:7`) is
+an acceptable retreat. It is the fallback, not the plan.
+
+### The reactive subtree: `AnySignal<DynArray<T>>`
+
+This constructor makes a whole subtree swappable — conditional branches, a
+section of a list that changes shape wholesale. The rule on swap:
+
+> The new subtree's items are a **new set** and get **fresh ids**, unless
+> upstream supplied identity (i.e. the new subtree contains a `forEach` that
+> keys them).
+
+That is the honest default. The framework cannot know that an item in the old
+subtree "is" an item in the new one; guessing would be structural matching,
+which this design rejects for the reasons in *Rationale* below. If a caller
+wants continuity across a swap, it puts the keying inside the subtree where the
+keys are actually known.
+
+### C++ pitfalls to get right
+
+These are design constraints on the implementation, not incidental details.
+
+- **The "convertible to `T`" constructor must be SFINAE-constrained.** An
+  unconstrained `template <typename U> DynArray(U&&)` is a better match than the
+  copy and move constructors for a non-const lvalue `DynArray`, and it will also
+  swallow `AnySignal<T>` and braced lists that were meant for the dedicated
+  constructors. Constrain it on `std::is_convertible_v<U, T>` *and* exclude
+  `DynArray` itself and every other accepted form. This is the single most
+  likely way to get a mysterious compile error or a silently wrong overload.
+
+- **Prefer an explicit `std::initializer_list<DynArray<T>>` constructor.** In
+  braced initialisation an `initializer_list` constructor wins over everything
+  else, so relying on a `vector<DynArray<T>>` constructor to catch braces is a
+  trap — the `initializer_list` form must exist, and the `vector` form is the
+  runtime-built sibling, not a substitute.
+
+- **Define `{}` and `{x}` deliberately.** `{}` must mean *the empty list*, not a
+  default-constructed `T` — say so and test it. `{x}` is ambiguous between "a
+  one-element list containing `x`" and "the single item `x`"; the two flatten
+  identically, so pick one reading, document it, and make sure the overload set
+  actually produces it rather than leaving it to whichever constructor happened
+  to be a better match.
+
+## `forEach`
+
+```
+forEach(collection, keyFn, delegate) -> DynArray<U>
+```
+
+`forEach` is the producer of structural dynamism, and the replacement for the
+`Collection` / `DataSource` / `dataBind` plumbing.
+
+**collection** accepts `std::vector<T>`, `AnySignal<std::vector<T>>`, an
+initializer list, or the existing `Collection<T>`.
+
+**keyFn** maps an item to a key. The key must be usable in `std::map`, i.e.
+ordered and comparable — `std::map` is the internal store, chosen for simplicity
+over a hash map (no hash requirement on user keys, no `std::hash`
+specialisations to write).
+
+**delegate** is `(AnySignal<T>) -> U`, and that is the **only** form.
+A `(T) -> U` shorthand was considered and deliberately rejected; the *Rationale*
+section is that argument, and it is the most important part of this document.
+
+### Behaviour
+
+- **The delegate is invoked only when a new id is introduced.** It is never
+  re-invoked because a value changed — a value change arrives through the
+  `AnySignal<T>` the delegate already holds. This is the whole point.
+- **The delegate is the last parameter** so it can be defaulted when only keying
+  is wanted. *Wrinkle to settle:* with a signal-taking delegate, the identity
+  default gives `U = AnySignal<T>`, so the defaulted call yields
+  `DynArray<AnySignal<T>>` rather than `DynArray<T>`. That is defensible but not
+  obviously what a caller expects; decide at implementation time whether the
+  default flattens, or whether the defaulted overload is simply not offered.
+- **`keyFn` runs for every item whenever the array signal changes.** The
+  algorithm computes the new key set, drops the ids whose keys are absent, and
+  preserves the id for every key that is still present.
+- **A changed key means a new item.** The old key vanishes, so its id is evicted
+  and its item removed; the new key is new, so it gets a new id and the delegate
+  runs. This is a consequence of the rule above, not a separate one.
+- **Eviction is strict.** When an item disappears its key→id mapping is dropped
+  immediately; the resulting `DynArray` is a strict 1:1 mapping of the source
+  array, with no lingering entries for items that might come back.
+- **Duplicate keys**: assert in debug. In release, tolerate gracefully — the
+  result may be suboptimal (an item may lose its identity and be rebuilt) but it
+  must not crash, corrupt the mapping, or drop items.
+
+### No index is passed to the delegate
+
+Deliberately. An index is *positional*, and position is exactly what keyed
+identity abandons. A delegate that closes over an index would have to re-run for
+every item whose position shifted — inserting at the front would rebuild the
+entire list, which is the behaviour `forEach` exists to avoid.
+
+Callers that genuinely need an index get a small helper that **injects indices
+upstream**, turning `AnySignal<vector<T>>` into `AnySignal<vector<pair<size_t,
+T>>>` before `forEach` sees it. With that comes a warning worth stating loudly:
+
+> **Key on the item's identity, not the injected index.** Keying on the index
+> makes every key change when the list reorders, which discards every id and
+> rebuilds everything — precisely the failure mode indices were avoiding.
+
+### Skipping repeats is a property of the data, not a requirement on `T`
+
+`bq::signal::Signal` already has the facility: **`tryCheck()`**
+(`src/bq/include/bq/signal/signal.h:114` and `:133`), with the strict sibling
+**`check()`** (`:128`), implemented by the `Check` node
+(`src/bq/include/bq/signal/check.h`).
+
+The semantics, verified:
+
+- `check()` exists **only** when the signal's value type is equality-comparable
+  (`btl::IsEqualityComparable`, `src/btl/include/btl/typetraits.h:78`); calling
+  it on a non-comparable type is a hard "no member named `check`" error.
+- `tryCheck()` exists always. When the type is comparable it *is* `check()`;
+  when it is not, it is a **silent passthrough** returning an equivalent signal
+  with no `Check` node inserted — no SFINAE failure, no diagnostic.
+- What `Check` suppresses is the **change notification**, not the value: its
+  `update()` downgrades the inner signal's `didChange` to `false` when the newly
+  evaluated value compares equal to the cached one
+  (`src/bq/include/bq/signal/check.h:44`). `nextUpdate` passes through.
+- Comparison of a multi-value `SignalResult<Ts...>` is **all-or-nothing**, not
+  per element (`src/bq/include/bq/signal/signalresult.h:117`): the trait is true
+  only if every `T` is comparable, and a change in any element propagates all of
+  them.
+
+So "skip repeated values" is opt-in at the point of use, via `.tryCheck()` on
+the per-item signal, and it degrades to a no-op rather than a compile error for
+types without `operator==`. `forEach` therefore imposes **no `operator==`
+requirement on `T`** — it neither calls `tryCheck()` on the caller's behalf nor
+demands comparability. Note also that `tryCheck()` on a non-comparable type is
+*silently* a no-op, which is a usability trap in its own right: a caller who
+adds `.tryCheck()` expecting deduplication gets nothing and no warning. Worth a
+Doxygen note on `tryCheck` when this lands.
+
+## What this supersedes
+
+The existing pipeline, and what `forEach` does instead:
+
+**`Collection<T>`** (`src/bqui/include/bqui/collection.h:196`) is a mutable,
+lock-guarded container whose writer API (`pushBack`, `update`, `erase`, `swap`,
+`move`, `sort` — `collection.h:307-461`) mutates the vector under a spin lock and
+synchronously invokes registered callbacks. Each item's `size_t` id is the
+address of its heap-allocated value —
+`reinterpret_cast<size_t>(iter_->ptr())` (`collection.h:138-141`) — which is
+stable across reallocation but **not reproducible between runs**. That is
+another argument for a scoped allocator with dense, deterministic ids: a test
+can assert on the id set. `forEach` accepts a `Collection<T>` directly, so it
+stays useful as a *source*; what goes away is its role as the only entry point
+to a dynamic list.
+
+**`DataSource<T>`** (`src/bqui/include/bqui/datasource.h:13`) is the event
+protocol between the two: an `evaluate` function returning the current
+`vector<pair<size_t, T>>` plus a stream of
+`variant<Insert, Update, Erase, Swap, Move, Refresh>` (`datasource.h:53-56`).
+**`dataSourceFromCollection`** (`src/bqui/include/bqui/datasourcefromcollection.h:11`)
+is the only adapter into it. `forEach` needs no such protocol: it diffs key sets
+from the array signal, so any `AnySignal<vector<T>>` is a source, and the six
+event kinds collapse into one code path.
+
+**`dataBind`** (`src/bqui/include/bqui/databind.h:22`) is `forEach` specialised
+to `DataSource` and hard-wired to `AnyWidget`. It returns exactly the flattened
+shape (`databind.h:22`). `forEach` is the same operator with the delegate
+generalised to any `U`, the source generalised past `DataSource`, and the
+identity supplied by a key function instead of by the collection.
+
+**`dynamicBox`** (`src/bqui/include/bqui/dynamicbox.h:23`, the implementation
+behind `hbox`/`vbox` — `src/bqui/src/widget/hbox.cpp:18`,
+`src/bqui/src/widget/vbox.cpp:20`) consumes that flattened signal. It keeps its
+job: `DynArray<AnyWidget>` flattens to the very signal it already takes, so it
+needs at most an overload. What it should shed is its build-cache (below).
+
+Existing callers are `src/bqui/test/databindtest.cpp:18` and
+`src/testapp1/adder.cpp:84`; both are `Collection` → `dataSourceFromCollection`
+→ `dataBind` → `vbox`, and both become a single `forEach`.
+
+## Rationale: why the delegate must take a signal
+
+A `(T) -> U` delegate is the obvious ergonomic shorthand, and every list API
+that has one eventually wants "rebuild the item when its value changes, but
+preserve state when the new structure matches the old." That is what we are
+rejecting. It is not a matter of taste — it is infeasible in this architecture,
+and the failure mode of approximating it is silent data corruption.
+
+### Rebuilding mints new identities, and state is keyed by identity
+
+A widget rebuild walks `Widget → Builder → Element → Instance`
+(`docs/architecture.md`) and constructs **new signal control blocks** along the
+way. Those controls mint a `btl::UniqueId` **in their own constructor**, from a
+global counter:
+
+- `InputControl`'s constructor: `id_(makeUniqueId())`
+  (`src/bq/include/bq/signal/input.h:19`).
+- `SharedControl`'s constructor: `id_(makeUniqueId())`
+  (`src/bq/include/bq/signal/sharedcontrol.h:142`).
+- `bq::signal::makeUniqueId` is a monotonically increasing global atomic
+  (`src/bq/src/signal/datacontext.cpp:7-11`).
+
+Per-context state is looked up by exactly that id:
+`InputSignal::initialize` calls `context.findData<ContextDataType>(control_->id_)`
+and, on a miss, creates fresh state (`src/bq/include/bq/signal/input.h:126-131`);
+`SharedControl::initialize` does the same (`sharedcontrol.h:148-154`).
+`DataContext::findData` is a plain map lookup keyed by `DataId = btl::UniqueId`
+(`src/bq/include/bq/signal/datacontext.h:79-100`).
+
+So: **a new control block is a new id is a miss in `findData` is fresh state.**
+State is keyed by object identity, and rebuilding destroys that identity by
+construction. This is not an oversight to be patched; it is how the context
+works.
+
+### Rebuilding inside the same `SignalContext` does not help
+
+The tempting fix is "rebuild, but in the same context, so the state is still
+there." It does not work, and there is already a live demonstration.
+
+`dynamicBox` rebuilds its children inside a `.map()` — `std::move(widget.second)(params)`
+invokes each child's whole build function (`src/bqui/include/bqui/dynamicbox.h:35`).
+That map node is created **once**, when `WindowGlue` constructs its
+`SignalContext` (`src/bqui/src/app.cpp:81-84`, member declared at `:438-439`),
+and that context lives for the entire run — it is pumped once per frame at
+`app.cpp:269` and torn down only at `app.cpp:509`. So every list change
+re-executes the build inside the *same*, never-reinitialised context, and the
+rebuilt children still get fresh state. The context is shared; the *ids* are
+not, because the rebuild constructed new controls.
+
+### Most state is not in the `DataContext` at all
+
+`DataContext` holds only the state of id-bearing nodes (inputs, shared nodes).
+The state of every ordinary combinator — `map`, `merge`, `withPrevious`, and the
+`iterate` fold that turns a stream into a signal — lives in the **`DataType`
+tree**, a plain nested struct hierarchy owned by the `SignalContext`:
+
+- `Map::DataType` is `{ typename TSignal::DataType signalData; ... }` — the
+  child's `DataType` embedded by value (`src/bq/include/bq/signal/map.h:23-32`),
+  built by `initialize()` recursing into the child (`map.h:40-43`).
+- `WithPrevious::DataType` holds the fold's running value (`currentResult`,
+  `hasPrevious`) alongside the child's data
+  (`src/bq/include/bq/signal/withprevious.h:59-78`).
+- `SignalContext` builds that whole tree **once**, in its constructor, and owns
+  it as `std::tuple<SignalDataTypeT<TSignals>...> data_`
+  (`src/bq/include/bq/signal/signalcontext.h:41-43`, `:76-81`, `:124`).
+
+That tree has no ids. It is addressed **positionally**, by the shape of the
+`initialize()` recursion. It is created with the signal and dies with it. So
+even a hypothetical id-preserving rebuild would still reset every `map` cache,
+every `withPrevious`, and every `iterate` fold in the item's subgraph.
+
+### Therefore structural matching is not just hard — it is wrong
+
+"Preserve state when the structure matches" needs a key derived from the shape
+of the signal graph. Two different items in a list produce *structurally
+identical* graphs by design — that is what makes them a list. So a structural
+key **collides**, and the consequence is not a rebuild, it is **silent
+mis-association**: widget A's text and cursor position appearing inside widget B
+after a reorder.
+
+Streams are the worst case. An `iterate` fold and the `pipe` feeding it are
+separate nodes; nothing guarantees they are preserved or recreated together, so
+a structural match can preserve one and recreate the other — a fold reading from
+a pipe that no longer feeds it. The type check in `findData`
+(`datacontext.h:87-93`) does not save this: it only catches collisions between
+*differently*-typed data, and same-shaped list items are the same type by
+construction.
+
+Silently attaching one item's state to another is worse than rebuilding. So the
+delegate takes a signal, is invoked once per identity, and the question never
+arises.
+
+### The pattern already exists
+
+`forEach` is not a new idea in this codebase; it is a generalisation of what the
+existing machinery already does by hand.
+
+**`dataBind` already builds each item's widget exactly once.** On the initial
+evaluation and on every `Insert` it creates a per-item `makeInput<T>` and calls
+`delegate(input.signal, id)`, storing the resulting widget together with the
+input's handle (`src/bqui/include/bqui/databind.h:48-53`, `:69-77`). A later
+`Update` does **not** call the delegate — it finds the item by id and pushes the
+new value through that stored handle: `i->valueHandle.set(std::move(update.value))`
+(`databind.h:83-91`). `Erase`, `Swap`, `Move`, and `Refresh` only reorder or
+drop entries (`databind.h:93-187`); none of them rebuilds. The final `.map()`
+projects the state to `vector<pair<size_t, AnyWidget>>` (`databind.h:199-209`).
+
+That is the signal-taking delegate, hand-rolled: build once per identity, push
+values through a handle, never rebuild.
+
+**`dynamicBox` caches the built element by item id.** Its `withPrevious` fold
+keeps, for each id present in the new builder list, the element it built
+previously, and only constructs an element for ids it has not seen
+(`src/bqui/include/bqui/dynamicbox.h:104-159` — the `prev.first == id` hit at
+`:116-120` reuses the old element and `continue`s at `:123`).
+
+`forEach` formalises exactly this pattern and moves it below the UI layer, where
+it works for any `U` rather than only for widgets.
+
+## Future directions (explicitly out of scope)
+
+**Widgets carry no identity field.** `Widget`, `Builder`, and `Element` have no
+identity of their own. Even with a per-item key from `forEach`, a delegate that
+conditionally swaps subtree shapes — "show a text field when editing, a label
+otherwise" — cannot express "the text field in branch A is the same text field
+as in branch B." Threading identity through the widget chain is the sound route
+to SwiftUI-style state preservation, and is strictly better than structural
+matching because the identity is *declared* rather than inferred. Out of scope
+here; noted so the option stays visible.
+
+**`dynamicBox` wastes work.** Its two stages disagree. Stage 1 (widget →
+builder, `dynamicbox.h:28-40`) re-invokes **every** child's build function on
+**every** list change, allocating throwaway inputs, pipes, and ids. Stage 2
+(builder → element, `dynamicbox.h:104-159`) then caches by id, so for every
+pre-existing item the builder stage 1 just produced is dropped unused at the
+`continue` on `dynamicbox.h:123-124`. The cache makes `dynamicBox` *correct*,
+not *cheap*: one insert costs an O(n) build-and-discard. `.share()`
+(`dynamicbox.h:40`) bounds it to once per changed frame, but not per changed
+item. Worth cleaning up when this area is reworked; `forEach` removes the reason
+for the pattern entirely. (Related, and cheap to fix while there: the per-id
+`hints` signal at `dynamicbox.h:55-72` is computed, `.share()`d, and never used.)
+
+**PR #99 (dynamic windows)** is open, and makes `App`'s window list
+`AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
+stable id. It is expected to be reworked onto `DynArray<Window>`, with `App`
+owning the id allocator.
+
+## Open questions
+
+Points the design does not yet settle. Flagged rather than guessed.
+
+- **The defaulted delegate's return type.** As noted above, defaulting a
+  `(AnySignal<T>) -> U` delegate to identity yields `DynArray<AnySignal<T>>`,
+  not `DynArray<T>`. Decide whether to flatten, to require the delegate, or to
+  offer the default only where `DynArray<AnySignal<T>>` is what the consumer
+  wants.
+- **`{x}` — one-element list or single item?** They flatten identically, so the
+  choice is about which constructor wins and what the error messages say. Pick
+  one and write the test.
+- **Where the id allocator is threaded.** "Owned by the consumer" is clear for
+  `App`, but a `DynArray<T>` is constructed *before* it reaches a consumer, and
+  nested `DynArray`s are constructed before their parent. Either flattening —
+  not construction — assigns ids (the allocator is a parameter of `flatten`), or
+  construction needs an ambient allocator. The first is cleaner and is the
+  assumption the rest of this document makes; confirm it survives contact with
+  `forEach`, which must remember key→id across flattens and therefore needs
+  somewhere durable to keep that map.
+- **Where `forEach`'s key→id map lives.** It is per-`forEach`-node state that
+  must survive across updates, which in this architecture means a `DataType` in
+  the `SignalContext` or a control block with an id. Which one is not decided,
+  and it interacts with the previous point.
+- **Duplicate-key tolerance is under-specified.** "Suboptimal but not
+  catastrophic" needs a concrete rule — e.g. first occurrence wins the id,
+  subsequent duplicates get fresh ids each flatten (and therefore rebuild).
+  State the rule so the release behaviour is testable rather than accidental.
+- **Whether `Collection<T>` and `DataSource<T>` are removed or kept.** `forEach`
+  supersedes the *plumbing*; `Collection` remains a reasonable mutable source.
+  Note that `Collection`'s ids are pointer values, so a `Collection` source must
+  either feed its ids through as keys or be keyed on item content.
+
+## Implementation order
+
+Two commits, in this order:
+
+1. **`DynArray<T>` core** — the type, its constructors, the tree, flattening,
+   and the scoped id allocator. Independently useful: `App::windows` can consume
+   it before `forEach` exists.
+2. **`forEach`** — the keyed operator on top, plus the retirement path for
+   `dataBind` / `dataSourceFromCollection` / `dynamicBox`'s caching layer.

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -1,6 +1,6 @@
 # bq — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `2c6969c` (2026-07-20).*
 
 Internals, entry points, and traps for the reactive core. Concepts and usage are
 in `readme.md`; project-wide conventions are in the top-level `docs/`. This file
@@ -40,6 +40,10 @@ folder here and leave one-line hooks below.
   `combine`/`join`/`conditional` (same folder). `constant` (`bq/signal/constant.h`).
 - Streams: `pipe` (`bq/stream/pipe.h`) → `{handle, stream}`, `handle.push`;
   `iterate` (`bq/stream/iterate.h`) folds a stream into a signal; `collect`.
+- Keyed collections: `ArraySignal<T>` (`bq/signal/arraysignal.h`) with
+  `forEach`/`map`/`concat`; `KeyedArraySignal<A>` with `extract`/`scatter`
+  (`bq/signal/arraysignallayout.h`, for container implementations only). Design
+  record: `docs/design/arraysignal.md`.
 
 ## Traps
 
@@ -48,6 +52,15 @@ folder here and leave one-line hooks below.
   even found by ADL. Build a no-input signal as a `constant` instead. The
   principled fix would be a `signal<void>` identity element for `merge` — see
   `docs/decisions.md`.
+
+- **`Join` re-initialises its inner signal whenever the outer changes**
+  (`bq/signal/join.h`, in `update`). Everything below it that keeps state in the
+  positional `DataType` tree — `map` caches, `withPrevious`, `iterate` folds —
+  starts over. Anything that must survive has to sit under a `.share()`, because
+  `SharedControl` keys its state by a `btl::UniqueId` in the `DataContext` and so
+  re-finds it. This is why every per-identity signal in `arraysignal.h` is
+  shared; the failure mode without it is that inserting one list element silently
+  resets every sibling.
 
 For cross-cutting rules (the `Any` = type-erasure convention, the include-dir
 firewall, symbol visibility) see `docs/conventions.md`; do not restate them here.

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -1,0 +1,634 @@
+#pragma once
+
+#include "combine.h"
+#include "constant.h"
+#include "join.h"
+#include "merge.h"
+#include "signal.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace bq::signal
+{
+    template <typename T>
+    class ArraySignal;
+
+    namespace detail
+    {
+        /** @brief The identity space of one ArraySignal.
+         *
+         * Constructed together with the ArraySignal that owns it. Ids are
+         * unique within one space and mean nothing outside it, and composing
+         * two arrays keeps their spaces distinct — which is what makes their
+         * ids distinct without any shared counter.
+         */
+        class ArrayIdSpace
+        {
+        public:
+            uint64_t allocate()
+            {
+                return next_.fetch_add(1, std::memory_order_relaxed);
+            }
+
+        private:
+            std::atomic<uint64_t> next_{ 1 };
+        };
+    } // namespace detail
+
+    /** @brief The identity of one element of one ArraySignal.
+     *
+     * Ids never reach user code: they are minted by an ArraySignal and matched
+     * within it. An id is equality-comparable and orderable so that it can be
+     * used as a map key; nothing else about it is meaningful, and in particular
+     * its ordering says nothing about element order.
+     */
+    class ArrayId
+    {
+    public:
+        ArrayId() = default;
+
+        ArrayId(std::shared_ptr<detail::ArrayIdSpace> space, uint64_t index) :
+            space_(std::move(space)),
+            index_(index)
+        {
+        }
+
+        bool operator==(ArrayId const& rhs) const
+        {
+            return index_ == rhs.index_ && space_ == rhs.space_;
+        }
+
+        bool operator!=(ArrayId const& rhs) const
+        {
+            return !(*this == rhs);
+        }
+
+        bool operator<(ArrayId const& rhs) const
+        {
+            if (space_ != rhs.space_)
+                return std::less<void const*>()(space_.get(), rhs.space_.get());
+
+            return index_ < rhs.index_;
+        }
+
+    private:
+        std::shared_ptr<detail::ArrayIdSpace> space_;
+        uint64_t index_ = 0;
+    };
+
+    namespace detail
+    {
+        /** @brief One realised element: its identity and its value over time.
+         *
+         * An element that survives a membership change keeps both — in
+         * particular the very same value signal object, so anything an operator
+         * built on that signal keeps its state.
+         *
+         * Two elements are equal when they have the same identity; the value is
+         * not part of the comparison. That makes an element sequence
+         * equality-comparable, so `tryCheck()` on it suppresses a change
+         * notification exactly when membership is unchanged.
+         */
+        template <typename T>
+        struct ArrayElement
+        {
+            ArrayId id;
+            AnySignal<T> value;
+
+            bool operator==(ArrayElement const& rhs) const
+            {
+                return id == rhs.id;
+            }
+
+            bool operator!=(ArrayElement const& rhs) const
+            {
+                return id != rhs.id;
+            }
+        };
+
+        template <typename T>
+        using ArrayElements = std::vector<ArrayElement<T>>;
+
+        /** @brief Applies a function once per identity and caches the result.
+         *
+         * This is the shared primitive under `map`, `forEach`, `extract` and
+         * `scatter`. The cache is keyed by identity rather than by position, so
+         * a sibling insertion or a reorder does not disturb it. An entry is
+         * evicted when its id leaves the array, and a re-appearing id is a new
+         * item that is built again.
+         *
+         * The cache lives with the operator rather than in a SignalContext,
+         * because everything it holds is an immutable description — a signal,
+         * or a value the delegate built. It is mutex-guarded because a signal
+         * may be evaluated from any thread.
+         */
+        template <typename T, typename U, typename TFunc>
+        class OncePerId
+        {
+        public:
+            OncePerId(TFunc func) :
+                func_(std::move(func))
+            {
+            }
+
+            ArrayElements<U> apply(ArrayElements<T> const& elements)
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                ArrayElements<U> result;
+                result.reserve(elements.size());
+
+                std::set<ArrayId> live;
+                for (auto const& element : elements)
+                {
+                    auto i = cache_.find(element.id);
+                    if (i == cache_.end())
+                    {
+                        i = cache_.emplace(element.id,
+                                func_(element.id, element.value)).first;
+                    }
+
+                    live.insert(element.id);
+                    result.push_back({ element.id, i->second });
+                }
+
+                for (auto i = cache_.begin(); i != cache_.end();)
+                    i = live.count(i->first) ? std::next(i) : cache_.erase(i);
+
+                return result;
+            }
+
+        private:
+            std::mutex mutex_;
+            std::map<ArrayId, AnySignal<U>> cache_;
+            TFunc func_;
+        };
+
+        /** @brief Runs `func` once per identity over an element signal. */
+        template <typename U, typename T, typename TFunc>
+        AnySignal<ArrayElements<U>> mapElementsOnce(
+                AnySignal<ArrayElements<T>> elements, TFunc func)
+        {
+            auto once = std::make_shared<OncePerId<T, U, TFunc>>(
+                    std::move(func));
+
+            return elements.map([once](ArrayElements<T> const& es)
+                {
+                    return once->apply(es);
+                });
+        }
+
+        /** @brief Fans the element values in, discarding identity. */
+        template <typename T>
+        AnySignal<std::vector<T>> flattenValues(
+                AnySignal<ArrayElements<T>> elements)
+        {
+            return elements
+                .map([](ArrayElements<T> const& es)
+                    {
+                        std::vector<AnySignal<T>> sigs;
+                        sigs.reserve(es.size());
+                        for (auto const& element : es)
+                            sigs.push_back(element.value);
+
+                        return AnySignal<std::vector<T>>(
+                                combine(std::move(sigs)));
+                    })
+                .join();
+        }
+
+        /** @brief A source vector re-expressed as keyed entries.
+         *
+         * `order` is the source order; `byEntry` is the lookup a per-item
+         * signal uses to find its own value. The entry is the caller's key
+         * paired with its occurrence index, which is zero for every key unless
+         * the caller supplied duplicates.
+         */
+        template <typename TKey, typename T>
+        struct KeyedSource
+        {
+            using Entry = std::pair<TKey, size_t>;
+
+            std::vector<Entry> order;
+            std::map<Entry, T> byEntry;
+        };
+
+        template <typename T>
+        struct IsArraySignal : std::false_type
+        {
+        };
+
+        template <typename T>
+        struct IsArraySignal<ArraySignal<T>> : std::true_type
+        {
+        };
+
+        template <typename T>
+        struct IsAnySignal : std::false_type
+        {
+        };
+
+        template <typename... Ts>
+        struct IsAnySignal<AnySignal<Ts...>> : std::true_type
+        {
+        };
+    } // namespace detail
+
+    /** @brief An immutable description of a list whose contents and membership
+     * may both change over time.
+     *
+     * An ArraySignal is a value, not a container: it has no mutating
+     * operations, and dynamism reaches it from upstream. Each element carries
+     * an identity, which is what lets an operator build something once per item
+     * and keep it across insertions, removals and reorderings of its siblings.
+     *
+     * Every accepted source converts to an ArraySignal, so a braced list of
+     * them is itself one and nesting needs no special case in a consumer:
+     *
+     * @code
+     * ArraySignal<int> values = { 1, 2, someSignal, otherArray };
+     * @endcode
+     *
+     * `{}` is the empty list, and `{x}` is a one-element list — which exports
+     * the same sequence as the single item `x` would.
+     *
+     * The type is type-erased by construction and has no storage-typed twin;
+     * there is deliberately no `AnyArraySignal`.
+     */
+    template <typename T>
+    class ArraySignal
+    {
+    public:
+        using ElementsSignal = AnySignal<detail::ArrayElements<T>>;
+
+        /** @brief Constructs the empty list. */
+        ArraySignal() :
+            ArraySignal(ElementsSignal(constant(detail::ArrayElements<T>())))
+        {
+        }
+
+        /** @brief Constructs a list of children, flattened in order. */
+        ArraySignal(std::initializer_list<ArraySignal<T>> children) :
+            ArraySignal(std::vector<ArraySignal<T>>(children))
+        {
+        }
+
+        /** @overload */
+        ArraySignal(std::vector<ArraySignal<T>> children) :
+            ArraySignal(concatElements(std::move(children)))
+        {
+        }
+
+        /** @brief Constructs a fixed list of constant items. */
+        ArraySignal(std::vector<T> values) :
+            ArraySignal(constantElements(std::move(values)))
+        {
+        }
+
+        /** @brief Constructs a single item whose value varies over time. */
+        ArraySignal(AnySignal<T> value) :
+            ArraySignal(singleElement(std::move(value)))
+        {
+        }
+
+        /** @brief Constructs a varying list of items.
+         *
+         * Identity here is positional — item *k* is item *k* for as long as the
+         * list is at least that long, and a shorter list evicts the tail. Key
+         * the items with `forEach` instead when the list reorders.
+         */
+        ArraySignal(AnySignal<std::vector<T>> values) :
+            ArraySignal(positionalElements(std::move(values)))
+        {
+        }
+
+        /** @brief Constructs a single constant item. */
+        template <typename U, typename = std::enable_if_t<
+            std::is_convertible_v<U, T>
+            && !detail::IsArraySignal<std::decay_t<U>>::value
+            && !detail::IsAnySignal<std::decay_t<U>>::value
+            >>
+        ArraySignal(U&& value) :
+            ArraySignal(singleElement(AnySignal<T>(
+                            constant(T(std::forward<U>(value))))))
+        {
+        }
+
+        /** @brief Transforms every element's value.
+         *
+         * Value-level: `func` is re-run whenever an element's value changes,
+         * inside a graph node that is built once per identity. Do not construct
+         * anything stateful here — a widget built in `map` is rebuilt, and
+         * loses whatever it was holding, on every value change. Build in
+         * `forEach` instead.
+         */
+        template <typename TFunc>
+        auto map(TFunc func) const
+        {
+            using U = std::decay_t<std::invoke_result_t<TFunc, T const&>>;
+
+            return ArraySignal<U>::fromElements(detail::mapElementsOnce<U>(
+                        elements_,
+                        [func](ArrayId const&, AnySignal<T> const& value)
+                        {
+                            return AnySignal<U>(value.map(func).share());
+                        }));
+        }
+
+        /** @brief Keys the elements and builds one result per key.
+         *
+         * Identity-level: `delegate` receives the item's value as a signal and
+         * is invoked once per key. It is not re-invoked when the item's value
+         * changes — the new value arrives through the signal the delegate
+         * already holds — so nothing the delegate built is destroyed by a value
+         * change. This is what preserves the state of what was built.
+         *
+         * `keyFn` runs for every item on every change. A changed key is a new
+         * item: the old key's result is destroyed and the new key's is built.
+         *
+         * Duplicate keys assert in debug. In release each occurrence of a
+         * repeated key gets its own identity, in order of appearance, so
+         * nothing is dropped and nothing churns.
+         */
+        template <typename TKeyFunc, typename TDelegate>
+        auto forEach(TKeyFunc keyFn, TDelegate delegate) const;
+
+        /** @brief The identified elements.
+         *
+         * An operator's entry point into the array, not part of the
+         * caller-facing surface.
+         */
+        ElementsSignal const& elements() const
+        {
+            return elements_;
+        }
+
+        /** @brief Wraps an element signal an operator produced.
+         *
+         * Not part of the caller-facing surface.
+         */
+        static ArraySignal fromElements(ElementsSignal elements)
+        {
+            return ArraySignal(std::move(elements));
+        }
+
+    private:
+        explicit ArraySignal(ElementsSignal elements) :
+            elements_(std::move(elements).tryCheck().share())
+        {
+        }
+
+        static ElementsSignal singleElement(AnySignal<T> value)
+        {
+            auto space = std::make_shared<detail::ArrayIdSpace>();
+
+            detail::ArrayElements<T> elements;
+            elements.push_back({ ArrayId(space, space->allocate()),
+                    std::move(value) });
+
+            return constant(std::move(elements));
+        }
+
+        static ElementsSignal constantElements(std::vector<T> values)
+        {
+            auto space = std::make_shared<detail::ArrayIdSpace>();
+
+            detail::ArrayElements<T> elements;
+            for (auto& value : values)
+            {
+                elements.push_back({ ArrayId(space, space->allocate()),
+                        AnySignal<T>(constant(std::move(value))) });
+            }
+
+            return constant(std::move(elements));
+        }
+
+        static ElementsSignal positionalElements(
+                AnySignal<std::vector<T>> values)
+        {
+            struct State
+            {
+                std::mutex mutex;
+                std::shared_ptr<detail::ArrayIdSpace> space =
+                    std::make_shared<detail::ArrayIdSpace>();
+                detail::ArrayElements<T> byPosition;
+            };
+
+            auto state = std::make_shared<State>();
+            auto source = AnySignal<std::vector<T>>(values.share());
+
+            return source
+                .map([](std::vector<T> const& current)
+                    {
+                        return current.size();
+                    })
+                .tryCheck()
+                .merge(source)
+                .map([state, source](size_t size,
+                            std::vector<T> const& current)
+                    {
+                        std::lock_guard<std::mutex> lock(state->mutex);
+
+                        while (state->byPosition.size() < size)
+                        {
+                            size_t const index = state->byPosition.size();
+                            T initial = current[index];
+
+                            auto value = AnySignal<T>(source
+                                    .map([index, initial](
+                                                std::vector<T> const& v) -> T
+                                        {
+                                            return index < v.size()
+                                                ? v[index] : initial;
+                                        })
+                                    .share());
+
+                            state->byPosition.push_back({
+                                    ArrayId(state->space,
+                                            state->space->allocate()),
+                                    std::move(value) });
+                        }
+
+                        return detail::ArrayElements<T>(
+                                state->byPosition.begin(),
+                                state->byPosition.begin()
+                                + static_cast<ptrdiff_t>(size));
+                    });
+        }
+
+        static ElementsSignal concatElements(
+                std::vector<ArraySignal<T>> children)
+        {
+            std::vector<AnySignal<detail::ArrayElements<T>>> sigs;
+            sigs.reserve(children.size());
+            for (auto const& child : children)
+                sigs.push_back(child.elements());
+
+            return combine(std::move(sigs))
+                .map([](std::vector<detail::ArrayElements<T>> const& groups)
+                    {
+                        detail::ArrayElements<T> result;
+                        for (auto const& group : groups)
+                        {
+                            result.insert(result.end(), group.begin(),
+                                    group.end());
+                        }
+
+                        return result;
+                    });
+        }
+
+        ElementsSignal elements_;
+    };
+
+    /** @brief Keys a changing list and builds one result per key.
+     *
+     * The entry into the ArraySignal domain, and the only operation other than
+     * constructing a single item that mints identity. See
+     * `ArraySignal::forEach` for the semantics of `keyFn` and `delegate`.
+     */
+    template <typename T, typename TKeyFunc, typename TDelegate>
+    auto forEach(AnySignal<std::vector<T>> source, TKeyFunc keyFn,
+            TDelegate delegate)
+    {
+        using Key = std::decay_t<std::invoke_result_t<TKeyFunc, T const&>>;
+        using Keyed = detail::KeyedSource<Key, T>;
+        using Entry = typename Keyed::Entry;
+        using U = std::decay_t<std::invoke_result_t<TDelegate, AnySignal<T>>>;
+
+        auto keyed = AnySignal<Keyed>(source
+                .map([keyFn](std::vector<T> const& values)
+                    {
+                        Keyed result;
+                        std::map<Key, size_t> seen;
+
+                        for (auto const& value : values)
+                        {
+                            Key key = keyFn(value);
+                            size_t const occurrence = seen[key]++;
+                            assert(occurrence == 0
+                                    && "forEach: duplicate key");
+
+                            Entry entry(std::move(key), occurrence);
+                            result.byEntry.emplace(entry, value);
+                            result.order.push_back(std::move(entry));
+                        }
+
+                        return result;
+                    })
+                .share());
+
+        struct State
+        {
+            std::mutex mutex;
+            std::shared_ptr<detail::ArrayIdSpace> space =
+                std::make_shared<detail::ArrayIdSpace>();
+            std::map<Entry, detail::ArrayElement<T>> items;
+        };
+
+        auto state = std::make_shared<State>();
+
+        auto elements = AnySignal<detail::ArrayElements<T>>(
+                keyed.map([state, keyed](Keyed const& current)
+                    {
+                        std::lock_guard<std::mutex> lock(state->mutex);
+
+                        detail::ArrayElements<T> result;
+                        result.reserve(current.order.size());
+
+                        for (auto const& entry : current.order)
+                        {
+                            auto i = state->items.find(entry);
+                            if (i == state->items.end())
+                            {
+                                T initial = current.byEntry.at(entry);
+
+                                auto value = AnySignal<T>(keyed
+                                        .map([entry, initial](
+                                                    Keyed const& now) -> T
+                                            {
+                                                auto j = now.byEntry.find(
+                                                        entry);
+                                                return j == now.byEntry.end()
+                                                    ? initial : j->second;
+                                            })
+                                        .share());
+
+                                i = state->items.emplace(entry,
+                                        detail::ArrayElement<T>{
+                                            ArrayId(state->space,
+                                                    state->space->allocate()),
+                                            std::move(value) }).first;
+                            }
+
+                            result.push_back(i->second);
+                        }
+
+                        for (auto i = state->items.begin();
+                                i != state->items.end();)
+                        {
+                            i = current.byEntry.count(i->first)
+                                ? std::next(i) : state->items.erase(i);
+                        }
+
+                        return result;
+                    }));
+
+        return ArraySignal<U>::fromElements(detail::mapElementsOnce<U>(
+                    std::move(elements),
+                    [delegate](ArrayId const&, AnySignal<T> const& value)
+                    {
+                        return AnySignal<U>(constant(delegate(value)));
+                    }));
+    }
+
+    /** @overload */
+    template <typename T, typename TKeyFunc, typename TDelegate>
+    auto forEach(std::vector<T> source, TKeyFunc keyFn, TDelegate delegate)
+    {
+        return forEach(AnySignal<std::vector<T>>(constant(std::move(source))),
+                std::move(keyFn), std::move(delegate));
+    }
+
+    template <typename T>
+    template <typename TKeyFunc, typename TDelegate>
+    auto ArraySignal<T>::forEach(TKeyFunc keyFn, TDelegate delegate) const
+    {
+        return signal::forEach(detail::flattenValues(elements_),
+                std::move(keyFn), std::move(delegate));
+    }
+
+    /** @brief Concatenates arrays, preserving order and every identity.
+     *
+     * The children keep their own identity spaces, so their ids stay distinct
+     * without being rewritten. With the empty array as its identity element
+     * this is a monoid, which is the same statement as `{a, {b, c}}` and
+     * `{a, b, c}` exporting the same list.
+     */
+    template <typename T>
+    ArraySignal<T> concat(std::vector<ArraySignal<T>> arrays)
+    {
+        return ArraySignal<T>(std::move(arrays));
+    }
+
+    /** @overload */
+    template <typename T, typename... Ts>
+    ArraySignal<T> concat(ArraySignal<T> first, Ts&&... rest)
+    {
+        return concat(std::vector<ArraySignal<T>>{ std::move(first),
+                ArraySignal<T>(std::forward<Ts>(rest))... });
+    }
+} // namespace bq::signal

--- a/src/bq/include/bq/signal/arraysignallayout.h
+++ b/src/bq/include/bq/signal/arraysignallayout.h
@@ -1,0 +1,338 @@
+#pragma once
+
+#include "arraysignal.h"
+#include "combine.h"
+#include "constant.h"
+#include "join.h"
+#include "merge.h"
+#include "signal.h"
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+/** @brief The fan-in / fan-out pair a container implementation needs.
+ *
+ * Everything here is for code that computes over a whole collection at once —
+ * a layout deciding where its children go — and hands each element its own
+ * share of the result. An ordinary caller reaching for `scatter` almost always
+ * wants `ArraySignal::map` instead.
+ *
+ * The separation is by header and namespace rather than by the include
+ * firewall: ArraySignal lives in `bq` and layouts live above it, so anything
+ * kept out of `bq`'s include directory would be unreachable from exactly the
+ * code that needs it. Writing the extra include is the declaration of intent.
+ */
+namespace bq::signal::layout
+{
+    /** @brief An element's identity as `mapKeyed` sees it.
+     *
+     * Opaque: comparable and orderable so it can be matched and stored, and
+     * meaningless otherwise. Nothing may be inferred from its value, from its
+     * ordering relative to another key, or from its stability across runs.
+     */
+    class ArrayKey
+    {
+    public:
+        explicit ArrayKey(ArrayId id) :
+            id_(std::move(id))
+        {
+        }
+
+        bool operator==(ArrayKey const& rhs) const
+        {
+            return id_ == rhs.id_;
+        }
+
+        bool operator!=(ArrayKey const& rhs) const
+        {
+            return id_ != rhs.id_;
+        }
+
+        bool operator<(ArrayKey const& rhs) const
+        {
+            return id_ < rhs.id_;
+        }
+
+        /** @brief The identity behind the key. Not for consumers of the key. */
+        ArrayId const& id() const
+        {
+            return id_;
+        }
+
+    private:
+        ArrayId id_;
+    };
+
+    /** @brief One value per element of an ArraySignal, with identity attached.
+     *
+     * Produced by `extract` and consumed by `scatter`. It is a sibling of
+     * ArraySignal, not a subtype: an ArraySignal is operated on per element,
+     * whereas a KeyedArraySignal is operated on as a whole vector, because that
+     * is what a layout computation needs. There is no `forEach` here, and that
+     * is deliberate.
+     *
+     * The alignment between the values and the elements they came from is
+     * carried by the type rather than by an assertion at the point of use:
+     * only something `extract` produced can be scattered back.
+     */
+    template <typename A>
+    class KeyedArraySignal
+    {
+    public:
+        using AggregateSignal = AnySignal<std::vector<ArrayId>,
+              std::vector<A>>;
+
+        /** @brief Wraps an aggregate an operator produced.
+         *
+         * Not part of the caller-facing surface.
+         */
+        static KeyedArraySignal fromSignal(AggregateSignal sig)
+        {
+            return KeyedArraySignal(std::move(sig));
+        }
+
+        /** @brief Computes over every element's value at once.
+         *
+         * `g` is called as `g(extras..., values)` — the ambient signals first,
+         * the per-element vector last — and must return one value per input
+         * value, positionally aligned with it. The input is the current
+         * membership, not the membership at the time the node was built. The
+         * size is asserted; the alignment cannot be checked and is the
+         * function's contract to keep. A computation that reorders or drops
+         * elements wants `mapKeyed` instead.
+         *
+         * `extras` are ambient signals injected alongside the vector — for a
+         * layout, the container's own size.
+         */
+        template <typename TFunc, typename... TExtras>
+        auto mapValues(TFunc g, TExtras... extras) const
+        {
+            using Result = std::decay_t<std::invoke_result_t<TFunc,
+                  SingleSignalTypeT<std::decay_t<TExtras>> const&...,
+                  std::vector<A> const&>>;
+            using B = typename Result::value_type;
+
+            auto sig = merge(sig_, std::move(extras)...)
+                .map([g](std::vector<ArrayId> const& ids,
+                            std::vector<A> const& values,
+                            auto const&... extraValues)
+                    {
+                        std::vector<B> result = g(extraValues..., values);
+                        assert(result.size() == values.size()
+                                && "mapValues: size must be preserved");
+
+                        return makeSignalResult(ids, std::move(result));
+                    });
+
+            return KeyedArraySignal<B>::fromSignal(std::move(sig));
+        }
+
+        /** @brief Computes over every element's value, carrying the key.
+         *
+         * `h` maps `vector<pair<ArrayKey, A>>` to `vector<pair<ArrayKey, B>>`
+         * and may reorder or drop entries. Identity is preserved for the keys
+         * `h` returns; the rest are dropped, and an element whose key is
+         * dropped disappears from a later `scatter`.
+         *
+         * Use this rather than `mapValues` whenever the computation needs to
+         * match values across a membership change — position does not survive
+         * an insertion or a reorder, so a fold that pairs the current vector
+         * with the previous one by position pairs different elements.
+         */
+        template <typename TFunc>
+        auto mapKeyed(TFunc h) const
+        {
+            using Result = std::decay_t<std::invoke_result_t<TFunc,
+                  std::vector<std::pair<ArrayKey, A>> const&>>;
+            using B = typename Result::value_type::second_type;
+
+            auto sig = sig_.map([h](std::vector<ArrayId> const& ids,
+                        std::vector<A> const& values)
+                {
+                    std::vector<std::pair<ArrayKey, A>> input;
+                    input.reserve(ids.size());
+                    for (size_t i = 0; i < ids.size(); ++i)
+                        input.emplace_back(ArrayKey(ids[i]), values[i]);
+
+                    auto output = h(input);
+
+                    std::vector<ArrayId> outIds;
+                    std::vector<B> outValues;
+                    outIds.reserve(output.size());
+                    outValues.reserve(output.size());
+                    for (auto& entry : output)
+                    {
+                        outIds.push_back(entry.first.id());
+                        outValues.push_back(std::move(entry.second));
+                    }
+
+                    return makeSignalResult(std::move(outIds),
+                            std::move(outValues));
+                });
+
+            return KeyedArraySignal<B>::fromSignal(std::move(sig));
+        }
+
+        /** @brief Leaves the domain, discarding identity.
+         *
+         * The one-way escape back to a plain signal. Entering the domain needs
+         * a key because only the caller knows what makes two items the same
+         * thing; leaving it needs nothing, because forgetting is free.
+         */
+        AnySignal<std::vector<A>> values() const
+        {
+            return sig_.map([](std::vector<ArrayId> const&,
+                        std::vector<A> const& values)
+                {
+                    return values;
+                });
+        }
+
+        /** @brief The identities and values together.
+         *
+         * An operator's entry point into the aggregate, not part of the
+         * caller-facing surface.
+         */
+        AggregateSignal const& sig() const
+        {
+            return sig_;
+        }
+
+    private:
+        explicit KeyedArraySignal(AggregateSignal sig) :
+            sig_(std::move(sig).share())
+        {
+        }
+
+        AggregateSignal sig_;
+    };
+
+    /** @brief Order-preserving fan-in: one signal per element, gathered.
+     *
+     * `f` is applied **once per identity**, so the per-element signal it
+     * returns is initialised once and thereafter merely updates. That is not an
+     * optimisation: it is what stops a sibling insertion from resetting every
+     * surviving element's state.
+     *
+     * `f` takes the element's value signal and returns the signal to gather.
+     * A plain `A(T)` is accepted too and is mapped over the element's value.
+     */
+    template <typename T, typename TFunc>
+    auto extract(ArraySignal<T> const& array, TFunc f)
+    {
+        constexpr bool takesSignal = std::is_invocable_v<TFunc, AnySignal<T>>;
+
+        auto perIdentity = [f](ArrayId const&, AnySignal<T> const& value)
+        {
+            if constexpr (takesSignal)
+                return AnySignal<SingleSignalTypeT<std::decay_t<
+                    std::invoke_result_t<TFunc, AnySignal<T>>>>>(
+                            f(value).share());
+            else
+                return AnySignal<std::decay_t<std::invoke_result_t<TFunc,
+                       T const&>>>(value.map(f).share());
+        };
+
+        using A = SingleSignalTypeT<std::decay_t<
+            std::invoke_result_t<decltype(perIdentity), ArrayId const&,
+            AnySignal<T> const&>>>;
+
+        auto sig = detail::mapElementsOnce<A>(array.elements(),
+                perIdentity)
+            .map([](detail::ArrayElements<A> const& elements)
+                {
+                    std::vector<ArrayId> ids;
+                    std::vector<AnySignal<A>> sigs;
+                    ids.reserve(elements.size());
+                    sigs.reserve(elements.size());
+                    for (auto const& element : elements)
+                    {
+                        ids.push_back(element.id);
+                        sigs.push_back(element.value);
+                    }
+
+                    return makeSignalResult(std::move(ids),
+                            AnySignal<std::vector<A>>(combine(
+                                    std::move(sigs))));
+                })
+            .join();
+
+        return KeyedArraySignal<A>::fromSignal(std::move(sig));
+    }
+
+    /** @brief Identity-matched fan-out: `map` with one extra argument.
+     *
+     * `f` receives the element's own value signal and the element's own share
+     * of the aggregate, and is applied once per identity — as is the matching
+     * itself, which happens when the identity appears rather than on every
+     * emission. An element whose identity is not in the aggregate (because
+     * `mapKeyed` dropped it) is absent from the result.
+     *
+     * The name is a mild deterrent by design: a caller who reaches for it
+     * usually wants `ArraySignal::map` and does not yet know it.
+     */
+    template <typename T, typename B, typename TFunc>
+    auto scatter(ArraySignal<T> const& array, KeyedArraySignal<B> const& keyed,
+            TFunc f)
+    {
+        using U = std::decay_t<std::invoke_result_t<TFunc, AnySignal<T>,
+              AnySignal<B>>>;
+
+        auto byId = AnySignal<std::map<ArrayId, B>>(keyed.sig()
+                .map([](std::vector<ArrayId> const& ids,
+                            std::vector<B> const& values)
+                    {
+                        std::map<ArrayId, B> result;
+                        for (size_t i = 0; i < ids.size(); ++i)
+                            result.emplace(ids[i], values[i]);
+
+                        return result;
+                    })
+                .share());
+
+        auto once = std::make_shared<detail::OncePerId<T, U,
+             std::function<AnySignal<U>(ArrayId const&,
+                     AnySignal<T> const&)>>>(
+                [f, byId](ArrayId const& id, AnySignal<T> const& value)
+                {
+                    auto slice = AnySignal<B>(byId
+                            .map([id](std::map<ArrayId, B> const& all) -> B
+                                {
+                                    auto i = all.find(id);
+                                    assert(i != all.end()
+                                            && "scatter: unmatched identity");
+                                    return i->second;
+                                })
+                            .share());
+
+                    return AnySignal<U>(constant(f(value, std::move(slice))));
+                });
+
+        auto elements = merge(array.elements(), keyed.sig())
+            .map([once](detail::ArrayElements<T> const& all,
+                        std::vector<ArrayId> const& ids,
+                        std::vector<B> const&)
+                {
+                    std::set<ArrayId> present(ids.begin(), ids.end());
+
+                    detail::ArrayElements<T> live;
+                    live.reserve(all.size());
+                    for (auto const& element : all)
+                    {
+                        if (present.count(element.id))
+                            live.push_back(element);
+                    }
+
+                    return once->apply(live);
+                });
+
+        return ArraySignal<U>::fromElements(std::move(elements));
+    }
+} // namespace bq::signal::layout

--- a/src/bq/include/bq/signal/join.h
+++ b/src/bq/include/bq/signal/join.h
@@ -14,18 +14,39 @@ namespace bq::signal
     template <typename T, typename... Ts>
     class Signal;
 
+    template <typename... Ts>
+    class AnySignal;
+
     namespace detail
     {
         template <typename T>
-        auto toSignal(T&& t)
+        struct IsSignalObject : std::false_type
         {
-            return constant(std::forward<T>(t));
-        }
+        };
 
         template <typename T, typename... Ts>
-        Signal<T, Ts...> toSignal(Signal<T, Ts...> sig)
+        struct IsSignalObject<Signal<T, Ts...>> : std::true_type
         {
-            return sig;
+        };
+
+        template <typename... Ts>
+        struct IsSignalObject<AnySignal<Ts...>> : std::true_type
+        {
+        };
+
+        // A signal passes through; anything else becomes a constant. This is
+        // one function rather than an overload pair because an AnySignal is
+        // derived from Signal, so an unconstrained forwarding overload would
+        // be the better match for it and would wrap a signal in a constant.
+        template <typename T>
+        auto toSignal(T&& t)
+        {
+            if constexpr (IsSignalObject<std::decay_t<T>>::value)
+                return std::forward<T>(t);
+            else if constexpr (IsSignal<std::decay_t<T>>::value)
+                return wrap(std::decay_t<T>(std::forward<T>(t)));
+            else
+                return constant(std::forward<T>(t));
         }
     } // anonymous namespace
 

--- a/src/bq/include/bq/signal/signal.h
+++ b/src/bq/include/bq/signal/signal.h
@@ -214,7 +214,7 @@ namespace bq::signal
 
         auto join() const
         {
-            return wrap(Join<TStorage>(Super::sig_));
+            return wrap(Join<StorageType>(Super::sig_));
         }
 
         Signal clone() const

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -17,6 +17,7 @@ libbqdep = declare_dependency(
   )
 
 bqtest = executable('bqtest',
+  'test/arraysignaltest.cpp',
   'test/signaltest.cpp',
   'test/signalcontexttest.cpp',
   'test/streamtest.cpp',

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -1,0 +1,661 @@
+#include <bq/signal/arraysignal.h>
+#include <bq/signal/arraysignallayout.h>
+
+#include <bq/signal/constant.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signalcontext.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace bq::signal;
+using bq::signal::layout::ArrayKey;
+using bq::signal::layout::extract;
+using bq::signal::layout::scatter;
+
+namespace
+{
+    /** Fans an array back out to a plain signal of its element values. */
+    template <typename T>
+    AnySignal<std::vector<T>> valuesOf(ArraySignal<T> const& array)
+    {
+        return extract(array, [](AnySignal<T> value)
+            {
+                return value;
+            }).values();
+    }
+
+    FrameInfo nextFrame(uint64_t id)
+    {
+        return FrameInfo(id, signal_time_t(0));
+    }
+
+    /** An item with an identity of its own and a value that can change. */
+    struct Item
+    {
+        int key = 0;
+        int value = 0;
+
+        bool operator==(Item const& rhs) const
+        {
+            return key == rhs.key && value == rhs.value;
+        }
+    };
+
+    std::vector<Item> items(std::vector<std::pair<int, int>> const& pairs)
+    {
+        std::vector<Item> result;
+        for (auto const& pair : pairs)
+            result.push_back(Item{ pair.first, pair.second });
+
+        return result;
+    }
+} // namespace
+
+TEST(arraySignal, constructFromBraces)
+{
+    ArraySignal<int> array = { 1, 2, 3 };
+
+    auto context = makeSignalContext(valuesOf(array));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, constructEmpty)
+{
+    ArraySignal<int> array = {};
+
+    auto context = makeSignalContext(valuesOf(array));
+
+    EXPECT_TRUE(context.evaluate<0>().get<0>().empty());
+}
+
+TEST(arraySignal, constructFromVector)
+{
+    ArraySignal<int> array(std::vector<int>{ 4, 5 });
+
+    auto context = makeSignalContext(valuesOf(array));
+
+    EXPECT_EQ((std::vector<int>{ 4, 5 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, constructFromSignal)
+{
+    auto input = makeInput(std::vector<int>{ 1, 2 });
+    ArraySignal<int> array(AnySignal<std::vector<int>>(input.signal));
+
+    auto context = makeSignalContext(valuesOf(array));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), context.evaluate<0>().get<0>());
+
+    input.handle.set(std::vector<int>{ 7, 8, 9 });
+    context.update(nextFrame(1));
+
+    EXPECT_EQ((std::vector<int>{ 7, 8, 9 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, constructFromNestedBraces)
+{
+    ArraySignal<int> inner = { 2, 3 };
+    ArraySignal<int> array = { 1, inner, 4 };
+
+    auto context = makeSignalContext(valuesOf(array));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3, 4 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, concat)
+{
+    ArraySignal<int> a = { 1, 2 };
+    ArraySignal<int> b = { 3 };
+
+    auto context = makeSignalContext(valuesOf(concat(a, b)));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, concatKeepsIdentitiesDistinct)
+{
+    ArraySignal<int> a = { 1 };
+    ArraySignal<int> b = { 1 };
+
+    auto keyed = extract(concat(a, b), [](AnySignal<int> value)
+        {
+            return value;
+        });
+
+    auto context = makeSignalContext(keyed.sig());
+
+    auto const& ids = context.evaluate<0>().get<0>();
+    ASSERT_EQ(2u, ids.size());
+    EXPECT_NE(ids[0], ids[1]);
+}
+
+TEST(arraySignal, mapIsValueLevel)
+{
+    auto input = makeInput(std::vector<int>{ 1, 2 });
+    ArraySignal<int> array(AnySignal<std::vector<int>>(input.signal));
+
+    auto calls = std::make_shared<int>(0);
+    auto mapped = array.map([calls](int value)
+        {
+            ++*calls;
+            return value * 10;
+        });
+
+    auto context = makeSignalContext(valuesOf(mapped));
+
+    EXPECT_EQ((std::vector<int>{ 10, 20 }), context.evaluate<0>().get<0>());
+
+    int const before = *calls;
+    input.handle.set(std::vector<int>{ 3, 4 });
+    context.update(nextFrame(1));
+
+    EXPECT_EQ((std::vector<int>{ 30, 40 }), context.evaluate<0>().get<0>());
+    EXPECT_GT(*calls, before);
+}
+
+TEST(arraySignal, forEachRunsDelegateOncePerKey)
+{
+    auto input = makeInput(items({ { 1, 10 }, { 2, 20 } }));
+
+    auto calls = std::make_shared<int>(0);
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [calls](AnySignal<Item> item)
+            {
+                ++*calls;
+                return item.map([](Item const& i)
+                    {
+                        return i.value;
+                    });
+            });
+
+    auto context = makeSignalContext(valuesOf(built));
+
+    EXPECT_EQ(2, *calls);
+
+    input.handle.set(items({ { 1, 10 }, { 2, 20 }, { 3, 30 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(3, *calls);
+
+    input.handle.set(items({ { 3, 30 }, { 1, 10 }, { 2, 20 } }));
+    context.update(nextFrame(2));
+
+    EXPECT_EQ(3, *calls);
+}
+
+TEST(arraySignal, forEachDoesNotRebuildOnValueChange)
+{
+    auto input = makeInput(items({ { 1, 10 }, { 2, 20 } }));
+
+    auto calls = std::make_shared<int>(0);
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [calls](AnySignal<Item> item)
+            {
+                ++*calls;
+                return item.map([](Item const& i)
+                    {
+                        return i.value;
+                    });
+            });
+
+    auto context = makeSignalContext(
+            extract(built, [](AnySignal<AnySignal<int>> value)
+                {
+                    return value.join();
+                }).values());
+
+    EXPECT_EQ(2, *calls);
+    EXPECT_EQ((std::vector<int>{ 10, 20 }), context.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { 1, 11 }, { 2, 22 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(2, *calls);
+    EXPECT_EQ((std::vector<int>{ 11, 22 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, forEachRebuildsOnChangedKey)
+{
+    auto input = makeInput(items({ { 1, 10 } }));
+
+    auto calls = std::make_shared<int>(0);
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [calls](AnySignal<Item> item)
+            {
+                ++*calls;
+                return item.map([](Item const& i)
+                    {
+                        return i.value;
+                    });
+            });
+
+    auto context = makeSignalContext(valuesOf(built));
+
+    EXPECT_EQ(1, *calls);
+
+    input.handle.set(items({ { 2, 10 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(2, *calls);
+}
+
+TEST(arraySignal, forEachPreservesOrderOnReorder)
+{
+    auto input = makeInput(items({ { 1, 10 }, { 2, 20 }, { 3, 30 } }));
+
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [](AnySignal<Item> item)
+            {
+                return item.map([](Item const& i)
+                    {
+                        return i.value;
+                    });
+            });
+
+    auto keyed = extract(built, [](AnySignal<AnySignal<int>> value)
+        {
+            return value.join();
+        });
+
+    auto context = makeSignalContext(keyed.sig());
+
+    auto const idsBefore = context.evaluate<0>().get<0>();
+    EXPECT_EQ((std::vector<int>{ 10, 20, 30 }), context.evaluate<0>().get<1>());
+
+    input.handle.set(items({ { 3, 30 }, { 1, 10 }, { 2, 20 } }));
+    context.update(nextFrame(1));
+
+    auto const idsAfter = context.evaluate<0>().get<0>();
+    EXPECT_EQ((std::vector<int>{ 30, 10, 20 }), context.evaluate<0>().get<1>());
+
+    ASSERT_EQ(3u, idsAfter.size());
+    EXPECT_EQ(idsBefore[2], idsAfter[0]);
+    EXPECT_EQ(idsBefore[0], idsAfter[1]);
+    EXPECT_EQ(idsBefore[1], idsAfter[2]);
+}
+
+TEST(arraySignal, forEachEvictsRemovedKeys)
+{
+    auto input = makeInput(items({ { 1, 10 }, { 2, 20 } }));
+
+    auto alive = std::make_shared<int>(0);
+    struct Tracker
+    {
+        explicit Tracker(std::shared_ptr<int> alive) :
+            alive_(std::move(alive))
+        {
+            ++*alive_;
+        }
+
+        Tracker(Tracker const& rhs) :
+            alive_(rhs.alive_)
+        {
+            ++*alive_;
+        }
+
+        ~Tracker()
+        {
+            --*alive_;
+        }
+
+        Tracker& operator=(Tracker const&) = delete;
+
+        std::shared_ptr<int> alive_;
+    };
+
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [alive](AnySignal<Item>)
+            {
+                return std::make_shared<Tracker>(alive);
+            });
+
+    auto context = makeSignalContext(valuesOf(built));
+
+    EXPECT_EQ(2, *alive);
+
+    input.handle.set(items({ { 1, 10 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(1u, context.evaluate<0>().get<0>().size());
+    EXPECT_EQ(1, *alive);
+}
+
+TEST(arraySignal, siblingStateSurvivesInsertionAndRemoval)
+{
+    auto input = makeInput(items({ { 1, 1 } }));
+
+    auto built = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [](AnySignal<Item> item)
+            {
+                return item
+                    .map([](Item const& i)
+                        {
+                            return i.value;
+                        })
+                    .withPrevious([](int total, int value)
+                        {
+                            return total + value;
+                        }, 0);
+            });
+
+    auto keyed = extract(built, [](AnySignal<AnySignal<int>> value)
+        {
+            return value.join();
+        });
+
+    auto context = makeSignalContext(keyed.values());
+
+    ASSERT_EQ(1u, context.evaluate<0>().get<0>().size());
+    int const initial = context.evaluate<0>().get<0>()[0];
+
+    input.handle.set(items({ { 1, 1 } }));
+    context.update(nextFrame(1));
+
+    ASSERT_EQ(1u, context.evaluate<0>().get<0>().size());
+    int const accumulated = context.evaluate<0>().get<0>()[0];
+    EXPECT_GT(accumulated, initial);
+
+    input.handle.set(items({ { 1, 1 }, { 2, 100 } }));
+    context.update(nextFrame(2));
+
+    ASSERT_EQ(2u, context.evaluate<0>().get<0>().size());
+    EXPECT_EQ(accumulated + 1, context.evaluate<0>().get<0>()[0]);
+
+    int const afterInsert = context.evaluate<0>().get<0>()[0];
+
+    input.handle.set(items({ { 1, 1 } }));
+    context.update(nextFrame(3));
+
+    ASSERT_EQ(1u, context.evaluate<0>().get<0>().size());
+    EXPECT_EQ(afterInsert + 1, context.evaluate<0>().get<0>()[0]);
+}
+
+TEST(arraySignal, extractAppliesFunctionOncePerIdentity)
+{
+    auto input = makeInput(std::vector<int>{ 1, 2 });
+    ArraySignal<int> array(AnySignal<std::vector<int>>(input.signal));
+
+    auto calls = std::make_shared<int>(0);
+    auto keyed = extract(array, [calls](AnySignal<int> value)
+        {
+            ++*calls;
+            return value.map([](int v)
+                {
+                    return v * 2;
+                });
+        });
+
+    auto context = makeSignalContext(keyed.values());
+
+    EXPECT_EQ(2, *calls);
+    EXPECT_EQ((std::vector<int>{ 2, 4 }), context.evaluate<0>().get<0>());
+
+    input.handle.set(std::vector<int>{ 5, 6, 7 });
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(3, *calls);
+    EXPECT_EQ((std::vector<int>{ 10, 12, 14 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, mapValuesSeesEveryValueAndKeepsAlignment)
+{
+    ArraySignal<int> array = { 1, 2, 3 };
+
+    auto keyed = extract(array, [](AnySignal<int> value)
+        {
+            return value;
+        });
+
+    auto sizes = keyed.mapValues([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            int total = 0;
+            for (int value : values)
+                total += value;
+
+            for (size_t i = 0; i < values.size(); ++i)
+                result.push_back(total);
+
+            return result;
+        });
+
+    auto context = makeSignalContext(sizes.values());
+
+    EXPECT_EQ((std::vector<int>{ 6, 6, 6 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, mapValuesTakesAmbientExtras)
+{
+    ArraySignal<int> array = { 1, 2 };
+    auto extra = makeInput(10);
+
+    auto scaled = extract(array, [](AnySignal<int> value)
+        {
+            return value;
+        })
+        .mapValues([](int factor, std::vector<int> const& values)
+            {
+                std::vector<int> result;
+                for (int value : values)
+                    result.push_back(value * factor);
+
+                return result;
+            }, AnySignal<int>(extra.signal));
+
+    auto context = makeSignalContext(scaled.values());
+
+    EXPECT_EQ((std::vector<int>{ 10, 20 }), context.evaluate<0>().get<0>());
+
+    extra.handle.set(3);
+    context.update(nextFrame(1));
+
+    EXPECT_EQ((std::vector<int>{ 3, 6 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, mapKeyedCarriesTheKey)
+{
+    ArraySignal<int> array = { 1, 2, 3 };
+
+    auto keyed = extract(array, [](AnySignal<int> value)
+        {
+            return value;
+        });
+
+    auto reversed = keyed.mapKeyed(
+            [](std::vector<std::pair<ArrayKey, int>> const& input)
+            {
+                std::vector<std::pair<ArrayKey, int>> result(input.rbegin(),
+                        input.rend());
+                return result;
+            });
+
+    auto context = makeSignalContext(reversed.values());
+
+    EXPECT_EQ((std::vector<int>{ 3, 2, 1 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, extractMapValuesScatterRoundTrip)
+{
+    auto input = makeInput(items({ { 1, 1 }, { 2, 2 }, { 3, 3 } }));
+
+    auto array = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [](AnySignal<Item> item)
+            {
+                return item;
+            });
+
+    auto totals = extract(array, [](AnySignal<AnySignal<Item>> value)
+        {
+            return value.join().map([](Item const& item)
+                {
+                    return item.value;
+                });
+        })
+        .mapValues([](std::vector<int> const& values)
+            {
+                int total = 0;
+                for (int value : values)
+                    total += value;
+
+                std::vector<int> result;
+                for (size_t i = 0; i < values.size(); ++i)
+                    result.push_back(total);
+
+                return result;
+            });
+
+    auto built = scatter(array, totals,
+            [](AnySignal<AnySignal<Item>> item, AnySignal<int> total)
+            {
+                return item.join()
+                    .map([](Item const& i)
+                        {
+                            return i.value;
+                        })
+                    .merge(std::move(total))
+                    .map([](int value, int sum)
+                        {
+                            return value * 1000 + sum;
+                        });
+            });
+
+    auto context = makeSignalContext(
+            extract(built, [](AnySignal<AnySignal<int>> value)
+                {
+                    return value.join();
+                }).values());
+
+    EXPECT_EQ((std::vector<int>{ 1006, 2006, 3006 }),
+            context.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { 3, 3 }, { 1, 1 }, { 2, 2 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ((std::vector<int>{ 3006, 1006, 2006 }),
+            context.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { 3, 3 }, { 1, 1 }, { 2, 2 }, { 4, 4 } }));
+    context.update(nextFrame(2));
+
+    EXPECT_EQ((std::vector<int>{ 3010, 1010, 2010, 4010 }),
+            context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, scatterBuildsOncePerIdentity)
+{
+    auto input = makeInput(items({ { 1, 1 }, { 2, 2 } }));
+
+    auto array = forEach(AnySignal<std::vector<Item>>(input.signal),
+            [](Item const& item)
+            {
+                return item.key;
+            },
+            [](AnySignal<Item> item)
+            {
+                return item;
+            });
+
+    auto counts = extract(array, [](AnySignal<AnySignal<Item>> value)
+        {
+            return value.join().map([](Item const& item)
+                {
+                    return item.value;
+                });
+        });
+
+    auto calls = std::make_shared<int>(0);
+    auto built = scatter(array, counts,
+            [calls](AnySignal<AnySignal<Item>>, AnySignal<int> value)
+            {
+                ++*calls;
+                return value;
+            });
+
+    auto context = makeSignalContext(
+            extract(built, [](AnySignal<AnySignal<int>> value)
+                {
+                    return value.join();
+                }).values());
+
+    EXPECT_EQ(2, *calls);
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), context.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { 1, 5 }, { 2, 6 } }));
+    context.update(nextFrame(1));
+
+    EXPECT_EQ(2, *calls);
+    EXPECT_EQ((std::vector<int>{ 5, 6 }), context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, valuesDiscardsIdentity)
+{
+    ArraySignal<std::string> array = { std::string("a"), std::string("b") };
+
+    auto keyed = extract(array, [](AnySignal<std::string> value)
+        {
+            return value;
+        });
+
+    auto context = makeSignalContext(keyed.values());
+
+    EXPECT_EQ((std::vector<std::string>{ "a", "b" }),
+            context.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, duplicateKeysAssertInDebug)
+{
+    auto build = []
+    {
+        auto array = forEach(std::vector<Item>(items({ { 1, 1 }, { 1, 2 } })),
+                [](Item const& item)
+                {
+                    return item.key;
+                },
+                [](AnySignal<Item> item)
+                {
+                    return item.map([](Item const& i)
+                        {
+                            return i.value;
+                        });
+                });
+
+        auto context = makeSignalContext(valuesOf(array));
+        EXPECT_EQ(2u, context.evaluate<0>().get<0>().size());
+    };
+
+    EXPECT_DEBUG_DEATH(build(), "duplicate key");
+}


### PR DESCRIPTION
Design record plus the `bq` implementation it specifies.

## What is here

**The design** — `docs/design/arraysignal.md`. `ArraySignal<T>` as a value in
`bq` describing a list whose contents and membership may both change; `forEach`
as the keyed operator that builds once per identity; `KeyedArraySignal<A>` with
`extract`/`scatter` as the fan-in/fan-out pair a container needs. The headline
finding is that `bqui`'s two layout engines (`layout()` and `dynamicBox`)
collapse into one — `layout()`'s own `ObbMap`/`SizeHintMap` aliases already *are*
this API.

**Steps 1 and 2 of it, built.** Two new public headers in `bq`:

- `bq/signal/arraysignal.h` — `ArraySignal<T>`, its constructors, `map`,
  `forEach`, `concat`.
- `bq/signal/arraysignallayout.h` — `KeyedArraySignal<A>` with `mapValues`,
  `mapKeyed` and `values`, plus the free functions `extract` and `scatter`, in
  `bq::signal::layout`.

22 tests in `src/bq/test/arraysignaltest.cpp`. **Nothing in `bqui` changes** —
`layout()` and `dynamicBox` are untouched; steps 3 and 4 are separate work.

## The part that matters

Once-per-identity initialisation is what stops a sibling insert from resetting
every surviving child. `Join::update` re-initialises its inner signal whenever
the outer changes, which discards everything held in the positional `DataType`
tree below it — `map` caches, `withPrevious`, `iterate` folds. The fan-in is
still `combine(...).join()`; what makes it safe is that every per-identity signal
is `.share()`d, because `SharedControl` keys its per-context state by a
`btl::UniqueId` in the `DataContext` and so re-finds it instead of building
fresh. On top of that, element equality compares identity only, so `tryCheck()`
on an element sequence means "membership unchanged" and a value change never
enters the re-initialisation path at all.

`forEach`, `map`, `extract` and `scatter` all run through **one**
apply-once-per-identity operation, so they cannot drift apart the way `layout()`
and `dynamicBox` did.

**Mutation-verified.** Dropping the single `.share()` in `extract` turns exactly
`siblingStateSurvivesInsertionAndRemoval` red and nothing else. Making the
once-per-identity cache rebuild on every emission turns five red, including both
`forEach` delegate-count tests.

## Two pre-existing `bq` bugs fixed on the way

`join()` did not work on type-erased signals, in two independent ways:

- `Signal::join()` instantiated `Join<TStorage>`, and `TStorage` is `void` for an
  `AnySignal` — a hard error.
- `detail::toSignal`'s forwarding overload beat its `Signal<T, Ts...>` overload
  for an `AnySignal` (exact match vs derived-to-base), so `join()` over a signal
  whose *value* was an `AnySignal` wrapped it in a `constant` and **silently did
  not join**.

## Where the design did not survive contact

Recorded in the doc under *What building it changed*, in full. The substantive
ones:

- **`extract`'s function takes `AnySignal<T>`, not `T`.** A `T`-taking `f`
  cannot be applied once per identity — reaching a `T` means evaluating the
  element's signal, which needs a `SignalContext` the operator does not have,
  and `value.map(f).join()` is precisely the `Join` hazard.
- **`mapValues` passes its extras first**, resolving a sentence that
  contradicted itself: the claim that it matches `ObbMap` "down to the argument
  order" is the load-bearing half, since it is what lets an existing `ObbMap` be
  passed straight in.
- **Ids are namespaced by allocator identity**, so `concat` rewrites nothing —
  but ids embed a pointer and are therefore not reproducible between runs. That
  retires the doc's argument that a test can assert on the id set. No loss: ids
  never surface.
- **The duplicate-key release rule is settled** by occurrence index. Every
  occurrence keeps a stable identity; nothing is dropped and nothing churns.
  Strictly better than the candidate rule it supersedes.

Also corrected, from PR #103's empirical result: the claim that `getSizes`'
divide-by-zero is masked only by `std::min`'s argument order is **wrong** and is
dropped. The reversed-operand mutation leaves all 24 layout tests green, because
a zero combined interval means every child's interval at that index is zero too.
The non-monotonic overflow hazard stands and is now pinned by a test.

## Deliberately not done

`join`/`flatMap` and `filter` (nothing needs them; `filter`'s eviction semantics
are an open question), the `AnySignal<ArraySignal<T>>` reactive-subtree
constructor (the doc does not yet agree with itself about whether it mints
identity), `map` with extra signals (waits on `Signal::map` gaining that form
first, as the design requires), and the defaulted `forEach` delegate.

The open question about whether identity surfaces at the exit is untouched —
that is PR #99's call and it does not block the core.

## Verification

Full tree configured and built with `clang-cl`, debug. All four suites pass
(`bq`, `btl`, `avg`, `bqui`).
