### PR TITLE
bqui: test layout geometry through realised widgets

### DIFF
--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -88,6 +88,7 @@ libbquidep = declare_dependency(
 bquitest =  executable('bquitest',
   'test/collectiontest.cpp',
   'test/databindtest.cpp',
+  'test/layouttest.cpp',
   'test/shapetest.cpp',
   'test/widgetinstancemodifiertest.cpp',
   'test/widgettest.cpp',

--- a/src/bqui/test/layouttest.cpp
+++ b/src/bqui/test/layouttest.cpp
@@ -1,0 +1,301 @@
+#include <bqui/modifier/instancemodifier.h>
+#include <bqui/modifier/setsizehint.h>
+#include <bqui/modifier/widgetmodifier.h>
+
+#include <bqui/widget/box.h>
+#include <bqui/widget/hbox.h>
+#include <bqui/widget/vbox.h>
+#include <bqui/widget/widget.h>
+
+#include <bqui/buildparams.h>
+#include <bqui/inputarea.h>
+#include <bqui/simplesizehint.h>
+#include <bqui/sizehint.h>
+
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+
+#include <avg/obb.h>
+#include <avg/transform.h>
+#include <avg/vector.h>
+
+#include <btl/uniqueid.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace bqui;
+using namespace bqui::widget;
+
+namespace
+{
+
+/**
+ * @brief Position and size a layout gave to one child.
+ *
+ * The position is in the coordinates of the layout that was realised, with
+ * the origin at its bottom-left corner.
+ */
+struct Geometry
+{
+    avg::Vector2f position;
+    avg::Vector2f size;
+};
+
+/**
+ * @brief Creates probe widgets and reads back the geometry they were given.
+ *
+ * A probe is an empty widget with a fixed size hint that tags its realised
+ * Instance with an InputArea carrying a unique id. Input areas are the one
+ * piece of geometry that travels intact from a leaf to the root Instance:
+ * every enclosing transform is accumulated into the area's own transform
+ * while its obb stays in the leaf's local coordinates. Realising the layout
+ * and looking up the areas by id therefore recovers both the size each child
+ * was allocated and where it was placed, without rendering anything.
+ */
+class ProbeSet
+{
+public:
+    AnyWidget add(SizeHintResult width, SizeHintResult height);
+
+    std::vector<Geometry> realise(AnyWidget widget, avg::Vector2f size) const;
+
+private:
+    std::vector<btl::UniqueId> ids_;
+};
+
+AnyWidget tagGeometry(btl::UniqueId id)
+{
+    return makeWidget()
+        | modifier::makeWidgetModifier(modifier::makeInstanceModifier(
+                    [id](Instance instance)
+                    {
+                        auto areas = instance.getInputAreas();
+                        areas.push_back(makeInputArea(id, instance.getObb()));
+
+                        return std::move(instance)
+                            .setInputAreas(std::move(areas));
+                    }))
+        ;
+}
+
+AnyWidget ProbeSet::add(SizeHintResult width, SizeHintResult height)
+{
+    btl::UniqueId id = btl::makeUniqueId();
+    ids_.push_back(id);
+
+    return tagGeometry(id)
+        | modifier::setSizeHint(simpleSizeHint(width, height))
+        ;
+}
+
+std::vector<Geometry> ProbeSet::realise(AnyWidget widget,
+        avg::Vector2f size) const
+{
+    auto instanceSignal = std::move(widget)(BuildParams())(
+            bq::signal::constant(size))
+        .getInstance();
+
+    // The whole tree is evaluated through this one context. A signal evaluated
+    // in a context of its own would be a different, parallel instantiation of
+    // the same graph (bq::signal::SignalContext).
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+    Instance const& instance = context.evaluate<0>().get<0>();
+
+    std::vector<Geometry> result;
+    result.reserve(ids_.size());
+
+    for (auto const& id : ids_)
+    {
+        InputArea const* found = nullptr;
+        for (auto const& area : instance.getInputAreas())
+            if (area.getId() == id)
+                found = &area;
+
+        if (!found)
+        {
+            ADD_FAILURE() << "probe " << id << " was not realised";
+            result.push_back(Geometry{});
+            continue;
+        }
+
+        result.push_back(Geometry{
+                found->getTransform().getTranslation(),
+                found->getObbs().front().getSize()
+                });
+    }
+
+    return result;
+}
+
+void expectGeometry(std::string const& label, Geometry const& geometry,
+        float x, float y, float width, float height)
+{
+    SCOPED_TRACE(label);
+
+    EXPECT_FLOAT_EQ(x, geometry.position[0]);
+    EXPECT_FLOAT_EQ(y, geometry.position[1]);
+    EXPECT_FLOAT_EQ(width, geometry.size[0]);
+    EXPECT_FLOAT_EQ(height, geometry.size[1]);
+}
+
+SizeHintResult const fixed50 = {{ 50.0f, 50.0f, 50.0f }};
+
+// Three hints that leave the minimums and the naturals satisfiable at a total
+// of 150, so only part of the filler range is handed out and the layout has to
+// distribute it: minimums total 60, naturals 100, fillers 200.
+SizeHintResult const smallHint = {{ 20.0f, 40.0f, 40.0f }};
+SizeHintResult const stretchyHint = {{ 10.0f, 30.0f, 130.0f }};
+SizeHintResult const rigidHint = {{ 30.0f, 30.0f, 30.0f }};
+
+} // anonymous namespace
+
+TEST(Layout, hboxDistributesFillerSpace)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(smallHint, fixed50));
+    children.push_back(probes.add(stretchyHint, fixed50));
+    children.push_back(probes.add(rigidHint, fixed50));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(150.0f, 50.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // Naturals cost 100 of the 150, so half of each child's filler range is
+    // granted: 40, 30 + 50 and 30.
+    expectGeometry("small", geometries[0], 0.0f, 0.0f, 40.0f, 50.0f);
+    expectGeometry("stretchy", geometries[1], 40.0f, 0.0f, 80.0f, 50.0f);
+    expectGeometry("rigid", geometries[2], 120.0f, 0.0f, 30.0f, 50.0f);
+}
+
+TEST(Layout, hboxGrantsFullFillerWhenSpaceAllows)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(smallHint, fixed50));
+    children.push_back(probes.add(stretchyHint, fixed50));
+    children.push_back(probes.add(rigidHint, fixed50));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(200.0f, 50.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    expectGeometry("small", geometries[0], 0.0f, 0.0f, 40.0f, 50.0f);
+    expectGeometry("stretchy", geometries[1], 40.0f, 0.0f, 130.0f, 50.0f);
+    expectGeometry("rigid", geometries[2], 170.0f, 0.0f, 30.0f, 50.0f);
+}
+
+TEST(Layout, vboxStacksFromTopDown)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(fixed50, smallHint));
+    children.push_back(probes.add(fixed50, stretchyHint));
+    children.push_back(probes.add(fixed50, rigidHint));
+
+    auto geometries = probes.realise(vbox(std::move(children)),
+            avg::Vector2f(50.0f, 150.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // The y axis points up, so the first child occupies the topmost band and
+    // the last one sits at the origin.
+    expectGeometry("small", geometries[0], 0.0f, 110.0f, 50.0f, 40.0f);
+    expectGeometry("stretchy", geometries[1], 0.0f, 30.0f, 50.0f, 80.0f);
+    expectGeometry("rigid", geometries[2], 0.0f, 0.0f, 50.0f, 30.0f);
+}
+
+TEST(Layout, gravityCentersAChildInsideItsSlot)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(
+                SizeHintResult{{ 20.0f, 50.0f, 50.0f }},
+                SizeHintResult{{ 10.0f, 30.0f, 30.0f }}
+                ));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(200.0f, 100.0f));
+
+    ASSERT_EQ(1u, geometries.size());
+
+    // The child cannot use more than 50x30, and the default gravity is
+    // (0.5, 0.5), so it is centered in the 50x100 slot the hbox gave it.
+    expectGeometry("centered", geometries[0], 0.0f, 35.0f, 50.0f, 30.0f);
+}
+
+TEST(Layout, hboxAggregatesChildSizeHints)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(smallHint, fixed50));
+    children.push_back(probes.add(stretchyHint, fixed50));
+    children.push_back(probes.add(rigidHint, fixed50));
+
+    auto builder = hbox(std::move(children))(BuildParams());
+
+    auto context = bq::signal::makeSignalContext(builder.getSizeHint());
+    SizeHint const& hint = context.evaluate<0>().get<0>();
+
+    SizeHintResult width = hint.getWidth();
+    EXPECT_FLOAT_EQ(60.0f, width[0]);
+    EXPECT_FLOAT_EQ(100.0f, width[1]);
+    EXPECT_FLOAT_EQ(200.0f, width[2]);
+
+    // Across the layout axis the hints are combined by taking the largest.
+    SizeHintResult height = hint.getHeightForWidth(150.0f);
+    EXPECT_FLOAT_EQ(50.0f, height[0]);
+    EXPECT_FLOAT_EQ(50.0f, height[1]);
+    EXPECT_FLOAT_EQ(50.0f, height[2]);
+}
+
+TEST(Layout, mapObbsPlacesChildrenLeftToRight)
+{
+    std::vector<SizeHint> hints {
+        simpleSizeHint(smallHint, fixed50),
+        simpleSizeHint(stretchyHint, fixed50),
+        simpleSizeHint(rigidHint, fixed50)
+    };
+
+    auto obbs = mapObbs<Axis::x>(avg::Vector2f(150.0f, 50.0f), hints);
+
+    ASSERT_EQ(3u, obbs.size());
+
+    EXPECT_FLOAT_EQ(0.0f, obbs[0].getTransform().getTranslation()[0]);
+    EXPECT_FLOAT_EQ(40.0f, obbs[0].getSize()[0]);
+    EXPECT_FLOAT_EQ(40.0f, obbs[1].getTransform().getTranslation()[0]);
+    EXPECT_FLOAT_EQ(80.0f, obbs[1].getSize()[0]);
+    EXPECT_FLOAT_EQ(120.0f, obbs[2].getTransform().getTranslation()[0]);
+    EXPECT_FLOAT_EQ(30.0f, obbs[2].getSize()[0]);
+}
+
+TEST(Layout, mapObbsPlacesChildrenTopToBottom)
+{
+    std::vector<SizeHint> hints {
+        simpleSizeHint(fixed50, smallHint),
+        simpleSizeHint(fixed50, stretchyHint),
+        simpleSizeHint(fixed50, rigidHint)
+    };
+
+    auto obbs = mapObbs<Axis::y>(avg::Vector2f(50.0f, 150.0f), hints);
+
+    ASSERT_EQ(3u, obbs.size());
+
+    EXPECT_FLOAT_EQ(110.0f, obbs[0].getTransform().getTranslation()[1]);
+    EXPECT_FLOAT_EQ(40.0f, obbs[0].getSize()[1]);
+    EXPECT_FLOAT_EQ(30.0f, obbs[1].getTransform().getTranslation()[1]);
+    EXPECT_FLOAT_EQ(80.0f, obbs[1].getSize()[1]);
+    EXPECT_FLOAT_EQ(0.0f, obbs[2].getTransform().getTranslation()[1]);
+    EXPECT_FLOAT_EQ(30.0f, obbs[2].getSize()[1]);
+}


