### PR TITLE
btl: stop merge/whenAll completing from inside init()

### DIFF
--- a/src/btl/AGENTS.md
+++ b/src/btl/AGENTS.md
@@ -1,6 +1,6 @@
 # btl — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `2c6969c` (2026-07-19).*
 
 Small utilities used everywhere. Concepts are in `readme.md`; project-wide
 conventions are in the top-level `docs/`.
@@ -14,5 +14,13 @@ conventions are in the top-level `docs/`.
   (`test/manualfuture.h`) instead of sleeping — see `docs/decisions.md` for the
   rationale and the deferred injectable-executor follow-up. `async.delayed` is
   the one test that still legitimately measures wall-clock time.
+- **Combinator `init()` runs re-entrantly.** `merge` (`future/merge.h`) and
+  `whenAll` (`future/whenall.h`) register a completion callback per input while
+  walking their input container, and `addCallback` invokes the callback *inline*
+  when the input is already ready. Their outstanding-input counters therefore
+  start one above the input count; `init()` owns that extra count and releases
+  it only after the walk, so completion — which destroys the inputs — can never
+  run while `init()` is still iterating them. Any new combinator built this way
+  needs the same extra count.
 - Most of `btl` is header-only template code, which is why the include-dir
   firewall matters here (see `docs/conventions.md`).

--- a/src/btl/AGENTS.md
+++ b/src/btl/AGENTS.md
@@ -20,7 +20,17 @@ conventions are in the top-level `docs/`.
   when the input is already ready. Their outstanding-input counters therefore
   start one above the input count; `init()` owns that extra count and releases
   it only after the walk, so completion — which destroys the inputs — can never
-  run while `init()` is still iterating them. Any new combinator built this way
-  needs the same extra count.
+  run while `init()` is still iterating them.
+- **Dropping those inputs goes through an arrival rendezvous**, not a "clear
+  only if `init()` has finished" flag: such a flag leaves a window where a
+  failure and `init()` each conclude the other will clear, and the inputs are
+  retained for the lifetime of the combined future. `init()`, the success path
+  and the failure path all arrive; the second arrival drops the inputs. Exactly
+  two ever arrive — `init()` on every non-throwing pass, and precisely one of
+  success and failure, because a failed input reports failure instead of
+  readiness and so the counter never reaches one. Both sites arrive *before*
+  publishing the result, so a ready combined future implies the inputs are
+  already released. Any new combinator built this way needs both the extra
+  count and the rendezvous.
 - Most of `btl` is header-only template code, which is why the include-dir
   firewall matters here (see `docs/conventions.md`).

--- a/src/btl/include/btl/future/merge.h
+++ b/src/btl/include/btl/future/merge.h
@@ -49,10 +49,7 @@ namespace btl::future
 
             });
 
-            if (failed_.load(std::memory_order_acquire))
-                futures_.clear();
-
-            initialized_.store(true, std::memory_order_release);
+            arriveAndClear();
 
             reportFutureReady();
         }
@@ -63,10 +60,9 @@ namespace btl::future
             bool hadNotFailed = failed_.compare_exchange_strong(expected, true);
             if (hadNotFailed)
             {
-                this->setFailure(std::move(err));
+                arriveAndClear();
 
-                if (initialized_.load(std::memory_order_acquire))
-                    futures_.clear();
+                this->setFailure(std::move(err));
             }
         }
 
@@ -82,16 +78,29 @@ namespace btl::future
                 result.reserve(futures_.size());
                 for (auto&& future : futures_)
                     result.push_back(std::move(future).get());
-                this->setValue(std::move(result));
 
-                futures_.clear();
+                arriveAndClear();
+
+                this->setValue(std::move(result));
             }
         }
 
     private:
+        // Arrivals come from init(), the success path and the failure path,
+        // and exactly two of them ever happen: a failed input reports failure
+        // instead of readiness, so count_ never reaches one. init() arrives
+        // once its walk is over, so the second arrival, the one that clears,
+        // never runs mid-walk. Both callers arrive before publishing the
+        // result, so a ready merged future has already dropped its inputs.
+        void arriveAndClear()
+        {
+            if (clearArrivals_.fetch_add(1, std::memory_order_acq_rel) == 1)
+                futures_.clear();
+        }
+
         std::atomic_int count_;
         std::atomic_bool failed_ = false;
-        std::atomic_bool initialized_ = false;
+        std::atomic_int clearArrivals_ = 0;
         std::vector<Future<T>> futures_;
     };
 

