### PR TITLE
bqui: broaden layout test coverage

### DIFF
--- a/src/bqui/test/layouttest.cpp
+++ b/src/bqui/test/layouttest.cpp
@@ -4,14 +4,20 @@
 
 #include <bqui/widget/box.h>
 #include <bqui/widget/hbox.h>
+#include <bqui/widget/stack.h>
+#include <bqui/widget/uniformgrid.h>
 #include <bqui/widget/vbox.h>
 #include <bqui/widget/widget.h>
 
 #include <bqui/buildparams.h>
+#include <bqui/dynamicbox.h>
 #include <bqui/inputarea.h>
 #include <bqui/simplesizehint.h>
 #include <bqui/sizehint.h>
 
+#include <bq/signal/constant.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/input.h>
 #include <bq/signal/signal.h>
 #include <bq/signal/signalcontext.h>
 
@@ -23,6 +29,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -59,12 +69,44 @@ struct Geometry
 class ProbeSet
 {
 public:
+    /**
+     * @brief Registers a probe and builds the widget that carries it.
+     */
     AnyWidget add(SizeHintResult width, SizeHintResult height);
 
-    std::vector<Geometry> realise(AnyWidget widget, avg::Vector2f size) const;
+    /**
+     * @brief Builds another widget for the probe added at @p index.
+     *
+     * The new widget carries the same id and the same size hint as the
+     * original one, so a container that is handed a freshly built child list
+     * on every update still sees one continuous probe.
+     */
+    AnyWidget rebuild(size_t index) const;
+
+    /**
+     * @brief Realises @p widget at @p size and reads every probe back.
+     */
+    std::vector<std::optional<Geometry>> realise(AnyWidget widget,
+            avg::Vector2f size) const;
+
+    /**
+     * @brief Reads every probe out of an already realised instance.
+     *
+     * Entries come in the order the probes were added and are empty for a
+     * probe the instance does not contain. A test that drives updates owns
+     * the SignalContext itself and calls this after each pass.
+     */
+    std::vector<std::optional<Geometry>> read(Instance const& instance) const;
 
 private:
-    std::vector<btl::UniqueId> ids_;
+    struct Probe
+    {
+        btl::UniqueId id;
+        SizeHintResult width;
+        SizeHintResult height;
+    };
+
+    std::vector<Probe> probes_;
 };
 
 AnyWidget tagGeometry(btl::UniqueId id)
@@ -84,15 +126,21 @@ AnyWidget tagGeometry(btl::UniqueId id)
 
 AnyWidget ProbeSet::add(SizeHintResult width, SizeHintResult height)
 {
-    btl::UniqueId id = btl::makeUniqueId();
-    ids_.push_back(id);
+    probes_.push_back(Probe{ btl::makeUniqueId(), width, height });
 
-    return tagGeometry(id)
-        | modifier::setSizeHint(simpleSizeHint(width, height))
+    return rebuild(probes_.size() - 1);
+}
+
+AnyWidget ProbeSet::rebuild(size_t index) const
+{
+    Probe const& probe = probes_.at(index);
+
+    return tagGeometry(probe.id)
+        | modifier::setSizeHint(simpleSizeHint(probe.width, probe.height))
         ;
 }
 
