### PR TITLE
Fix the Linux Debug link failure and cover it in CI

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -49,7 +49,9 @@ jobs:
                   { "deps": "gcc-12 g++-12", "tool": "gcc-12",   "set": "Release" },
                   { "deps": "clang-11",      "tool": "clang-11", "set": "Release" },
                   { "deps": "clang-11",      "tool": "clang-11", "set": "Tracy"   },
-                  { "deps": "",              "tool": "clang-15", "set": "Sanitize" } ]
+                  { "deps": "",              "tool": "clang-15", "set": "Sanitize" },
+                  { "deps": "gcc-12 g++-12", "tool": "gcc-12",   "set": "Debug"   },
+                  { "deps": "clang-11",      "tool": "clang-11", "set": "Debug"   } ]
         runs-on: "ubuntu-22.04"
         steps:
         - uses: actions/checkout@v5

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
 # Conventions & gotchas
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `9cbe4cb` (2026-07-20).*
 
 Idioms and traps that are not obvious from reading a single file. Know these
 before editing the corresponding area.
@@ -23,7 +23,7 @@ edge should be a hard `#include` error, not a silent compile against another
 library's internals. When adding a public header, put it under the nested
 `<lib>/` directory.
 
-## Symbol visibility and DLL export (Windows)
+## Symbol visibility and DLL export
 
 Exported template instantiations use a macro scheme in
 `src/btl/include/btl/visibility.h` (`BTL_EXPORT_TEMPLATE` etc., re-exported per
@@ -39,6 +39,37 @@ so if the instantiation *definition* is not marked exported you get
 unresolved-symbol link errors under clang-cl only. Always mark the definition,
 not just the declaration. (This is why the Windows branch of `visibility.h`
 gives `*_EXPORT_TEMPLATE` a real `dllexport`/`dllimport`.)
+
+The other trap: **GCC cannot export bqui's type-erased instantiations at all.**
+The libraries build with `gnu_symbol_visibility: 'hidden'`, and GCC fixes a
+specialization's visibility when the specialization is first *named*. It takes
+the **minimum of the explicit attribute and the computed minimum over the
+template arguments** — an attribute is honoured, but it cannot lift an argument
+that is itself hidden. The type-erased classes name their own erased
+specialization inside their bodies — `operator AnyWidget() &&` and friends — so
+the specialization is fixed at that point, through `std::function` of a hidden
+type, and no later attribute reaches it. The instantiation is emitted, but
+localised when the shared object is linked, so a consumer's reference is
+unresolved.
+
+Raising it would mean marking every type in the argument tree default-visible,
+including `bq::signal::AnySignal` — a cross-library ABI widening with no
+compile-time backstop for the next unmarked type to join the tree. So
+**`Widget`, `Element`, `WidgetModifier`, `ElementModifier` and
+`BuilderModifier` carry no `extern template` declaration on any toolchain**;
+every translation unit instantiates them implicitly. `Element` had been doing
+exactly that for years already.
+
+This is specific to classes that name their own erased specialization.
+`avg::Animated<T>` keeps the `extern template` scheme and exports normally,
+because it has no such self-conversion operator.
+
+**A Release build hides the whole problem** — the members are small enough to
+inline at every call site, so no external reference is emitted. That is why the
+gcc-12 and clang-11 **Debug** matrix legs exist.
+
+GCC **9 through 16** were probed and behave identically, so this is not
+something to gate on a version range. clang is unaffected.
 
 ## Templates: latent bugs and smoke tests
 
@@ -84,9 +115,9 @@ template metaprogramming into named aliases, Doxygen-only API reference) live in
 
 ## CI
 
-The GitHub Actions matrix builds Linux (gcc-10/11/12, clang-11 ± tracy, plus one
-clang-15 ASan+UBSan leg), macOS (Release and Debug), and Windows (**MSVC and
-clang-cl**). A single aggregating
+The GitHub Actions matrix builds Linux (gcc-10/11/12, clang-11 ± tracy, one
+clang-15 ASan+UBSan leg, plus gcc-12 and clang-11 in Debug), macOS (Release and
+Debug), and Windows (**MSVC and clang-cl**). A single aggregating
 job, **`ci-success`**, `needs` all the build jobs and is the *only* required
 status check — new matrix legs are covered automatically, and a new top-level
 job just needs adding to its `needs` list. Mark only `ci-success` as required in

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,9 +1,35 @@
 # Decisions
 