--- a/src/btl/include/btl/future/merge.h
+++ b/src/btl/include/btl/future/merge.h
@@ -13,8 +13,11 @@ namespace btl::future
         public FutureControl<std::vector<T>>
     {
     public:
+        // count_ starts one above the input count; init() owns the extra count
+        // and releases it only after it has stopped walking futures_, so
+        // completion never destroys futures_ from under that walk.
         MergedFuture(std::vector<Future<T>> futures) :
-            count_(static_cast<int>(futures.size())),
+            count_(static_cast<int>(futures.size()) + 1),
             futures_(std::move(futures))
         {
         }
@@ -50,6 +53,8 @@ namespace btl::future
                 futures_.clear();
 
             initialized_.store(true, std::memory_order_release);
+
+            reportFutureReady();
         }
 
         void reportFailure(std::exception_ptr err)
@@ -67,7 +72,7 @@ namespace btl::future
 
         void reportFutureReady()
         {
-            auto count = count_.fetch_sub(1, std::memory_order_acquire);
+            auto count = count_.fetch_sub(1, std::memory_order_acq_rel);
 
             assert(count >= 1);
 

--- a/src/btl/include/btl/future/whenall.h
+++ b/src/btl/include/btl/future/whenall.h
@@ -51,8 +51,11 @@ namespace btl::future
                     >
     {
     public:
+        // count_ starts one above the input count; init() owns the extra count
+        // and releases it only after it has stopped walking values_, so
+        // completion never destroys values_ from under that walk.
         WhenAll(std::tuple<Ts...> values) :
-            count_(((IsFuture<std::decay_t<Ts>>::value ? 1 : 0) + ... + 0)),
+            count_(((IsFuture<std::decay_t<Ts>>::value ? 1 : 0) + ... + 0) + 1),
             values_(std::move(values))
         {
         }
@@ -86,6 +89,8 @@ namespace btl::future
                 values_.reset();
 
             initialized_.store(true, std::memory_order_release);
+
+            reportValueReady();
         }
 
         void reportFailure(std::exception_ptr err)
@@ -103,7 +108,7 @@ namespace btl::future
 
         void reportValueReady()
         {
-            auto count = count_.fetch_sub(1);
+            auto count = count_.fetch_sub(1, std::memory_order_acq_rel);
 
             assert(count >= 1);
 

--- a/src/btl/include/btl/future/whenall.h
+++ b/src/btl/include/btl/future/whenall.h
@@ -85,10 +85,7 @@ namespace btl::future
 
             });
 
-            if (failed_.load(std::memory_order_acquire))
-                values_.reset();
-
-            initialized_.store(true, std::memory_order_release);
+            arriveAndReset();
 
             reportValueReady();
         }
@@ -99,10 +96,9 @@ namespace btl::future
             bool hadNotFailed = failed_.compare_exchange_strong(expected, true);
             if (hadNotFailed)
             {
-                this->setFailure(std::move(err));
+                arriveAndReset();
 
-                if (initialized_.load(std::memory_order_acquire))
-                    values_.reset();
+                this->setFailure(std::move(err));
             }
         }
 
@@ -114,25 +110,39 @@ namespace btl::future
 
             if (count == 1)
             {
-                std::apply([this](auto&&... values)
+                auto value = std::apply([](auto&&... values)
                     {
-                        this->setValue(std::tuple_cat(
+                        return std::tuple_cat(
                                     detail::getValueAsTuple(
                                         std::forward<decltype(values)>(values)
                                         )...
-                                    ));
+                                    );
                     },
                     std::move(*values_)
                     );
 
-                values_.reset();
+                arriveAndReset();
+
+                this->setValue(std::move(value));
             }
         }
 
     private:
+        // Arrivals come from init(), the success path and the failure path,
+        // and exactly two of them ever happen: a failed input reports failure
+        // instead of readiness, so count_ never reaches one. init() arrives
+        // once its walk is over, so the second arrival, the one that resets,
+        // never runs mid-walk. Both callers arrive before publishing the
+        // result, so a ready combined future has already dropped its inputs.
+        void arriveAndReset()
+        {
+            if (resetArrivals_.fetch_add(1, std::memory_order_acq_rel) == 1)
+                values_.reset();
+        }
+
         std::atomic_int count_;
         std::atomic_bool failed_ = false;
-        std::atomic_bool initialized_ = false;
+        std::atomic_int resetArrivals_ = 0;
         std::optional<std::tuple<Ts...>> values_;
     };
 

