### PR TITLE
btl: avoid null-pointer arithmetic in monotonic_buffer_resource::release

### DIFF
--- a/src/btl/include/pmr/monotonic_buffer_resource.h
+++ b/src/btl/include/pmr/monotonic_buffer_resource.h
@@ -53,7 +53,9 @@ namespace pmr
             }
 
             current_ = ptr;
-            p_ = reinterpret_cast<char*>(current_) + sizeof(chunk);
+            p_ = current_
+                ? reinterpret_cast<char*>(current_) + sizeof(chunk)
+                : nullptr;
         }
 
     private:

--- a/src/btl/test/pmrtest.cpp
+++ b/src/btl/test/pmrtest.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <vector>
 #include <list>
 #include <iostream>
@@ -189,6 +190,51 @@ TEST(pmr, monotonic_buffer_resource_with_buffer)
     std::cout << "allocations: " <<  tr.getAllocationCount()
         << " (" << tr.getTotalAllocation() << " bytes)"
         << std::endl;
+}
+
+TEST(pmr, monotonic_buffer_resource_allocate_after_release)
+{
+    auto tr = TraceResource(new_delete_resource());
+
+    auto mono = monotonic_buffer_resource(&tr);
+
+    auto* p = static_cast<char*>(mono.allocate(64, 8));
+    std::fill(p, p + 64, 'a');
+
+    mono.release();
+
+    p = static_cast<char*>(mono.allocate(64, 8));
+    ASSERT_NE(nullptr, p);
+    EXPECT_EQ(0u, reinterpret_cast<std::uintptr_t>(p) % 8);
+    std::fill(p, p + 64, 'b');
+
+    for (int i = 0; i < 64; ++i)
+        EXPECT_EQ('b', p[i]);
+}
+
+TEST(pmr, monotonic_buffer_resource_release_is_idempotent)
+{
+    auto tr = TraceResource(new_delete_resource());
+
+    auto mono = monotonic_buffer_resource(&tr);
+
+    mono.release();
+    mono.release();
+
+    auto* p = mono.allocate(16, 8);
+    EXPECT_NE(nullptr, p);
+}
+
+TEST(pmr, monotonic_buffer_resource_without_allocating)
+{
+    auto tr = TraceResource(new_delete_resource());
+
+    {
+        auto mono = monotonic_buffer_resource(&tr);
+        (void)mono;
+    }
+
+    EXPECT_EQ(1u, tr.getAllocationCount());
 }
 
 TEST(pmr, monotonic_buffer_resource_alignment)


### PR DESCRIPTION
Split out of #97 so it can be reviewed and land on its own. The fix is the
same commit that was reviewed and CI-verified there; #97 will pick up the
merge.

## The bug

`monotonic_buffer_resource::release()` walks the chunk list to its end,
which leaves `current_` null, and then unconditionally does:

```cpp
p_ = reinterpret_cast<char*>(current_) + sizeof(chunk);
```

Applying a non-zero offset to a null pointer is undefined behaviour. It is
not an edge case: the primary constructor sets `current_->prev = nullptr`,
so the walk always runs to null and this fires on **every ordinary
destruction**. UBSan on the sanitizer leg being added in #97 reports:

```
src/btl/include/pmr/monotonic_buffer_resource.h:56:52: runtime error:
    applying non-zero offset 16 to null pointer
```

(The buffer-taking constructor sets `current_->prev = current_`, so the
walk stops immediately and that case is unaffected.)

## It is worse than a sanitizer finding

The original expectation was that this was benign — that `do_allocate`'s
`if (!p || ...)` guard catches the bad pointer before anything reads it.
It does not. After `release()`, `p_` is `null + sizeof(chunk)`, i.e. `0x10`
— **non-null**. So `!p` is false, evaluation falls through to

```cpp
reinterpret_cast<char*>(current_) + current_->size
```

and dereferences the null `current_`. Allocating after an explicit
`release()` is a hard access violation, not just UB on paper. Verified: on
`master` the new tests fault with `0xc0000005`.

## Why the fix is correct

```cpp
current_ = ptr;
p_ = current_
    ? reinterpret_cast<char*>(current_) + sizeof(chunk)
    : nullptr;
```

With `p_` *genuinely* null, `do_allocate` behaves as the rest of the class
already assumes: the alignment offset computes to `0` (`0 % alignment == 0`,
so `offset == alignment`, which is normalised to `0`), `p` stays null, the
`!p` branch is taken, and a fresh chunk is allocated with the
`current_ ? current_->size * 2 : 4096` fallback that was already written for
a null `current_`. The null-`current_` path in `do_allocate` was always
there; `release()` just never actually reached it.

## Tests

Three tests added to `src/btl/test/pmrtest.cpp` (already in the `btl`
suite, no `meson.build` change):

- `monotonic_buffer_resource_allocate_after_release` — allocate, write,
  `release()`, allocate again, confirm the memory is aligned and usable.
- `monotonic_buffer_resource_release_is_idempotent` — two `release()` calls
  then an allocation.
- `monotonic_buffer_resource_without_allocating` — construct and destroy
  with no allocation; `TraceResource`'s destructor asserts the chunk was
  returned.

The first two **genuinely fail on `master`** (SEH `0xc0000005` in the test
body) and pass with the fix, so they are a real regression guard, not just
a contract pin. The third passes either way — it pins the
construct/destroy contract and is the case that only UBSan can distinguish.

## Verification

- clang-cl (LLVM 18.1.7) debug configure, compile, and full `meson test`:
  all four suites green (`bq`, `avg`, `bqui`, `btl`).
- Reverting only the header hunk and rebuilding reproduces the two failures,
  confirming the tests bite.
- **UBSan was not confirmed locally.** A `-Db_sanitize=undefined` clang-cl
  build configures, links, and runs clean with the fix — but it also stays
  silent *without* the fix, so the Windows UBSan runtime is not reporting
  here and that leg proves nothing either way. The diagnostic quoted above
  comes from the Linux sanitizer leg in #97, which is not on `master` yet.