-*Last verified against `1c71f09` (2026-07-15).*
+*Last verified against `9cbe4cb` (2026-07-20).*
 
 Why non-obvious choices were made, so they are not re-litigated. Newest first.
 Each entry is intentionally short: the decision and its rationale.
+
+## bqui's type-erased classes use no `extern template`
+
+`Widget`, `Element`, `WidgetModifier`, `ElementModifier` and `BuilderModifier`
+have no `extern template` declaration and no explicit instantiation on any
+toolchain. Every translation unit instantiates them implicitly.
+
+**Why:** GCC cannot export them at all (see `docs/conventions.md`), which is why
+Linux `Debug` had never linked. Guarding the declarations under GCC only was
+tried first, but it leaves a GCC-built library unusable from a clang-compiled
+consumer: the consumer honours the declaration and references a symbol the
+library cannot emit.
+
+**Why the cost is acceptable — measured, not assumed.** Baseline versus dropped,
+alternating on the same runner, two repetitions each: full-rebuild wall clock
+moved by −0.5 s (linux gcc-12 Debug and Release, ~249 s), +1.5 s (windows
+msvc-17 Debug, ~225 s) and −5 s (windows msvc-17 Release, ~468 s) — every delta
+smaller than the spread between repetitions of the *same* variant. Binary size
+is flat: Linux Release `libbqui.so` and `bquitest` byte-identical; Windows
+`bqui.dll` 4–20 KB *smaller* and `bquitest.exe` 2–7 KB larger, the copy having
+moved from the DLL into the consumer. Cross-compiler linking works in both
+directions afterwards, which it did not before. Only 26 translation units name
+these types at all.
+
+**Not a general rule.** `avg::Animated<T>` still uses `extern template` and
+exports correctly, because it never names its own erased specialization.
 
 ## Sanitizers run on one dedicated leg, not on every leg
 

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -1,6 +1,6 @@
 # bqui — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `9cbe4cb` (2026-07-20).*
 
 Internals, entry points, and traps for the UI toolkit. Concepts and usage are in
 `readme.md`; project-wide conventions are in the top-level `docs/`. This file is
@@ -41,9 +41,11 @@ terminate to `AnyWidget`. Transforms are **paint-time and never affect layout**
 
 ## Traps
 
-- The exported template instantiations for `Widget`/`Element`/modifiers live in
-  `src/bqui/src/widget/widget.cpp`, export-marked for clang-cl (see
-  `docs/conventions.md`).
+- `Widget`/`Element`/the modifiers have **no `extern template` declaration and
+  no explicit instantiation** — every translation unit instantiates them
+  implicitly. GCC cannot export a specialization these classes name inside their
+  own bodies, and a Release build hides that, so don't add one back; the
+  gcc-12/clang-11 Debug legs are what catch it (see `docs/conventions.md`).
 - Shape builder methods are `&&`-qualified — call other `&&` overloads via
   `std::move(*this)`. A parameterless shape can't use `merge()`; it's built as a
   constant (the `if constexpr (sizeof...(Ts) == 0)` branch in `shape/shape.h`).

--- a/src/bqui/include/bqui/modifier/buildermodifier.h
+++ b/src/bqui/include/bqui/modifier/buildermodifier.h
@@ -41,9 +41,6 @@ namespace bqui::modifier
         btl::CloneOnCopy<std::decay_t<TFunc>> func_;
     };
 
-    extern template class BQUI_EXPORT_TEMPLATE
-        BuilderModifier<std::function<widget::AnyBuilder(widget::AnyBuilder)>>;
-
     using AnyBuilderModifier = BuilderModifier<std::function<widget::AnyBuilder(
             widget::AnyBuilder)>>;
 

--- a/src/bqui/include/bqui/modifier/elementmodifier.h
+++ b/src/bqui/include/bqui/modifier/elementmodifier.h
@@ -51,9 +51,6 @@ namespace bqui::modifier
         btl::CloneOnCopy<TFunc> func_;
     };
 
-    extern template class BQUI_EXPORT_TEMPLATE
-        ElementModifier<std::function<widget::AnyElement(widget::AnyElement)>>;
-
     namespace detail
     {
         template <typename TFunc>

--- a/src/bqui/include/bqui/modifier/widgetmodifier.h
+++ b/src/bqui/include/bqui/modifier/widgetmodifier.h
@@ -46,9 +46,6 @@ namespace bqui::modifier
         btl::CloneOnCopy<TFunc> func_;
     };
 