--- a/src/btl/test/asynctest.cpp
+++ b/src/btl/test/asynctest.cpp
@@ -15,6 +15,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
+#include <memory>
 #include <random>
 #include <thread>
 #include <type_traits>
@@ -436,21 +438,27 @@ TEST(async, futureResult)
 
 TEST(async, futureFail)
 {
-    bool failCalled = false;
+    // Retrieving the value does not imply the registered callbacks have run:
+    // the value is published before they are invoked, so the callback can
+    // still be pending when get() returns. Wait for the callback itself.
+    auto failCalled = std::make_shared<std::promise<void>>();
+    auto failLatch = failCalled->get_future();
+
     auto f = btl::async([]()
             {
                 throw std::runtime_error("test error");
 
                 return 10;
             })
-            .onFailure([&](std::exception_ptr const&)
+            .onFailure([failCalled](std::exception_ptr const&)
             {
-                failCalled = true;
+                failCalled->set_value();
             });
 
 
     EXPECT_THROW(std::move(f).get(), std::runtime_error);
-    EXPECT_TRUE(failCalled);
+    EXPECT_EQ(std::future_status::ready,
+            failLatch.wait_for(std::chrono::seconds(10)));
 }
 
 TEST(async, whenAllFail)
@@ -469,21 +477,24 @@ TEST(async, whenAllFail)
                     return 20;
                 });
 
-        std::atomic_bool failCalled = false;
+        auto failCalled = std::make_shared<std::promise<void>>();
+        auto failLatch = failCalled->get_future();
 
         auto r1 = whenAll(std::move(f1), std::move(f2))
             .then([](int x, int y)
             {
                 return x+y;
             })
-            .onFailure([&](std::exception_ptr const&)
+            .onFailure([failCalled](std::exception_ptr const&)
             {
-                failCalled.store(true);
+                failCalled->set_value();
             })
             ;
 
         EXPECT_THROW(std::move(r1).get(), std::runtime_error);
-        EXPECT_TRUE(failCalled.load());
+
+        ASSERT_EQ(std::future_status::ready,
+                failLatch.wait_for(std::chrono::seconds(10)));
     }
 }
 

--- a/src/btl/test/asynctest.cpp
+++ b/src/btl/test/asynctest.cpp
@@ -541,3 +541,35 @@ TEST(async, mergeFail)
     }
 }
 
+TEST(async, mergeInputsReadyBeforeInit)
+{
+    // Every input is already ready when merge() registers its callbacks, so
+    // each registration runs the completion path from inside init()'s loop.
+    std::vector<Future<int>> v;
+    for (int i = 0; i < 32; ++i)
+        v.push_back(makeReadyFuture(i));
+
+    auto r = merge(std::move(v));
+
+    EXPECT_EQ(32u, std::move(r).get().size());
+}
+
+TEST(async, mergeEmpty)
+{
+    auto r = merge(std::vector<Future<int>>());
+
+    EXPECT_TRUE(std::move(r).get().empty());
+}
+
+TEST(async, whenAllInputsReadyBeforeInit)
+{
+    // Both inputs are already ready when whenAll() registers its callbacks, so
+    // each registration runs the completion path from inside init()'s walk.
+    auto r = whenAll(makeReadyFuture(10), makeReadyFuture(20))
+        .then([](int i, int j)
+            {
+                return i + j;
+            });
+
+    EXPECT_EQ(30, std::move(r).get());
+}

--- a/src/btl/test/asynctest.cpp
+++ b/src/btl/test/asynctest.cpp
@@ -573,3 +573,56 @@ TEST(async, whenAllInputsReadyBeforeInit)
 
     EXPECT_EQ(30, std::move(r).get());
 }