### PR DESCRIPTION
Layout geometry currently has no test coverage. With a rewrite of the layouts
ahead, this establishes a harness that pins down *observable* geometry —
"given these children with these hints, in a box of this size, each child ends
up here with this size" — so it survives a reimplementation rather than
encoding today's internals.

## Approach: probe widgets read back through input areas

A probe is an empty widget with a fixed size hint that tags its realised
`Instance` with an `InputArea` carrying a unique id. Input areas are the one
geometry channel that travels intact from a leaf to the root `Instance`:
`Instance::transform` folds every enclosing transform into the area's own
transform while leaving its obb in leaf-local coordinates, and `addWidgets`
concatenates children's areas into the parent. Realising the layout once and
looking the areas up by id therefore recovers **both** the size a child was
allocated (the obb) and where it was placed (the transform), in the layout's
coordinates.

This matters because the geometry a child actually receives is decided
*outside* the child: `layout()` wraps each widget in `handleGravity()` and then
attaches `transformBuilder()` to the resulting builder. A probe that only
inspected itself would see its size but never its position. The input-area
channel sidesteps that, and has the bonus that it is the same data hit-testing
uses — asserting on it asserts something users depend on.

The tests name only `hbox`, `vbox`, `mapObbs`, `AnyWidget`, `SizeHint` and
`Instance`. Nothing about how the layouts are assembled internally is baked in.