-    extern template class BQUI_EXPORT_TEMPLATE
-        WidgetModifier<std::function<widget::AnyWidget(widget::AnyWidget)>>;
-
     namespace detail
     {
         template <typename TFunc>

--- a/src/bqui/include/bqui/widget/element.h
+++ b/src/bqui/include/bqui/widget/element.h
@@ -3,6 +3,7 @@
 #include "instance.h"
 
 #include "bqui/buildparams.h"
+#include "bqui/bquivisibility.h"
 
 #include <avg/vector.h>
 
@@ -88,12 +89,6 @@ namespace bqui::widget
         btl::CloneOnCopy<TInstance> instance_;
         BuildParams params_;
     };
-
-    /*
-    // Gcc has problems exporting this template
-    extern template class BQUI_EXPORT_TEMPLATE
-        Element<bq::signal::AnySignal<Instance>>;
-    */
 
     template <typename TInstance>
     auto makeElement(bq::signal::Signal<TInstance, Instance> instance, BuildParams params)

--- a/src/bqui/include/bqui/widget/widget.h
+++ b/src/bqui/include/bqui/widget/widget.h
@@ -7,6 +7,7 @@
 #include "bqui/provider/providebuildparams.h"
 
 #include "bqui/buildparams.h"
+#include "bqui/bquivisibility.h"
 
 #include <bq/signal/signal.h>
 
@@ -63,9 +64,6 @@ namespace bqui::widget
     private:
         btl::CloneOnCopy<TFunc> func_;
     };