+
+TEST(async, mergeReleasesInputsOnFailure)
+{
+    // A failing merge must drop its inputs, not hold them for as long as the
+    // merged future lives. The retained input still owns its value, so the
+    // value's use count is the observable.
+    auto value = std::make_shared<int>(7);
+
+    auto [p, fut] = btl::test::makeManualFuture<std::shared_ptr<int>>();
+
+    std::vector<Future<std::shared_ptr<int>>> v;
+    v.push_back(makeReadyFuture(value));
+    v.push_back(std::move(fut));
+
+    long useCountWhenReady = 0;
+
+    auto r = merge(std::move(v))
+        .onFailure([&](std::exception_ptr const&)
+            {
+                useCountWhenReady = value.use_count();
+            });
+
+    p.setFailure(std::make_exception_ptr(std::runtime_error("test error")));
+
+    EXPECT_THROW(std::move(r).get(), std::runtime_error);
+
+    // The inputs must already be gone by the time the merged future is made
+    // ready, not merely by the time the caller looks.
+    EXPECT_EQ(1, useCountWhenReady);
+    EXPECT_EQ(1, value.use_count());
+}
+
+TEST(async, whenAllReleasesInputsOnFailure)
+{
+    auto value = std::make_shared<int>(7);
+
+    auto [p, fut] = btl::test::makeManualFuture<int>();
+
+    long useCountWhenReady = 0;
+
+    auto r = whenAll(makeReadyFuture(value), std::move(fut))
+        .onFailure([&](std::exception_ptr const&)
+            {
+                useCountWhenReady = value.use_count();
+            });
+
+    p.setFailure(std::make_exception_ptr(std::runtime_error("test error")));
+
+    EXPECT_THROW(std::move(r).getTuple(), std::runtime_error);
+
+    EXPECT_EQ(1, useCountWhenReady);
+    EXPECT_EQ(1, value.use_count());
+}


### PR DESCRIPTION
Two defects in the same pair of combinators, both arising from `init()` walking its input container while completion can already be running.

## 1. The crash

`async.perf` aborts intermittently under a **debug clang-cl** build on Windows with

```
...\include\vector(78) : Assertion failed: can't increment invalidated vector iterator
```

Measured on a 16-core Windows box: **0/200** runs on an idle machine, **2/40** full-suite runs with the machine loaded. It never reproduces under MSVC `cl` debug, nor under a debugoptimized/ASan build.

`merge()` registers a completion callback on each input while iterating its input vector:

```cpp
btl::forEach(futures_, [&](auto&& future) { future.addCallback_(...); });
```

`FutureControl::addCallback` invokes the callback **inline** when the input is already ready. The outstanding-input counter therefore reaches zero on the *last* registration, so `reportFutureReady()` runs re-entrantly from inside the loop body — and it ends with `futures_.clear()`. Control returns into the range-for, which increments an iterator into the vector it just cleared. The `clear()` is the only thing that invalidates: the result-building loop above it reads through `Future::get() &&`, which never touches the `Future`'s `control_` and leaves the vector's storage alone.

This is same-thread re-entrancy, not a cross-thread data race. Instrumenting `MergedFuture` to report whether completion happened while `init()` was still walking showed `sameThread=1` in every observed instance, including the one caught in a real `async.perf` crash window. Whether the window is hit at all depends on scheduling, which is why it needs machine load and why it never showed up on an idle run.

The counter can only reach zero at the *last* registration, on either combinator: reaching zero requires every input to have completed **and** every callback to have been registered, and registration is what drives the decrements.

**Fix:** give the counter an extra count owned by `init()`, released only once the walk is finished. Completion cannot run while the container is being iterated, because the counter cannot fall below one until `init()` releases its count.

Invariant, with N registered inputs: total decrements = (number of inputs reporting success) + 1. `reportFailure` never decrements and the `failed_` early-return withholds more, so zero is reachable only when every input succeeded **and** `init()` has finished — exactly once. `assert(count >= 1)` remains unreachable.

Side effect: `merge()` of an empty vector now completes instead of never completing at all. Previously `count_` started at zero and no callback ever existed to drive it, so the future never resolved. Pinned by `async.mergeEmpty`.

## 2. Inputs retained when a merge fails

`reportFailure` guarded its `futures_.clear()` behind `initialized_`, and `init()` did its own failure clear *before* storing `initialized_`. A failure landing between init's `failed_` check and the `initialized_.store` found `initialized_` false and declined to clear, while init had already passed its own check. Nothing cleared `futures_`, so every input future and the values it holds stayed alive for as long as the merged future did.

Verified rather than argued: widening that window with a temporary sleep between the two statements and failing an input from another thread leaves a retained input value at `use_count() == 2`; with the rendezvous below, the same experiment gives `1`. (The widening was scaffolding and is not in the diff.)

**Fix:** replace both `initialized_`-guarded clears with a single arrival rendezvous, with all three parties arriving:

```cpp
if (clearArrivals_.fetch_add(1, std::memory_order_acq_rel) == 1)
    futures_.clear();
```

`fetch_add` returns the previous value, so the second arrival clears. Exactly two of the three sites ever arrive: `init()` always, and precisely one of success/failure, since a failed input calls `reportFailure` instead of `reportFutureReady` and so the counter never reaches one. Init's arrival is what marks the walk as over, so the clearing arrival can never be mid-walk. There is no read-then-act window left, and `initialized_` becomes dead and is removed from both files.