### Alternatives considered

- **Walking the realised render tree.** More end-to-end, but obbs on
  `ContainerNode`/`ShapeNode` are local and would need flattening by hand, and
  the probes would have to draw something to appear at all. Strictly more
  machinery for the same numbers.
- **Testing `ObbMap`/`SizeHintMap` in isolation.** Cheap and precise, but it
  only covers the pure placement maths — not gravity, not the size-hint
  aggregation, not the transform plumbing that turns an obb into a child's
  actual position. Included here as a *complement* (the two `mapObbs` tests),
  not as the answer: the mutation run below shows exactly where they stop.
- **Introspection (PR #89).** Its window-space obb tree is close to
  purpose-built for this and would make the probe unnecessary — the assertions
  would read against a named tree instead of ids. It is unmerged, so this works
  on master without it; if #89 lands, `ProbeSet::realise` is the single place
  that would be re-pointed at the introspection tree, and the tests themselves
  would not change.
- **Headless `ase` "dummy" backend / real app loop.** Overkill. Layout is
  resolved entirely in the signal graph before anything is drawn; no window,
  GL context or frame loop is needed to observe it.

## SignalContext

The whole tree is realised and evaluated through **one** `SignalContext`:

```cpp
auto instanceSignal = std::move(widget)(BuildParams())(
        bq::signal::constant(size)).getInstance();

auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
Instance const& instance = context.evaluate<0>().get<0>();
```

Contexts are parallel instantiations of the graph, so a signal peeked at in a
throwaway context is a *different* run of the same graph and diverges from the
live one (stream history is not replayed). Where a test needs two values, both
signals must go into the same `makeSignalContext(...)` call, addressed by
index — never a second context. Layout signals here are pure functions of
constant inputs, so a single `evaluate` with no `update()` is enough; anything
animated would need `update()` driven on that same context.

## Coverage

Covered: `hbox` filler distribution (partial and full), `vbox` reversed y axis,
`handleGravity` centering in an oversized slot, upward `SizeHint` aggregation
via `AccumulateSizeHint`, and `mapObbs` on both axes.

Not covered: `stack`, `uniformGrid`, `dynamicBox` (and its separate `MapObbs`
functor), nesting, zero/one-child and degenerate-hint edge cases, non-default
gravity, and animated/changing hints. All of those are additional `TEST`s
against the same `ProbeSet` — `stack` and `uniformGrid` need nothing new;
`dynamicBox` needs the probe list to be built from a signal; changing hints
need `context.update()` between evaluations, which is the one place the harness
would grow.

If breadth grows past this file, `ProbeSet` lifts to a `test/` header unchanged.

## Verification

Built and run with clang-cl (debug):

```
[==========] Running 7 tests from 1 test suite.
[ RUN      ] Layout.hboxDistributesFillerSpace
[       OK ] Layout.hboxDistributesFillerSpace (2 ms)
[ RUN      ] Layout.hboxGrantsFullFillerWhenSpaceAllows
[       OK ] Layout.hboxGrantsFullFillerWhenSpaceAllows (1 ms)
[ RUN      ] Layout.vboxStacksFromTopDown
[       OK ] Layout.vboxStacksFromTopDown (1 ms)
[ RUN      ] Layout.gravityCentersAChildInsideItsSlot
[       OK ] Layout.gravityCentersAChildInsideItsSlot (0 ms)
[ RUN      ] Layout.hboxAggregatesChildSizeHints
[       OK ] Layout.hboxAggregatesChildSizeHints (0 ms)
[ RUN      ] Layout.mapObbsPlacesChildrenLeftToRight
[       OK ] Layout.mapObbsPlacesChildrenLeftToRight (0 ms)
[ RUN      ] Layout.mapObbsPlacesChildrenTopToBottom
[       OK ] Layout.mapObbsPlacesChildrenTopToBottom (0 ms)
[  PASSED  ] 7 tests.
```

The full `bquitest` binary passes all 30 tests.

### The tests were checked against broken code

Two mutations were injected, built, run, and reverted.

**1. Off-by-one on the x accumulator (`acc += s[0] + 1.0f`) plus a reversed y
accumulator in `mapObbs`.** 5 of 7 red:

```
[  FAILED  ] Layout.hboxDistributesFillerSpace
[  FAILED  ] Layout.hboxGrantsFullFillerWhenSpaceAllows
[  FAILED  ] Layout.vboxStacksFromTopDown
[  FAILED  ] Layout.mapObbsPlacesChildrenLeftToRight
[  FAILED  ] Layout.mapObbsPlacesChildrenTopToBottom
```

with e.g. `Expected 40.0f ... Which is: 41` and, for the reversed axis,
`Expected 110 ... Which is: 150`. Importantly the *end-to-end probe* tests went
red alongside the direct `mapObbs` ones — the harness sees the perturbation
through the whole realisation chain, not just the pure function.

**2. Doubled gravity offset in `handleGravity`.** Exactly one test red, and only
the one that covers gravity:

```
[  FAILED  ] Layout.gravityCentersAChildInsideItsSlot
  Expected: y  Which is: 35
  Actual: geometry.position[1]  Which is: 70
```

Note this mutation left both `mapObbs` tests green — the isolated-maths tests
alone would have missed it, which is the concrete argument for the probe
harness over approach 3 on its own.

## Notes for review

- No bug was found in the layouts while writing these. Every expectation was
  computed by hand from `getSizes`/`mapObbs`/`handleGravity` before running, and
  all seven matched the implementation on the first run. Two fragilities are
  worth recording but are **not** touched here: `getSizes` divides by
  `combined[i] - combined[i-1]`, which is zero whenever consecutive hint
  components are equal (a very common case); the result is `inf` or `NaN`, and
  it clamps to a correct multiplier only because `std::min(1.0f, NaN)` returns
  `1.0f`. That is an accident of `std::min`'s argument order, not a designed
  invariant, and a rewrite should handle the degenerate interval explicitly.
  Also, `getSizes` does not clamp its output when `size` exceeds the total
  filler, so an oversized box overflows its children past its own bounds rather
  than leaving slack.
- `src/btl/test/asynctest.cpp` fails on this machine under debug clang-cl
  (`async.perf`, "can't increment invalidated vector iterator"). Pre-existing
  and unrelated — this PR adds no btl code.