-
-    extern template class BQUI_EXPORT_TEMPLATE
-        Widget<std::function<AnyBuilder(BuildParams)>>;
 
     namespace detail
     {

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -65,17 +65,12 @@ libbquisrc = [
 
 bquidep = [libbtldep, libbqdep, libasedep, libavgdep]
 
-args = []
-if target_machine.system() != 'windows'
-  args += ['-Wno-attributes']
-endif
-
 libbqui = library(
   'bqui',
   [libbquisrc],
   include_directories: include_directories('include', 'src'),
   dependencies: bquidep,
-  cpp_args: ['-DBQUI_EXPORT_SYMBOLS', args],
+  cpp_args: ['-DBQUI_EXPORT_SYMBOLS'],
   gnu_symbol_visibility: 'hidden'
   )
 

--- a/src/bqui/src/widget/widget.cpp
+++ b/src/bqui/src/widget/widget.cpp
@@ -5,16 +5,3 @@
 #include "bqui/modifier/widgetmodifier.h"
 #include "bqui/modifier/buildermodifier.h"
 #include "bqui/modifier/elementmodifier.h"
-
-namespace bqui::widget
-{
-    template class BQUI_EXPORT_TEMPLATE Widget<std::function<AnyBuilder(BuildParams)>>;
-    template class BQUI_EXPORT_TEMPLATE Element<bq::signal::AnySignal<Instance>>;
-}
-
-namespace bqui::modifier
-{
-    template class BQUI_EXPORT_TEMPLATE WidgetModifier<std::function<widget::AnyWidget(widget::AnyWidget)>>;
-    template class BQUI_EXPORT_TEMPLATE BuilderModifier<std::function<widget::AnyBuilder(widget::AnyBuilder)>>;
-    template class BQUI_EXPORT_TEMPLATE ElementModifier<std::function<widget::AnyElement(widget::AnyElement)>>;
-}


### PR DESCRIPTION
Linux `Debug` has never linked. A previous attempt added the matrix leg, saw it
fail, and dropped it again; this PR captures the real failure, explains it, and
fixes it.

## The failure

`gcc-12`, `--buildtype=debug`, linking `bquitest`:

```
src/bqui/include/bqui/widget/widget.h:55: undefined reference to `bqui::widget::Widget<std::function<bqui::widget::AnyBuilder (bqui::BuildParams)> >::Widget(bqui::widget::WidgetBuildTag const&, std::function<bqui::widget::AnyBuilder (bqui::BuildParams)>)'
src/bqui/test/layouttest.cpp:146: undefined reference to `bqui::widget::Widget<...>::operator()(bqui::BuildParams) &&'
src/btl/include/btl/cloneoncopy.h:61: undefined reference to `bqui::widget::Widget<...>::clone() const'
```

Four distinct symbols, all **ordinary (non-template) members** of the erased
specializations. Instantiated, but not visible: in `libbqui.so` they are
lowercase `t` (defined, localised); in the producing object `FUNC WEAK HIDDEN`.
The consumer's reference is `NOTYPE GLOBAL DEFAULT UND`, so the consumer is fine
and the producer simply never exports them.

## Why the export attribute does not take

GCC fixes a specialization's visibility when the specialization is first
*named*, taking the **minimum of the explicit attribute and the computed minimum
over the template arguments**. An attribute is honoured — but it cannot lift an
argument that is itself hidden. These classes name their own erased
specialization inside their bodies (`operator AnyWidget() &&`), so the
specialization is fixed at that point through `std::function` of a hidden type,
and no later attribute reaches it.

Confirmed with a reduced probe at `-fvisibility=hidden`, dumping
`readelf -sW | c++filt`. With the argument types left hidden, the specialization
comes out `HIDDEN` whether the attribute is on the extern declaration, the
explicit instantiation, the class template, the individual members, or a
`#pragma GCC visibility push`. It only comes out `DEFAULT` when the class
template **and** every argument type are marked default-visible — the two
conditions together, not either alone.

`BuilderModifier` escapes only by accident: it has no self-conversion operator,
and is indeed exported (`W`) in the same library. `element.h` already carried a
commented-out `extern template` with the note "Gcc has problems exporting this
template", i.e. this was hit before and worked around silently.

**GCC 9, 10, 11, 12, 13, 14, 15 and 16 were all probed and behave identically**,
so there is no version boundary to gate on. clang is unaffected.

## The fix

Drop the five `extern template` declarations and their explicit instantiations
outright, on every toolchain. Each translation unit instantiates the
specialization implicitly — which is what `Element` has been doing all along.

The alternative — marking the whole argument tree default-visible — was measured
and does work (`bquitest` links in Debug with the declarations restored), but it
requires unconditional `visibility("default")` on `bq::signal::AnySignal` among
others, because the per-library export macros expand to nothing on the side
merely consuming the library. That is a cross-library ABI widening with no
compile-time backstop for the next unmarked type to join the tree, so it was
rejected.

A guard that dropped the declarations under GCC only was also rejected: it
leaves a GCC-built library unusable from a clang-compiled consumer, which
honours the declaration and references a symbol the library cannot emit.

## The cost, measured

Baseline vs. dropped, alternating **on the same runner in the same job**, two
repetitions each, timing `ninja` after `ninja -t clean`:

| leg | baseline | dropped | delta |
|---|---|---|---|
| linux gcc-12 Debug | 249 / 248 s | 249 / 247 s | −0.5 s |
| linux gcc-12 Release | 250 / 250 s | 249 / 250 s | −0.5 s |
| windows msvc-17 Debug | 224 / 225 s | 227 / 225 s | +1.5 s |
| windows msvc-17 Release | 473 / 468 s | 464 / 467 s | −5 s |

Every delta is smaller than the spread between repetitions of the *same*
variant, and two of four go the other way. Binary size is flat: Linux Release
`libbqui.so` and `bquitest` are byte-identical; Windows `bqui.dll` is 4–20 KB
*smaller* and `bquitest.exe` 2–7 KB larger, the copy having moved from the DLL
into the consumer. Only 26 translation units name these types.

Cross-compiler linking, a real `libbqui.so` plus a consumer TU:

| library | consumer | before | after |
|---|---|---|---|
| gcc-12 | clang-11 | LINK FAILED | **LINK OK** |
| clang-11 | gcc-12 | LINK OK | **LINK OK** |

## Not a blanket conclusion

`avg::Animated<T>` remains a live user of the `extern template` scheme — nine
declarations plus nine instantiations — and exports correctly, because it never
names its own erased specialization. Every `*_EXPORT_TEMPLATE` and
`*_EXPORT_CLASS_TEMPLATE` macro is therefore kept, deliberately including
`BQUI_EXPORT_TEMPLATE` even though bqui no longer uses it, so the macro set
stays symmetric across libraries. Only `BTL_EXPORTABLE_EXTERN_TEMPLATE` — the
guard — is deleted.

## Also in this PR

- `-Wno-attributes` is removed from `src/bqui/meson.build`: with the flag gone
  and the drop applied, bqui's own TUs emit **zero** `-Wattributes` warnings.
  `libavg` still emits 26 from its own TUs (24 in `animated.cpp`, 2 in
  `rendertree/rendertreenode.h`) and always has, since it never carried the
  flag — a possible follow-up, deliberately not touched here.
- `gcc-12 Debug` and `clang-11 Debug` legs added to `build-linux`, covered by
  `ci-success` automatically. These are the regression backstop: Release cannot
  catch this.
- `docs/conventions.md`, `docs/decisions.md` and `src/bqui/AGENTS.md` updated.