Both sites arrive **before** publishing the result, so a ready combined future implies its inputs are already released. Otherwise the guarantee would be weaker than it sounds: a thread woken by `waitForResult`, or a continuation run inline from `set()`, could observe readiness with the inputs still alive. `whenAll`'s success path builds the combined tuple first so it can drop the inputs before calling `setValue`.

Including the **success** site in the rendezvous is robustness and uniformity, **not** a live bug fix — the success path was already safe under the extra-count scheme above, since workers decrementing during the walk bottom out at one and only init's trailing decrement can complete. Folding it in makes the invariant local to `arriveAndClear()` instead of resting on a counting argument that a later change to `count_` could silently invalidate.

## `whenall.h` status

`whenAll` has both defects in the same shape — `values_.reset()` destroys the tuple that the `tuple_foreach` walk still refers to, and the identical `initialized_` window — and **both are fixed here**, identically. `tuple_foreach` expands `std::get<S>(data)` per element, so any tuple element after the last future is visited after a reset.

Stating the asymmetry plainly, since it affects how much this PR proves:

- The `merge` crash is **observable**: a vector iterator is invalidated and the MSVC debug iterators abort on the next increment. `async.mergeInputsReadyBeforeInit` reproduces it 100% of the time against the unpatched header.
- The `whenAll` **crash** variant is **not observable on any configuration tested** — no container iterator for the debug STL to check, the destroyed tuple lives in storage that is destroyed but not freed so ASan sees nothing, and the trailing-element visit forms a reference without reading through it. `async.whenAllInputsReadyBeforeInit` passes against the unpatched header, so it pins behaviour but is not a reproducer.
- The `whenAll` **retention** variant *is* observable, and `async.whenAllReleasesInputsOnFailure` covers it.

## Tests, and what they actually assert

- `async.mergeInputsReadyBeforeInit` — every input ready before registration. Aborts 100% against the unpatched header; passes with the fix. Verified by A/B swapping only the two headers.
- `async.mergeEmpty` — pins that an empty merge completes. Cannot be an A/B test: pre-fix this *hangs* rather than fails.
- `async.mergeReleasesInputsOnFailure`, `async.whenAllReleasesInputsOnFailure` — assert observable lifetime (`use_count()` of a value owned by a retained input), not internals, sampled both *inside* the failure continuation and after it. Confirmed non-vacuous twice over: deleting the failure-path arrival makes both fail with `use_count() == 2`, and merely moving that arrival back to *after* `setFailure` also makes both fail, with `useCountWhenReady == 2`.
- `async.whenAllInputsReadyBeforeInit` — pins behaviour only, as above.

Two things could **not** be tested honestly, rather than being covered by something that passes vacuously:

- The exact racy interleaving of defect 2 is a two-statement window reachable only cross-thread. Pinning it needs a hook inside the header; it was verified by the widened-window experiment described above instead.
- The **success**-path clear is not observable through input values, because success moves the values out into the result and leaves a moved-from husk behind. It is pinned only behaviourally, by the existing success tests.

## Why `acq_rel` on the counter

The mutual exclusion does **not** depend on the ordering — it comes from the atomicity of the counter alone. Whichever decrement is last in the modification order of `count_` completes, and the decrement from `init()` is by construction not last unless the walk is over. That holds under any ordering.

What the ordering buys is that the *data* the winner reads is well-defined rather than accidentally correct. The interleaving it covers:

1. The init thread registers the callback for the final input, which is still pending; `addCallback` stores it and returns.
2. The init thread is preempted inside `forEach`, before finishing the walk.
3. A worker completes that input, runs the callback, and decrements. With the fix its `fetch_sub` returns 2, not 1, so it does not complete — `init()` still holds its count. Init resumes, finishes the walk, decrements, gets 1, and completes after the walk.
4. The mirror case: init's decrement lands first and returns 2; a straggling worker decrements, gets 1, and *that* worker completes, then reads and moves out of `futures_`.

In step 4 the completing thread is not the one that ran `init()`, so it must observe everything `init()` did before releasing its count. That needs init's decrement to be a **release** and the completing thread's to be an **acquire**; either thread can play either role depending on which lands last, so both are needed on the same operation — hence `acq_rel`. Read-modify-write operations on `count_` form a release sequence, so the acquiring thread still synchronizes-with the release when other decrements intervene. The same reasoning applies to the arrival counter, which carries the "the walk is over" publication.

## Verification