-std::vector<Geometry> ProbeSet::realise(AnyWidget widget,
+std::vector<std::optional<Geometry>> ProbeSet::realise(AnyWidget widget,
         avg::Vector2f size) const
 {
     auto instanceSignal = std::move(widget)(BuildParams())(
@@ -103,22 +151,26 @@ std::vector<Geometry> ProbeSet::realise(AnyWidget widget,
     // in a context of its own would be a different, parallel instantiation of
     // the same graph (bq::signal::SignalContext).
     auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
-    Instance const& instance = context.evaluate<0>().get<0>();
 
-    std::vector<Geometry> result;
-    result.reserve(ids_.size());
+    return read(context.evaluate<0>().get<0>());
+}
 
-    for (auto const& id : ids_)
+std::vector<std::optional<Geometry>> ProbeSet::read(
+        Instance const& instance) const
+{
+    std::vector<std::optional<Geometry>> result;
+    result.reserve(probes_.size());
+
+    for (auto const& probe : probes_)
     {
         InputArea const* found = nullptr;
         for (auto const& area : instance.getInputAreas())
-            if (area.getId() == id)
+            if (area.getId() == probe.id)
                 found = &area;
 
         if (!found)
         {
-            ADD_FAILURE() << "probe " << id << " was not realised";
-            result.push_back(Geometry{});
+            result.push_back(std::nullopt);
             continue;
         }
 
@@ -131,15 +183,26 @@ std::vector<Geometry> ProbeSet::realise(AnyWidget widget,
     return result;
 }
 
-void expectGeometry(std::string const& label, Geometry const& geometry,
+void expectGeometry(std::string const& label,
+        std::optional<Geometry> const& geometry,
         float x, float y, float width, float height)
 {
     SCOPED_TRACE(label);
 
-    EXPECT_FLOAT_EQ(x, geometry.position[0]);
-    EXPECT_FLOAT_EQ(y, geometry.position[1]);
-    EXPECT_FLOAT_EQ(width, geometry.size[0]);
-    EXPECT_FLOAT_EQ(height, geometry.size[1]);
+    ASSERT_TRUE(geometry.has_value()) << "probe was not realised";
+
+    EXPECT_FLOAT_EQ(x, geometry->position[0]);
+    EXPECT_FLOAT_EQ(y, geometry->position[1]);
+    EXPECT_FLOAT_EQ(width, geometry->size[0]);
+    EXPECT_FLOAT_EQ(height, geometry->size[1]);
+}
+
+void expectNotRealised(std::string const& label,
+        std::optional<Geometry> const& geometry)
+{
+    SCOPED_TRACE(label);
+
+    EXPECT_FALSE(geometry.has_value());
 }
 
 SizeHintResult const fixed50 = {{ 50.0f, 50.0f, 50.0f }};
@@ -150,6 +213,36 @@ SizeHintResult const fixed50 = {{ 50.0f, 50.0f, 50.0f }};
 SizeHintResult const smallHint = {{ 20.0f, 40.0f, 40.0f }};
 SizeHintResult const stretchyHint = {{ 10.0f, 30.0f, 130.0f }};
 SizeHintResult const rigidHint = {{ 30.0f, 30.0f, 30.0f }};
+
+// A hint whose minimum and natural are both zero and whose filler is far
+// larger than any container used here, so a probe carrying it takes whatever
+// it is offered on that axis.
+SizeHintResult const fillHint = {{ 0.0f, 0.0f, 1000.0f }};
+
+SizeHintResult const fixed100 = {{ 100.0f, 100.0f, 100.0f }};
+SizeHintResult const fixed150 = {{ 150.0f, 150.0f, 150.0f }};
+
+using KeyedWidgets = std::vector<std::pair<size_t, AnyWidget>>;
+
+/**
+ * @brief The child list dynamicBox takes, built from probe indices.
+ *
+ * Each probe is keyed by its own index, so a probe keeps its key across
+ * additions, removals and reorderings.
+ */
+KeyedWidgets keyed(ProbeSet const& probes, std::vector<size_t> const& indices)
+{
+    KeyedWidgets result;
+    for (size_t index : indices)
+        result.push_back({ index, probes.rebuild(index) });
+
+    return result;
+}
+
+bq::signal::FrameInfo nextFrame(uint64_t frameId)
+{
+    return bq::signal::FrameInfo(frameId, std::chrono::microseconds(0));
+}
 
 } // anonymous namespace
 
@@ -298,4 +391,435 @@ TEST(Layout, mapObbsPlacesChildrenTopToBottom)
     EXPECT_FLOAT_EQ(80.0f, obbs[1].getSize()[1]);
     EXPECT_FLOAT_EQ(0.0f, obbs[2].getTransform().getTranslation()[1]);
     EXPECT_FLOAT_EQ(30.0f, obbs[2].getSize()[1]);
+}
+
+TEST(Layout, fixedChildrenKeepTheirSizeAtTheNaturalSize)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(rigidHint, fixed50));
+    children.push_back(probes.add(rigidHint, fixed50));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(60.0f, 50.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    // A hint whose three entries are equal leaves getSizes with an empty
+    // interval between the minimum and the natural size, so the multiplier for
+    // that interval is computed from a zero denominator. It has to come out as
+    // one; anything else scales every fixed-size child away.
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 30.0f, 50.0f);
+    expectGeometry("second", geometries[1], 30.0f, 0.0f, 30.0f, 50.0f);
+}
+
+TEST(Layout, fixedChildrenKeepTheirSizeInAnOversizedBox)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(rigidHint, fixed50));
+    children.push_back(probes.add(rigidHint, fixed50));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(200.0f, 50.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    // The children have nothing to grow into, so the box keeps them at 30 each
+    // and leaves the remaining 140 unused.
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 30.0f, 50.0f);
+    expectGeometry("second", geometries[1], 30.0f, 0.0f, 30.0f, 50.0f);
+}
+
+TEST(Layout, hboxSquashesChildrenBelowTheirMinimum)
+{
+    ProbeSet probes;
+
+    SizeHintResult const fixed40 = {{ 40.0f, 40.0f, 40.0f }};
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(fixed40, fixed50));
+    children.push_back(probes.add(fixed40, fixed50));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(40.0f, 50.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    // Half of the requested minimum of 80 is available, so both children are
+    // scaled to half of their minimum instead of overflowing the box.
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 20.0f, 50.0f);
+    expectGeometry("second", geometries[1], 20.0f, 0.0f, 20.0f, 50.0f);
+}
+
+TEST(Layout, hboxPlacesASingleStretchingChild)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(
+                SizeHintResult{{ 10.0f, 20.0f, 100.0f }},
+                fillHint
+                ));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(60.0f, 50.0f));
+
+    ASSERT_EQ(1u, geometries.size());
+
+    // 60 covers the minimum, the natural size and half of the filler range, so
+    // the only child takes the whole box.
+    expectGeometry("only", geometries[0], 0.0f, 0.0f, 60.0f, 50.0f);
+}
+
+TEST(Layout, hboxGivesZeroSizedChildrenNoRoom)
+{
+    ProbeSet probes;
+
+    SizeHintResult const zero = {{ 0.0f, 0.0f, 0.0f }};
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(zero, zero));
+    children.push_back(probes.add(zero, zero));
+
+    auto geometries = probes.realise(hbox(std::move(children)),
+            avg::Vector2f(100.0f, 50.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    // Both children are realised with an empty size at the same spot, centered
+    // vertically in the full-height slot the hbox gave them.
+    expectGeometry("first", geometries[0], 0.0f, 25.0f, 0.0f, 0.0f);
+    expectGeometry("second", geometries[1], 0.0f, 25.0f, 0.0f, 0.0f);
+}
+
+TEST(Layout, emptyBoxHasNoChildrenAndAZeroSizeHint)
+{
+    auto builder = hbox(std::vector<AnyWidget>())(BuildParams());
+
+    auto sizeHint = builder.getSizeHint();
+    auto instanceSignal = std::move(builder)(
+            bq::signal::constant(avg::Vector2f(100.0f, 50.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(sizeHint),
+            std::move(instanceSignal));
+
+    SizeHint const& hint = context.evaluate<0>().get<0>();
+    Instance const& instance = context.evaluate<1>().get<0>();
+
+    SizeHintResult width = hint.getWidth();
+    EXPECT_FLOAT_EQ(0.0f, width[0]);
+    EXPECT_FLOAT_EQ(0.0f, width[1]);
+    EXPECT_FLOAT_EQ(0.0f, width[2]);
+
+    SizeHintResult height = hint.getHeightForWidth(100.0f);
+    EXPECT_FLOAT_EQ(0.0f, height[0]);
+    EXPECT_FLOAT_EQ(0.0f, height[1]);
+    EXPECT_FLOAT_EQ(0.0f, height[2]);
+
+    EXPECT_TRUE(instance.getInputAreas().empty());
+}
+
+// Pins current behaviour rather than asserting correctness. getSizes assumes
+// the three entries of a hint are non-decreasing and never clamps its output
+// against the size it was given; a hint whose natural size is below its minimum
+// breaks that assumption and the children are handed more room than there is.
+TEST(Layout, mapObbsOverflowsOnNonMonotonicHints)
+{
+    SizeHintResult const nonMonotonic = {{ 100.0f, 0.0f, 100.0f }};
+
+    std::vector<SizeHint> hints {
+        simpleSizeHint(nonMonotonic, fixed50),
+        simpleSizeHint(nonMonotonic, fixed50)
+    };
+
+    auto obbs = mapObbs<Axis::x>(avg::Vector2f(200.0f, 50.0f), hints);
+
+    ASSERT_EQ(2u, obbs.size());
+
+    // Each child is given the whole 200, so the second one starts where the
+    // container ends and the two together cover twice the container.
+    EXPECT_FLOAT_EQ(0.0f, obbs[0].getTransform().getTranslation()[0]);
+    EXPECT_FLOAT_EQ(200.0f, obbs[0].getSize()[0]);
+    EXPECT_FLOAT_EQ(200.0f, obbs[1].getTransform().getTranslation()[0]);
+    EXPECT_FLOAT_EQ(200.0f, obbs[1].getSize()[0]);
+}
+
+TEST(Layout, stackGivesEveryChildTheContainerSize)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(fillHint, fillHint));
+    children.push_back(probes.add(fixed50, rigidHint));
+
+    auto geometries = probes.realise(stack(std::move(children)),
+            avg::Vector2f(200.0f, 100.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    // Both children are offered the full 200x100. The stretching one takes all
+    // of it; the fixed one keeps 50x30 and gravity centers it in the same slot.
+    expectGeometry("stretching", geometries[0], 0.0f, 0.0f, 200.0f, 100.0f);
+    expectGeometry("fixed", geometries[1], 75.0f, 35.0f, 50.0f, 30.0f);
+}
+
+TEST(Layout, stackAggregatesChildSizeHintsByMaximum)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(
+                SizeHintResult{{ 40.0f, 50.0f, 90.0f }},
+                SizeHintResult{{ 10.0f, 30.0f, 30.0f }}
+                ));
+    children.push_back(probes.add(
+                SizeHintResult{{ 10.0f, 80.0f, 30.0f }},
+                SizeHintResult{{ 20.0f, 60.0f, 60.0f }}
+                ));
+
+    auto builder = stack(std::move(children))(BuildParams());
+
+    auto context = bq::signal::makeSignalContext(builder.getSizeHint());
+    SizeHint const& hint = context.evaluate<0>().get<0>();
+
+    // The maximum is taken entry by entry, so the aggregate width matches
+    // neither child.
+    SizeHintResult width = hint.getWidth();
+    EXPECT_FLOAT_EQ(40.0f, width[0]);
+    EXPECT_FLOAT_EQ(80.0f, width[1]);
+    EXPECT_FLOAT_EQ(90.0f, width[2]);
+
+    SizeHintResult height = hint.getHeightForWidth(200.0f);
+    EXPECT_FLOAT_EQ(20.0f, height[0]);
+    EXPECT_FLOAT_EQ(60.0f, height[1]);
+    EXPECT_FLOAT_EQ(60.0f, height[2]);
+}
+
+TEST(Layout, uniformGridPlacesCellsFromTheBottomLeft)
+{
+    ProbeSet probes;
+
+    auto bottomLeft = probes.add(fillHint, fillHint);
+    auto bottomRight = probes.add(fillHint, fillHint);
+    auto topRow = probes.add(fillHint, fillHint);
+
+    AnyWidget grid = uniformGrid(2, 2)
+        .cell(0, 0, 1, 1, std::move(bottomLeft))
+        .cell(1, 0, 1, 1, std::move(bottomRight))
+        .cell(0, 1, 2, 1, std::move(topRow))
+        ;
+
+    auto geometries = probes.realise(std::move(grid),
+            avg::Vector2f(200.0f, 100.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // Cells are 100x50. Unlike vbox, the grid's rows grow upwards from the
+    // origin, so row 0 is the bottom one.
+    expectGeometry("bottom left", geometries[0], 0.0f, 0.0f, 100.0f, 50.0f);
+    expectGeometry("bottom right", geometries[1], 100.0f, 0.0f, 100.0f, 50.0f);
+    expectGeometry("top row", geometries[2], 0.0f, 50.0f, 200.0f, 50.0f);
+}
+
+// Pins current behaviour rather than asserting correctness: the container hint
+// scales the aggregate by the grid dimensions alone and never looks at a
+// child's cell span. The child below spans the whole 2x2 grid and so receives
+// the container's full size, yet the container asks for twice what the child
+// wants on both axes.
+TEST(Layout, uniformGridSizeHintIgnoresCellSpans)
+{
+    ProbeSet probes;
+
+    AnyWidget grid = uniformGrid(2, 2)
+        .cell(0, 0, 2, 2, probes.add(
+                    SizeHintResult{{ 10.0f, 20.0f, 30.0f }},
+                    SizeHintResult{{ 5.0f, 10.0f, 15.0f }}
+                    ))
+        ;
+
+    auto builder = std::move(grid)(BuildParams());
+
+    auto context = bq::signal::makeSignalContext(builder.getSizeHint());
+    SizeHint const& hint = context.evaluate<0>().get<0>();
+
+    SizeHintResult width = hint.getWidth();
+    EXPECT_FLOAT_EQ(20.0f, width[0]);
+    EXPECT_FLOAT_EQ(40.0f, width[1]);
+    EXPECT_FLOAT_EQ(60.0f, width[2]);
+
+    SizeHintResult height = hint.getHeightForWidth(40.0f);
+    EXPECT_FLOAT_EQ(10.0f, height[0]);
+    EXPECT_FLOAT_EQ(20.0f, height[1]);
+    EXPECT_FLOAT_EQ(30.0f, height[2]);
+}
+
+TEST(Layout, nestedBoxesComposeTransforms)
+{
+    ProbeSet probes;
+
+    std::vector<AnyWidget> row;
+    row.push_back(probes.add(fixed50, fillHint));
+    row.push_back(probes.add(fixed50, fillHint));
+
+    std::vector<AnyWidget> column;
+    column.push_back(hbox(std::move(row)));
+    column.push_back(probes.add(fillHint, rigidHint));
+
+    auto geometries = probes.realise(vbox(std::move(column)),
+            avg::Vector2f(200.0f, 100.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // The vbox gives the row the top 70 and the footer the bottom 30. The row
+    // wants only 100 of the 200 available width, so gravity centers it at
+    // x = 50; a leaf's position is that offset plus its own place in the row.
+    expectGeometry("first in row", geometries[0], 50.0f, 30.0f, 50.0f, 70.0f);
+    expectGeometry("second in row", geometries[1], 100.0f, 30.0f, 50.0f, 70.0f);
+    expectGeometry("footer", geometries[2], 0.0f, 0.0f, 200.0f, 30.0f);
+}
+
+TEST(Layout, dynamicBoxPlacesChildrenLeftToRight)
+{
+    ProbeSet probes;
+
+    KeyedWidgets children;
+    children.push_back({ 0, probes.add(fixed100, fixed50) });
+    children.push_back({ 1, probes.add(fixed50, fixed50) });
+
+    auto input = bq::signal::makeInput(std::move(children));
+
+    auto instanceSignal = dynamicBox<Axis::x>(input.signal)(BuildParams())(
+            bq::signal::constant(avg::Vector2f(300.0f, 50.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+
+    auto geometries = probes.read(context.evaluate<0>().get<0>());
+
+    ASSERT_EQ(2u, geometries.size());
+
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 100.0f, 50.0f);
+    expectGeometry("second", geometries[1], 100.0f, 0.0f, 50.0f, 50.0f);
+}
+
+TEST(Layout, dynamicBoxPlacesAnAddedChild)
+{
+    ProbeSet probes;
+
+    KeyedWidgets children;
+    children.push_back({ 0, probes.add(fixed100, fixed50) });
+    children.push_back({ 1, probes.add(fixed50, fixed50) });
+
+    auto input = bq::signal::makeInput(std::move(children));
+
+    auto instanceSignal = dynamicBox<Axis::x>(input.signal)(BuildParams())(
+            bq::signal::constant(avg::Vector2f(300.0f, 50.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+
+    KeyedWidgets grown = keyed(probes, { 0, 1 });
+    grown.push_back({ 2, probes.add(fixed150, fixed50) });
+
+    input.handle.set(std::move(grown));
+    context.update(nextFrame(1));
+
+    auto geometries = probes.read(context.evaluate<0>().get<0>());
+
+    ASSERT_EQ(3u, geometries.size());
+
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 100.0f, 50.0f);
+    expectGeometry("second", geometries[1], 100.0f, 0.0f, 50.0f, 50.0f);
+    expectGeometry("added", geometries[2], 150.0f, 0.0f, 150.0f, 50.0f);
+}
+
+TEST(Layout, dynamicBoxDropsARemovedChild)
+{
+    ProbeSet probes;
+
+    KeyedWidgets children;
+    children.push_back({ 0, probes.add(fixed100, fixed50) });
+    children.push_back({ 1, probes.add(fixed50, fixed50) });
+    children.push_back({ 2, probes.add(fixed150, fixed50) });
+
+    auto input = bq::signal::makeInput(std::move(children));
+
+    auto instanceSignal = dynamicBox<Axis::x>(input.signal)(BuildParams())(
+            bq::signal::constant(avg::Vector2f(300.0f, 50.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+
+    input.handle.set(keyed(probes, { 0, 2 }));
+    context.update(nextFrame(1));
+
+    auto geometries = probes.read(context.evaluate<0>().get<0>());
+
+    ASSERT_EQ(3u, geometries.size());
+
+    expectGeometry("first", geometries[0], 0.0f, 0.0f, 100.0f, 50.0f);
+    expectNotRealised("removed", geometries[1]);
+    expectGeometry("last", geometries[2], 100.0f, 0.0f, 150.0f, 50.0f);
+}
+
+TEST(Layout, dynamicBoxFollowsReorderedKeys)
+{
+    ProbeSet probes;
+
+    KeyedWidgets children;
+    children.push_back({ 0, probes.add(fixed100, fixed50) });
+    children.push_back({ 1, probes.add(fixed50, fixed50) });
+    children.push_back({ 2, probes.add(fixed150, fixed50) });
+
+    auto input = bq::signal::makeInput(std::move(children));
+
+    auto instanceSignal = dynamicBox<Axis::x>(input.signal)(BuildParams())(
+            bq::signal::constant(avg::Vector2f(300.0f, 50.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+
+    input.handle.set(keyed(probes, { 2, 0, 1 }));
+    context.update(nextFrame(1));
+
+    auto geometries = probes.read(context.evaluate<0>().get<0>());
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // Every child keeps its key, so nothing is rebuilt and each one moves to
+    // the slot its new position in the list earns it.
+    expectGeometry("first", geometries[0], 150.0f, 0.0f, 100.0f, 50.0f);
+    expectGeometry("second", geometries[1], 250.0f, 0.0f, 50.0f, 50.0f);
+    expectGeometry("last", geometries[2], 0.0f, 0.0f, 150.0f, 50.0f);
+}
+
+// Pins a difference between dynamicBox and the layout() containers rather than
+// asserting correctness: dynamicBox hands each child its slot directly, while
+// layout() puts handleGravity() in front of every child. The probe below asks
+// for 50x30 and gets the whole 50x100 slot; in an hbox it would be 50x30
+// centered at y = 35.
+TEST(Layout, dynamicBoxDoesNotApplyGravity)
+{
+    ProbeSet probes;
+
+    KeyedWidgets children;
+    children.push_back({ 0, probes.add(fixed50, rigidHint) });
+
+    auto input = bq::signal::makeInput(std::move(children));
+
+    auto instanceSignal = dynamicBox<Axis::x>(input.signal)(BuildParams())(
+            bq::signal::constant(avg::Vector2f(300.0f, 100.0f)))
+        .getInstance();
+
+    auto context = bq::signal::makeSignalContext(std::move(instanceSignal));
+
+    auto geometries = probes.read(context.evaluate<0>().get<0>());
+
+    ASSERT_EQ(1u, geometries.size());
+
+    expectGeometry("only", geometries[0], 0.0f, 0.0f, 50.0f, 100.0f);
 }


### PR DESCRIPTION
Extends the layout harness from #102 to the containers and edge cases it did
not reach. 7 tests → 24.

## What is covered now

- **`stack`** — every child is offered the container's full size (a stretching
  child takes all of it, a fixed one is gravity-centered in the same slot), and
  `stackSizeHints` aggregates upwards by taking the maximum entry by entry.
- **`uniformGrid`** — cell placement and spans on a 2x2 grid, including that its
  rows grow *upwards* from the origin, unlike `vbox`.
- **`dynamicBox`** — previously zero coverage. Initial layout, adding a child,
  removing a child, and reordering children while keeping their keys.
- **Nesting** — an `hbox` inside a `vbox`, asserting each leaf's absolute
  position, which needs the transform composed through two levels plus the
  gravity offset the row picks up.
- **Degenerate hints** — fixed-size children at their natural size and in an
  oversized box, zero-size children, a single stretching child, an empty child
  list, and a container narrower than the children's minimum.

Every test asserts hand-computed positions and sizes.

## Pinned behaviour

Three tests pin what the code does today rather than what it should do, and are
commented as such:

- `uniformGridSizeHintIgnoresCellSpans` — the container hint scales the
  aggregate by the grid dimensions only and never looks at `cell.w`/`cell.h`.
  A child spanning a whole 2x2 grid receives the container's full size, yet the
  container asks for twice what the child wants. Known limitation from #101.
- `dynamicBoxDoesNotApplyGravity` — `layout()` puts `handleGravity()` in front of
  every child; `dynamicBox` hands each child its slot directly. A probe asking
  for 50x30 fills the whole 50x100 slot instead of being centered. The pending
  rewrite should make this test go red rather than change behaviour quietly.
- `mapObbsOverflowsOnNonMonotonicHints` — see below.

## Bugs found

**`getSizes` does not clamp its output against the size it was given, and a
non-monotonic hint makes it overflow.** `{{100, 0, 100}}` yields
`multiplier = {1, 0, 1}`, so a child is granted 200 inside a 200-wide box; two of
them cover 400. Nothing validates hints, so this is reachable from any caller
that builds one by arithmetic. Pinned as current behaviour in
`mapObbsOverflowsOnNonMonotonicHints` rather than fixed — the fix is a policy
choice (reject the hint, sort the entries, or clamp the output) and belongs in
its own PR. For *monotonic* hints an oversized box under-fills and leaves slack
instead, which `fixedChildrenKeepTheirSizeInAnOversizedBox` pins, so the tests do
not assert `sum(sizes) == size`.

**The divide-by-zero in `getSizes` is real but not observable for monotonic
hints.** `combined[i] - combined[i-1]` is zero for any all-fixed child list and
the ratio is `0/0` at the natural size. It cannot change the result: a zero
combined interval is a sum of non-negative child intervals, so *every* child's
interval there is zero too and the multiplier it is multiplied by does not
matter. Verified by mutation — reversing the clamp to `std::min(m, 1.0f)`, which
turns the NaN into a `0.0f` multiplier, leaves all 24 tests green.
`fixedChildrenKeepTheirSizeAtTheNaturalSize` and its oversized twin pin the
correct output for fixed-size children regardless.

## Harness changes

`ProbeSet` gains two members, both general:

- `rebuild(index)` — builds another widget for an already registered probe,
  carrying the same id and hint. `dynamicBox` is handed a freshly built child
  list on every update, and this keeps one probe continuous across those
  updates.
- `read(instance)` — reads every probe out of an instance the test realised
  itself, so a test that drives signal updates owns its `SignalContext` and can
  read after each pass. `realise()` is now a thin wrapper over it.

Both report an absent probe as an empty entry instead of failing, which is what
the removal case asserts; `expectGeometry` fails on an empty entry, so a probe
that silently disappears is still caught.

## Mutation testing

Each mutation was applied to the source, the suite run, then reverted.

| Mutation | Caught by |
| --- | --- |
| `box.h` `getSizes`: drop the `std::max(0.0f, …)` lower clamp | `hboxSquashesChildrenBelowTheirMinimum` only |
| `stack.cpp`: halve the width of each child's obb | `stackGivesEveryChildTheContainerSize` only |
| `uniformgrid.cpp`: swap `cell.x`/`cell.y` in the cell translation | `uniformGridPlacesCellsFromTheBottomLeft` only |
| `dynamicbox.h`: obb lookup returns the first obb instead of matching the key | all four `dynamicBox` placement tests |
| `dynamicbox.h`: key the obbs by list position instead of by the child's key | `dynamicBoxFollowsReorderedKeys` and `dynamicBoxDropsARemovedChild` only — the initial-layout and add-a-child tests stay green, which is exactly the case the reorder test exists for |

`box.h` `getSizes`: reversing the clamp to `std::min(m, 1.0f)` was **not** caught,
and per the analysis above it should not be. Recorded here so it is not
mistaken for a coverage hole.

## Still uncovered

`getHeightForWidth` / `getWidthForHeight` on a hint that actually varies with the
other axis (every probe uses `simpleSizeHint`, which ignores it), so the
two-pass width→height→width negotiation in `handleGravity` is only exercised on
its trivial path. Non-default gravity values. `mapObbs` on `Axis::y` for `stack`
and `uniformGrid`. Element reuse identity in `dynamicBox` is asserted only
through geometry, not by observing that an unchanged child is not rebuilt.

## Verification

Configured and built with clang-cl per `AGENTS.md`; all four suites pass. The
known `async.perf` crash did not reproduce in this run.

```
1/4 reactive:bq   OK                0.09s
2/4 reactive:avg  OK                0.15s
3/4 reactive:bqui OK                0.18s
4/4 reactive:btl  OK                1.72s

Ok:                4
Fail:              0
```
