### PR TITLE
Include <cstdint> where fixed-width integer types are used

### DIFF
--- a/src/ase/include/ase/genericwindow.h
+++ b/src/ase/include/ase/genericwindow.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <optional>
 #include <chrono>
+#include <cstdint>
 
 namespace ase
 {

--- a/src/ase/include/ase/glxwindow.h
+++ b/src/ase/include/ase/glxwindow.h
@@ -32,6 +32,7 @@
 #include <X11/Xutil.h>
 #include <X11/X.h>
 
+#include <cstdint>
 #include <mutex>
 #include <vector>
 

--- a/src/ase/include/ase/vector.h
+++ b/src/ase/include/ase/vector.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Geometry>
 
+#include <cstdint>
 #include <ostream>
 
 namespace ase

--- a/src/ase/src/genericwindow.cpp
+++ b/src/ase/src/genericwindow.cpp
@@ -1,5 +1,6 @@
 #include "genericwindow.h"
 
+#include <cstdint>
 #include <iostream>
 
 namespace ase

--- a/src/ase/src/gl/glindexbuffer.cpp
+++ b/src/ase/src/gl/glindexbuffer.cpp
@@ -3,6 +3,8 @@
 #include "dispatcher.h"
 #include "buffer.h"
 
+#include <cstdint>
+
 namespace ase
 {
 

--- a/src/ase/src/glx/glxwindow.cpp
+++ b/src/ase/src/glx/glxwindow.cpp
@@ -6,6 +6,7 @@
 
 #include <tracy/Tracy.hpp>
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace ase

--- a/src/ase/src/keyevent.cpp
+++ b/src/ase/src/keyevent.cpp
@@ -1,5 +1,7 @@
 #include "keyevent.h"
 
+#include <cstdint>
+
 namespace ase
 {
 

--- a/src/ase/src/windows/wglwindow.cpp
+++ b/src/ase/src/windows/wglwindow.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <iostream>
 #include <codecvt>
+#include <cstdint>
 
 namespace ase
 {

--- a/src/avg/include/avg/softmesh.h
+++ b/src/avg/include/avg/softmesh.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <cstdint>
 
 namespace avg
 {

--- a/src/avg/src/region.cpp
+++ b/src/avg/src/region.cpp
@@ -15,6 +15,7 @@
 
 #include <stdexcept>
 #include <memory>
+#include <cstdint>
 
 namespace mapbox::util {
 

--- a/src/avg/src/rendering.cpp
+++ b/src/avg/src/rendering.cpp
@@ -29,6 +29,7 @@
 
 #include <tracy/Tracy.hpp>
 
+#include <cstdint>
 #include <optional>
 
 namespace avg

--- a/src/avg/src/rendertree/uniqueid.cpp
+++ b/src/avg/src/rendertree/uniqueid.cpp
@@ -1,6 +1,7 @@
 #include "rendertree/uniqueid.h"
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 
 namespace avg

--- a/src/avg/src/softmesh.cpp
+++ b/src/avg/src/softmesh.cpp
@@ -6,6 +6,8 @@
 #include <pmr/vector.h>
 #include <pmr/shared_ptr.h>
 
+#include <cstdint>
+
 namespace avg
 {
 

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -6,6 +6,7 @@
 
 #include <mutex>
 #include <memory>
+#include <cstdint>
 
 namespace bq::signal
 {

--- a/src/bq/include/bq/signal/weak.h
+++ b/src/bq/include/bq/signal/weak.h
@@ -4,6 +4,8 @@
 #include "signaltraits.h"
 #include "datacontext.h"
 
+#include <cstdint>
+
 namespace bq::signal
 {
     template <typename... Ts>

--- a/src/bq/include/bq/stream/collect.h
+++ b/src/bq/include/bq/stream/collect.h
@@ -13,6 +13,7 @@
 #include <btl/spinlock.h>
 #include <btl/shared.h>
 
+#include <cstdint>
 #include <mutex>
 
 namespace bq::stream

--- a/src/bq/src/signal/datacontext.cpp
+++ b/src/bq/src/signal/datacontext.cpp
@@ -2,6 +2,8 @@
 
 #include <btl/uniqueid.h>
 
+#include <cstdint>
+
 namespace bq::signal
 {
 btl::UniqueId makeUniqueId()

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include <cstdint>
 
 namespace bqui
 {

--- a/src/bqui/src/modifier/onkeyevent.cpp
+++ b/src/bqui/src/modifier/onkeyevent.cpp
@@ -10,6 +10,8 @@
 
 #include <ase/keyevent.h>
 
+#include <cstdint>
+
 namespace bqui::modifier
 {
 

--- a/src/btl/include/btl/hash.h
+++ b/src/btl/include/btl/hash.h
@@ -5,6 +5,8 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <cstddef>
+#include <cstdint>
 
 namespace btl
 {

--- a/src/btl/include/pmr/unsynchronized_pool_resource.h
+++ b/src/btl/include/pmr/unsynchronized_pool_resource.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 #include <cassert>
+#include <cstdint>
 
 namespace pmr
 {

--- a/src/btl/include/utf8/utf8.h
+++ b/src/btl/include/utf8/utf8.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <cstring>
+#include <cstdint>
 
 namespace utf8
 {

--- a/src/btl/test/asynctest.cpp
+++ b/src/btl/test/asynctest.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <random>

--- a/src/btl/test/pmrtest.cpp
+++ b/src/btl/test/pmrtest.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <iostream>
 #include <array>
+#include <cstdint>
 
 using namespace pmr;
 

--- a/src/btl/test/utf8test.cpp
+++ b/src/btl/test/utf8test.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 using namespace utf8;
 


### PR DESCRIPTION
`btl/hash.h` specialises `is_contiguously_hashable` for `int8_t` … `uint64_t`
but never included `<cstdint>`. It compiled only because some other header
transitively declared those types. gcc-14 no longer provides them transitively
here, so the build fails outright with `'uint8_t' was not declared in this
scope` while compiling `libase` — a hard blocker on bumping the GCC versions in
CI, which currently tops out at gcc-12.

This adds the include there and, from a sweep of `src/`, in every other file
that names a fixed-width integer type (`int8_t` … `uint64_t`, `uintptr_t`)
without an include that declares it: 10 headers and 15 sources/tests across
`btl`, `bq`, `ase`, `avg` and `bqui`. The vendored `src/avg/src/clipper/` is
left untouched.

`size_t` is deliberately left alone. It is used in far more places, and in all
of them it arrives via a standard header the file already includes. The one
exception is `btl/hash.h` itself, which uses `size_t` in a template parameter
list, so it also gets `<cstddef>`.

No behaviour change; includes only.

Verified locally with clang-cl (configure, build, `meson test`: 4/4 green), and
on CI. The gcc-14 failure was reproduced on a throwaway branch carrying a
temporary gcc-14 job: it fails on `master` and passes with this change. The
temporary job is not part of this PR.