| config | before | after |
|---|---|---|
| clang-cl debug, full suite under load | 2/40 abort | 0 aborts / 270 |
| clang-cl debug, `merge` regression test | 100% abort | pass |
| clang-cl debug, retention experiment (widened window) | `use_count` 2 | `use_count` 1 |
| MSVC cl debug | does not detect the crash | pass |
| clang-cl debugoptimized + ASan | clean | clean |
| clang-cl debug, `whenAllFail`+`futureFail` under load | 3/400 fail (master) | 0/1600 |

`meson test` is green in all three build configurations.

## 3. A pre-existing test flake (third commit, droppable)

Surfaced by the soaks for the work above, but **present on master and unrelated to it**: `async.whenAllFail` fails its `EXPECT_TRUE(failCalled.load())` at roughly 1 run in 400 under load on Windows/clang-cl. Measured on **pristine `origin/master`: 3/400**; on this branch **2/400** and **1/400** — indistinguishable, so not introduced here.

The tests asserted that their `onFailure` callback had run as soon as `get()` returned. Nothing promises that. `FutureControl::set()` publishes `ready_` at `futurecontrol.h:215` and only invokes the callback at `:224`; `waitForResult`'s **slow** path is fine, since it stashes `callback_`, installs a notifier and runs the old callback at `:69-70` before returning — but the **fast** path at `:44-45` (`if (ready()) return;`) returns without touching `callback_` at all. Hence a *late* callback rather than a lost one, and only when the value is already published by the time the waiter looks. A probe that keeps waiting past the assertion point found **1 late and 0 lost over 18,000,000 iterations**.

Fixed on the **test** side. Guaranteeing the ordering in the library would need a second synchronization point on the `waitForResult` fast path that every future in the system pays for, on behalf of these tests. The tests now wait on the callback itself, through a promise the callback fulfils. `async.futureFail` had the same pattern plus a plain `bool` written by a worker and read by the test thread, and is fixed the same way.

Checked before choosing the test side: **nothing in the codebase relies on "value observed implies continuations have run"**, so the guarantee is neither real nor depended upon. Searched every `btl::future` consumer outside `btl` — `ase`'s fence futures in `glxplatform`/`wglplatform` (`wait()` for frame throttling, then `pop()`, with no continuation on the waited future), `ase/commandbuffer.cpp`'s fire-and-forget `pushFence().then(cb).detach()`, and `bq/test/signaltest.cpp` (whose `.then()` runs inline because the futures are already ready, making the later `wait()` a no-op). `bqui/src/app.cpp` and `bq/signal/{signal,shared}.h` include the headers without using them; `avg` and `testapp1` have no usage. The `merge` hits in `bqui` are `bq::signal::merge`, an unrelated function.

Soak: **0 failures in 1600 runs** of `async.whenAllFail` + `async.futureFail` under load, against a pre-fix baseline of **3/400** on master. At that baseline 1600 runs would be expected to produce roughly 12 failures, so observing none is not luck (P(0) ≈ 6e-6).

**This is still a soak result, not a proof.** The rewritten tests are not deterministic the way the manual-future tests are — they run real threadpool work, and the fix removes a wrong assertion rather than removing the concurrency. The claim is that the assertion no longer depends on unsynchronized ordering, and the soak is consistent with that.

## Notes

- MSVC `cl` does not flag the crash at `_ITERATOR_DEBUG_LEVEL=2` even though clang-cl does; a four-line standalone repro of "clear a vector inside a range-for" survives under `cl` and aborts under `clang-cl` with identical flags. The clang-cl report is correct — the code is UB either way.
- ASan reports nothing because nothing is *read* after the invalidation: the cleared vector keeps its buffer, and the invalidated iterator increments straight onto the cached `end()`. The impact is confined to iterator-checked builds; it is still UB, and it aborts a first-class CI toolchain.
- This is **not** the long-standing macOS/ARM64 `whenAll` flakiness, and this PR does not claim to fix it.
- The pre-existing `async.whenAllFail` flake is handled in the third commit — see the section below. It is deliberately separable from the two fixes above.
- Unrelated defect spotted while reading `threadpool.h`, **not** fixed here: `TimedQueue::push()` does a plain `push_back` with no `std::push_heap`, while `pop()` calls `std::pop_heap` and `hasTaskReady()`/`getNextEventTime()` read `front()` as if it were the earliest. With two or more outstanding timed tasks they can fire out of order. Only `btl::delayed` uses this path and never with more than one task at a time, so nothing currently exercises it.
