### PR TITLE
Prove the ArraySignal pick construction

### DIFF
--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -495,6 +495,22 @@ absent. One copy, per-context, entirely legal, and it turns the failure mode fro
 undefined into briefly stale. The invariant then becomes something the tests
 assert rather than something the design leans on.
 
+**The construction is built and proven.** `bq::signal::detail::Pick` and its two
+helpers live in `src/bq/include/bq/signal/detail/pick.h`, with
+`src/bq/test/picktest.cpp` covering the four cases step 1 called for. Three
+results settle points this document had left open or inferred:
+
+- Two `SignalContext`s over one `pick` description are wholly independent —
+  separate latches, and each evaluates the shared source for itself.
+- One description instantiated twice into **one** context shares its latch and
+  evaluates the shared source once per pass, exactly as inferred from
+  `SharedControl`. An instantiation made after the key has already left the
+  source finds the earlier latch rather than failing for want of a value, so the
+  sharing is of the state itself and not a coincidence of two copies having seen
+  the same values.
+- `pick` reports **no change** while its key is absent, so a latched element is
+  inert rather than merely stale.
+
 **`scatter` is the same node.** Its aggregate is positional rather than keyed, but
 the scatter node knows the current key order, so it zips aggregate-with-keys into
 an `AnySignal<std::map<ArrayId, W>>`, shares that, and hands each identity the
@@ -1218,11 +1234,6 @@ Points the design does not settle. Flagged rather than guessed.
   `AnySignal<vector<pair<size_t, Window>>>` and reconciling by hand. The two live
   consumers are PR #99's window list and `dataBind`
   (`src/bqui/include/bqui/databind.h:22`). Decide it when PR #99 is reworked.
-- **Does a description instantiated twice into the *same* context share
-  correctly?** `SharedArraySignal` should get this for free — same `UniqueId`,
-  same `findData` hit, exactly as `SharedControl` does — but this is inference
-  from reading `sharedcontrol.h`, not something the spike tested. It is the first
-  thing step 1 must prove.
 - **The reactive subtree `AnySignal<ArraySignal<T>>`.** Still unimplemented and
   still unreconciled: the identity algebra says only construction and `forEach`
   mint identity, but this constructor hands out fresh ids on every swap. Either
@@ -1243,6 +1254,8 @@ Points the design does not settle. Flagged rather than guessed.
 Written for a from-scratch implementation. The spike on PR #100 is superseded and
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
+
+Steps 0 and 1 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** A **prerequisite**, not a
    nicety. `data_` holds `weak_ptr`s and the assert requires the id to be absent

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -473,11 +473,13 @@ once, and then, per identity as each key first appears,
 shared.map(pick(key))            // AnySignal<T>
 ```
 
-`pick(key)` is an ordinary recipe carrying only a key by value. `.share()`
-already supplies per-context state keyed by a `UniqueId` through `SharedControl`,
-and its frame check (`sharedcontrol.h:187`) means the source is updated once per
-pass no matter how many pick-signals pull on it. Nothing custom, nothing outside
-the context.
+`pick(key)` is an ordinary recipe carrying only a key by value, and both steps
+are plain `map`s. `.share()` already supplies per-context state keyed by a
+`UniqueId` through `SharedControl`, and its frame check (`sharedcontrol.h:187`)
+means the source is updated once per pass no matter how many pick-signals pull on
+it. **No custom signal node, and no per-context state of its own** — that is the
+whole point of the construction, and anything that reintroduces either should be
+treated as a sign the construction has been misread.
 
 **Key it, do not scan it.** Sharing a `vector<pair<TKey, T>>` forces each pick to
 search — O(n) per element per update, O(n²) per frame across the array. Sharing a
@@ -495,45 +497,48 @@ and n resident copies besides. What the shared signal carries must be a
 This is a property of `Shared`, not of this design; a by-reference evaluate path
 for shared nodes would remove the constraint, and is worth having independently.
 
-**`pick` latches its last value.** Every signal must always have a value, so
-`pick(key)` cannot return nothing when its key has left the source. The lifetime
-argument says this never happens — the pick signal lives exactly as long as its
-`U`, the node destroys `U` in the same `update` that observes the removal, and
-the exit evaluates after that update — but that is an *ordering* argument, and
-the point of this revision is to stop depending on ordering arguments. So the
-pick node keeps the last value in its own `DataType` and holds it when the key is
-absent. One copy, per-context, entirely legal, and it turns the failure mode from
-undefined into briefly stale. The invariant then becomes something the tests
-assert rather than something the design leans on.
+**An absent key yields no value, and asking for it anyway is a hard error.**
+`pick(key)` produces an `AnySignal<std::optional<T>>`, empty for any update in
+which the key is not in the source. A consumer that needs the element — the
+`forEach` delegate does, since it is handed an `AnySignal<T>` — unwraps with a
+second plain `map` that throws when the value is missing.
 
-**The construction is built and proven.** `bq::signal::detail::Pick` and its two
-helpers live in `src/bq/include/bq/signal/detail/pick.h`, with
-`src/bq/test/picktest.cpp` covering the four cases step 1 called for. Four
-results settle points this document had left open, inferred, or stated too
-strongly:
+An earlier revision of this document specified a **latch** here instead: the pick
+would hold the last value it saw, so that a departed key produced a stale value
+rather than nothing. That is withdrawn. The key's presence cannot be encoded in
+the type system and cannot be guaranteed by construction, so its absence has to
+surface at runtime; a latch converts that into a **silently stale value**, which
+is a worse failure than a loud one and hides the bug that caused it. The latch
+also did not buy what it promised — it removed the ordering argument from
+`evaluate` only by moving it to `initialize`, where a context holding no live
+instantiation had nothing to latch and had to fail anyway.
 
-- Two `SignalContext`s over one `pick` description are wholly independent —
-  separate latches, and each evaluates the shared source for itself.
-- One description instantiated twice into **one** context shares its latch and
-  evaluates the shared source once per pass, exactly as inferred from
-  `SharedControl`. An instantiation made after the key has already left the
-  source finds the earlier latch rather than failing for want of a value, so the
-  sharing is of the state itself and not a coincidence of two copies having seen
-  the same values.
-- `pick` reports **no change** while its key is absent, so a latched element is
-  inert rather than merely stale. It does, however, report a change whenever
-  *any* element of the source changes, because that is what the shared source
+The obligation the latch was meant to soften therefore stands, and is now
+enforced rather than papered over: **build a pick when its key appears, and drop
+it no later than the update that observes the key leaving.** `forEach` owes that.
+A subtree swapped out and back by `join` or `conditional` breaks it, which is
+consistent with the reactive subtree minting fresh identity on a swap.
+
+**The construction is built.** `pick`, `requirePresent` and `shareKeyed` live in
+`src/bq/include/bq/signal/detail/pick.h` — three function templates over
+`map`/`share`, no node and no context data — with `src/bq/test/picktest.cpp`
+covering the cases step 1 called for. Two results settle points this document had
+inferred or stated too strongly:
+
+- Two `SignalContext`s over one `pick` description are wholly independent, and
+  one description instantiated twice into **one** context finds the shared
+  source's state already there and evaluates it once per pass, exactly as
+  inferred from `SharedControl`.
+- A pick reports a change whenever **any** element of the source changes, not
+  only when the picked element moves, because that is what the shared source
   reports and the element type carries no comparison requirement. Suppressing
   the repeats is `tryCheck()`'s job, at the point of use — the same answer this
   document already gives under *Skipping repeats is a property of the data*.
-- **The latch does not remove the ordering argument; it moves it to
-  initialisation.** Instantiations are the only owners of their context data, so
-  a context holding none of them has nothing to latch, and building a pick for a
-  key that is not currently in the source has no value it could report. The node
-  owes the guarantee: create a pick when its key appears, and drop it no later
-  than the update that observes the key leaving. A subtree swapped out and back
-  by `join` or `conditional` breaks that, which is consistent with the reactive
-  subtree minting fresh identity on a swap.
+
+Note also that the project builds with `b_ndebug` off, so `assert` is live in
+every configuration here. A debug-assert / release-throw pair does not exist for
+us: the assert would always win and the throw would be unreachable. Hard errors
+of this kind are therefore a throw alone.
 
 **`scatter` is the same node.** Its aggregate is positional rather than keyed, but
 the scatter node knows the current key order, so it zips aggregate-with-keys into
@@ -1295,10 +1300,10 @@ Steps 0 and 1 are done; the rest is outstanding.
 
 1. **Prove the pick construction.** The smallest thing that can fail. Build the
    shared keyed source and one `pick(key)` signal by hand, and show: it tracks its
-   key across membership changes; it latches when its key leaves; two
-   `SignalContext`s over the same description get independent state; and the same
-   description instantiated twice into *one* context shares state. Nothing else
-   proceeds until this is green.
+   key across membership changes; it yields no value when its key leaves, and
+   asking for one anyway throws; two `SignalContext`s over the same description
+   get independent state; and the same description instantiated twice into *one*
+   context shares the source. Nothing else proceeds until this is green.
 
 2. **The node: `forEach`, `concat`, `map`, `join`.** The `UniqueId` +
    `findData` + `DataType` pattern from `SharedControl`, with the key→id map, the
@@ -1329,8 +1334,8 @@ exercise what the first implementation got wrong. They are cheap and they are th
 regression net for the state-location rule:
 
 - **Shrink then grow.** Remove the last element, update, add one back. This is the
-  sequence that fires the `DataContext` assert of step 0, and the one that
-  exercises `pick`'s latch.
+  sequence that fires the `DataContext` assert of step 0, and the one in which a
+  pick must go empty and be picked up again rather than reporting a stale value.
 - **Remove while a sibling still reads.** A surviving element's signals must be
   untouched by a neighbour's removal — the spike's failure mode was a sibling's
   fold resetting on an unrelated insert.

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -496,6 +496,12 @@ and n resident copies besides. What the shared signal carries must be a
 `shared_ptr` to an immutable map, so the per-consumer copy is a refcount bump.
 This is a property of `Shared`, not of this design; a by-reference evaluate path
 for shared nodes would remove the constraint, and is worth having independently.
+A second `Shared` note while it is in view: `SharedControl::update` commits
+`lastFrame` and `updateResult` *before* re-evaluating (`sharedcontrol.h:187-196`),
+so an inner evaluation that throws leaves the node reporting a change with its
+previous value for the rest of the frame. Unreachable through `SignalContext`,
+which never catches, but it is the reason a throw is a discard-the-context error
+rather than a recoverable one.
 
 **An absent key yields no value, and asking for it anyway is a hard error.**
 `pick(key)` produces an `AnySignal<std::optional<T>>`, empty for any update in
@@ -538,7 +544,17 @@ inferred or stated too strongly:
 Note also that the project builds with `b_ndebug` off, so `assert` is live in
 every configuration here. A debug-assert / release-throw pair does not exist for
 us: the assert would always win and the throw would be unreachable. Hard errors
-of this kind are therefore a throw alone.
+of this kind are therefore a throw alone — that goes for a duplicate key as much
+as for a missing one.
+
+**A throw out of the graph ends the pass, not just the node.** `requirePresent`
+is the first thing in `bq` that makes evaluation throw, and where it surfaces
+depends on what is downstream: a `check` or `share` above it pulls the
+evaluation into `update`, so the exception comes out of
+`SignalContext::update()` with only some of the context's entries advanced and
+`swapFrameData()` skipped. Nothing is corrupted — the next frame recovers — but
+these are not exceptions to catch and continue from; the context should be
+discarded. Worth knowing before anything else in the tree learns to throw.
 
 **`scatter` is the same node.** Its aggregate is positional rather than keyed, but
 the scatter node knows the current key order, so it zips aggregate-with-keys into
@@ -696,13 +712,13 @@ section is that argument, and it is the most important part of this document.
   built for it is destroyed — no retention, no pool, no resurrection. The
   resulting `ArraySignal` is a strict 1:1 mapping of the source array. A key that
   goes away and comes back is a new item, exactly as a changed key is.
-- **Duplicate keys**: assert in debug; unspecified in release. Keys need only be
-  unique **within this `forEach`**, so a duplicate almost always means the caller
-  keyed on the wrong thing. The spike defined a release rule — disambiguate each
-  occurrence by its index, giving `(key, n)` entries — which worked but existed
-  only to satisfy a global-uniqueness requirement that no longer applies. It is
-  deleted rather than kept, because it added a concept to the model in exchange
-  for defining behaviour after a programming error.
+- **Duplicate keys throw.** Keys need only be unique **within this `forEach`**,
+  so a duplicate almost always means the caller keyed on the wrong thing. The
+  spike defined a release rule — disambiguate each occurrence by its index,
+  giving `(key, n)` entries — which worked but existed only to satisfy a
+  global-uniqueness requirement that no longer applies. It is deleted rather
+  than kept, because it added a concept to the model in exchange for defining
+  behaviour after a programming error.
 
 ### No index is passed to the delegate
 
@@ -767,9 +783,11 @@ of operators that no longer exist.
 ### Keys are unique within one `forEach`
 
 Not across the array — see *Identity is internal*. A duplicate key means the
-caller keyed on the wrong thing, so it is a **debug assert**; release behaviour is
-unspecified rather than defined, because defining it (the spike's occurrence-index
-scheme) bought nothing and cost a concept in the public model.
+caller keyed on the wrong thing, so it **throws**, in every build. Defining a
+recovery instead (the spike's occurrence-index scheme) bought nothing and cost a
+concept in the public model; asserting instead would be the same failure with
+less to go on, since `b_ndebug` is off here and an assert takes the process down
+without a message.
 
 ### `scatter`'s aggregate must be size-aligned with the current membership
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,6 +1,6 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, implementation started at step 1.** Steps 0 and 1 of
+> **Status: revised design, implementation started.** Steps 0 and 1 of
 > *Implementation order* have landed; everything from `forEach` onwards is
 > outstanding. The earlier implementation on PR #100 is a **superseded spike**:
 > it put the per-identity table in the description rather than in the
@@ -1245,7 +1245,7 @@ that the discarded builder may carry a genuinely changed widget — is in
 is deleted in favour of the unified engine.
 
 **`DataContext` never prunes.** `data_` holds `weak_ptr`s and an expired entry is
-reclaimed only when the *same* id is initialised again (`datacontext.h:73-78`).
+reclaimed only when the *same* id is initialised again (`datacontext.h:70-79`).
 Every id here is minted fresh, so a long-lived window whose list churns
 accumulates dead map nodes for the life of the context. Pre-existing, but this is
 the first design that mints ids at churn rate, so it becomes load-bearing here.
@@ -1292,13 +1292,15 @@ otherwise start clean.
 
 Steps 0 and 1 are done; the rest is outstanding.
 
-0. **Fix `DataContext::initializeData`'s assert.** A **prerequisite**, not a
-   nicety. `data_` holds `weak_ptr`s and the assert required the id to be absent,
-   but expired entries linger in the map. This design hits that path directly — a key disappears, every consumer drops it, the entry
-   expires, the key returns — so a legal sequence fires a debug assert. Allow an
-   expired entry.
+0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
+   not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
+   absent, but expired entries linger in the map. This design hits that path
+   directly — a key disappears, every consumer drops it, the entry expires, the
+   key returns — so a legal sequence fired the assert. An expired entry is now
+   allowed.
 
-1. **Prove the pick construction.** The smallest thing that can fail. Build the
+1. **Prove the pick construction.** *Done.* The smallest thing that can fail.
+   Build the
    shared keyed source and one `pick(key)` signal by hand, and show: it tracks its
    key across membership changes; it yields no value when its key leaves, and
    asking for one anyway throws; two `SignalContext`s over the same description

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,11 +1,12 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, no implementation.** The earlier implementation on
-> PR #100 is a **superseded spike**: it put the per-identity table in the
-> description rather than in the `SignalContext`, which is a correctness defect,
-> not a limitation. This revision relocates that state and, as a consequence,
-> removes five operators. Start from scratch; read the spike only for the two
-> `bq` `join` fixes it found and for its test cases.
+> **Status: revised design, implementation started at step 1.** Steps 0 and 1 of
+> *Implementation order* have landed; everything from `forEach` onwards is
+> outstanding. The earlier implementation on PR #100 is a **superseded spike**:
+> it put the per-identity table in the description rather than in the
+> `SignalContext`, which is a correctness defect, not a limitation. This revision
+> relocates that state and, as a consequence, removes five operators. Read the
+> spike only for the two `bq` `join` fixes it found and for its test cases.
 >
 > This document remains the design record until the work lands, at which point
 > the stable parts move to their normal homes — the model and its traps to
@@ -484,6 +485,16 @@ search — O(n) per element per update, O(n²) per frame across the array. Shari
 this: the node needs the membership order in its own state regardless, and that
 is where it belongs.
 
+**Share the map behind a pointer, not by value.** Keying removes the scan but not
+the copy: `SharedControl::DataType` holds the shared node's value **by value**
+(`sharedcontrol.h:103`) and re-copies it into every consumer on every changed
+frame (`sharedcontrol.h:199`). Sharing the container itself therefore costs O(n)
+per consumer per update — O(n²) again for an array where every element is picked,
+and n resident copies besides. What the shared signal carries must be a
+`shared_ptr` to an immutable map, so the per-consumer copy is a refcount bump.
+This is a property of `Shared`, not of this design; a by-reference evaluate path
+for shared nodes would remove the constraint, and is worth having independently.
+
 **`pick` latches its last value.** Every signal must always have a value, so
 `pick(key)` cannot return nothing when its key has left the source. The lifetime
 argument says this never happens — the pick signal lives exactly as long as its
@@ -497,8 +508,9 @@ assert rather than something the design leans on.
 
 **The construction is built and proven.** `bq::signal::detail::Pick` and its two
 helpers live in `src/bq/include/bq/signal/detail/pick.h`, with
-`src/bq/test/picktest.cpp` covering the four cases step 1 called for. Three
-results settle points this document had left open or inferred:
+`src/bq/test/picktest.cpp` covering the four cases step 1 called for. Four
+results settle points this document had left open, inferred, or stated too
+strongly:
 
 - Two `SignalContext`s over one `pick` description are wholly independent —
   separate latches, and each evaluates the shared source for itself.
@@ -509,7 +521,19 @@ results settle points this document had left open or inferred:
   sharing is of the state itself and not a coincidence of two copies having seen
   the same values.
 - `pick` reports **no change** while its key is absent, so a latched element is
-  inert rather than merely stale.
+  inert rather than merely stale. It does, however, report a change whenever
+  *any* element of the source changes, because that is what the shared source
+  reports and the element type carries no comparison requirement. Suppressing
+  the repeats is `tryCheck()`'s job, at the point of use — the same answer this
+  document already gives under *Skipping repeats is a property of the data*.
+- **The latch does not remove the ordering argument; it moves it to
+  initialisation.** Instantiations are the only owners of their context data, so
+  a context holding none of them has nothing to latch, and building a pick for a
+  key that is not currently in the source has no value it could report. The node
+  owes the guarantee: create a pick when its key appears, and drop it no later
+  than the update that observes the key leaving. A subtree swapped out and back
+  by `join` or `conditional` breaks that, which is consistent with the reactive
+  subtree minting fresh identity on a swap.
 
 **`scatter` is the same node.** Its aggregate is positional rather than keyed, but
 the scatter node knows the current key order, so it zips aggregate-with-keys into
@@ -1215,6 +1239,12 @@ that the discarded builder may carry a genuinely changed widget — is in
 *Rationale* above and is not merely a cleanup. Both are moot once `dynamicBox`
 is deleted in favour of the unified engine.
 
+**`DataContext` never prunes.** `data_` holds `weak_ptr`s and an expired entry is
+reclaimed only when the *same* id is initialised again (`datacontext.h:73-78`).
+Every id here is minted fresh, so a long-lived window whose list churns
+accumulates dead map nodes for the life of the context. Pre-existing, but this is
+the first design that mints ids at churn rate, so it becomes load-bearing here.
+
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
 stable id. It is expected to be reworked onto `ArraySignal<Window>`. Note that
@@ -1258,9 +1288,8 @@ otherwise start clean.
 Steps 0 and 1 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** A **prerequisite**, not a
-   nicety. `data_` holds `weak_ptr`s and the assert requires the id to be absent
-   (`datacontext.h:70`), but expired entries linger in the map. This design hits
-   that path directly — a key disappears, every consumer drops it, the entry
+   nicety. `data_` holds `weak_ptr`s and the assert required the id to be absent,
+   but expired entries linger in the map. This design hits that path directly — a key disappears, every consumer drops it, the entry
    expires, the key returns — so a legal sequence fires a debug assert. Allow an
    expired entry.
 

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -40,8 +40,9 @@ context's `initialize` and `update` passes — each a single synchronous call ov
 that context's entries. So **per-context state needs no lock**: two
 instantiations of one description in one context are advanced one after the
 other on one thread. What runs concurrently is *contexts*, over a shared
-description (`signaltest.cpp`'s `signal.share` drives 1024 of them on 1024
-threads), and each thread's `findData` reaches a different state object.
+description (`signaltest.cpp`'s `signal.share` drives 1024 of them concurrently
+over a thread pool), and each worker's `findData` reaches a different state
+object.
 
 What does need a lock is **description-level state written from another
 thread**. `InputControl` (`input.h:25`) is the case: `InputHandle::set` writes it
@@ -60,6 +61,11 @@ copy for a new node's per-context state.
   `combine`/`join`/`conditional` (same folder). `constant` (`bq/signal/constant.h`).
 - Streams: `pipe` (`bq/stream/pipe.h`) → `{handle, stream}`, `handle.push`;
   `iterate` (`bq/stream/iterate.h`) folds a stream into a signal; `collect`.
+
+`bq/signal/detail/` holds work that is built and tested but has no public caller
+yet, in namespace `bq::signal::detail`. Currently `pick.h`: `shareKeyed`, `pick`
+and `requirePresent`, the groundwork for `ArraySignal` — see
+`docs/design/arraysignal.md`.
 
 ## Traps
 

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -32,6 +32,26 @@ folder here and leave one-line hooks below.
 - Evaluation is **change-driven**: a signal is recomputed when its inputs
   actually change, not on a fixed frame tick.
 
+## Threading: the context is the unit of concurrency
+
+A `DataContext` is a private member of one `SignalContext`
+(`signalcontext.h:122`), and everything under it is written only by that
+context's `initialize` and `update` passes — each a single synchronous call over
+that context's entries. So **per-context state needs no lock**: two
+instantiations of one description in one context are advanced one after the
+other on one thread. What runs concurrently is *contexts*, over a shared
+description (`signaltest.cpp`'s `signal.share` drives 1024 of them on 1024
+threads), and each thread's `findData` reaches a different state object.
+
+What does need a lock is **description-level state written from another
+thread**. `InputControl` (`input.h:25`) is the case: `InputHandle::set` writes it
+from wherever the caller happens to be. Its per-context `ContextDataType` carries
+no lock, and neither does `Weak`'s (`weak.h:17`).
+
+`SharedControl` is the exception to the shape, not to the rule: its mutex
+(`sharedcontrol.h:54`) sits on per-context data. Do not read it as the pattern to
+copy for a new node's per-context state.
+
 ## Entry points
 
 - State in: `makeInput` (`bq/signal/input.h`) → `{signal, handle}`; push with

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -67,12 +67,13 @@ namespace bq::signal
         template <typename TData, typename... TArgs>
         std::shared_ptr<TData> initializeData(DataId id, TArgs&&... args)
         {
+#ifndef NDEBUG
             // An entry whose data has been released stays in the map until it
             // is overwritten, so re-initializing an id is only an error while
             // the previous data is still alive.
             auto existing = data_.find(id);
             assert(existing == data_.end() || existing->second.expired());
-            (void) existing;
+#endif
 
             auto data = std::make_shared<Data<TData>>(std::forward<TArgs>(args)...);
             data_.insert_or_assign(id, std::weak_ptr<Base>(data));

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -67,7 +67,12 @@ namespace bq::signal
         template <typename TData, typename... TArgs>
         std::shared_ptr<TData> initializeData(DataId id, TArgs&&... args)
         {
-            assert(data_.find(id) == data_.end());
+            // An entry whose data has been released stays in the map until it
+            // is overwritten, so re-initializing an id is only an error while
+            // the previous data is still alive.
+            auto existing = data_.find(id);
+            assert(existing == data_.end() || existing->second.expired());
+            (void) existing;
 
             auto data = std::make_shared<Data<TData>>(std::forward<TArgs>(args)...);
             data_.insert_or_assign(id, std::weak_ptr<Base>(data));

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -33,13 +33,13 @@ namespace bq::signal::detail
 
     /** @brief Blocks template argument deduction for a parameter. */
     template <typename T>
-    struct Identity
+    struct NonDeduced
     {
         using type = T;
     };
 
     template <typename T>
-    using IdentityT = typename Identity<T>::type;
+    using NonDeducedT = typename NonDeduced<T>::type;
 
     /** @brief Signal of the element stored under one key of a keyed source.
      *
@@ -60,6 +60,14 @@ namespace bq::signal::detail
     class Pick
     {
     public:
+        /** @brief The latched value, held once per context.
+         *
+         * Carries no lock. A DataContext belongs to one SignalContext and its
+         * data is written only by that context's initialize and update passes,
+         * so instantiations sharing this state are advanced one after another
+         * on a single thread. Concurrency in bq is between contexts, and
+         * between contexts each thread reaches a different one of these.
+         */
         struct ContextDataType
         {
             explicit ContextDataType(TValue value) :
@@ -167,7 +175,7 @@ namespace bq::signal::detail
      */
     template <typename TStorage, typename TKey, typename TValue>
     auto pick(Signal<TStorage, KeyedElements<TKey, TValue>> source,
-            IdentityT<TKey> key)
+            NonDeducedT<TKey> key)
     {
         using Storage = SignalStorageType<TStorage,
               KeyedElements<TKey, TValue>>;

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "bq/signal/signal.h"
+#include <bq/signal/signal.h>
 
 #include <btl/demangle.h>
+#include <btl/typetraits.h>
 
 #include <cassert>
 #include <map>
@@ -27,16 +28,6 @@ namespace bq::signal::detail
     template <typename TKey, typename TValue>
     using KeyedElements = std::shared_ptr<std::map<TKey, TValue> const>;
 
-    /** @brief Blocks template argument deduction for a parameter. */
-    template <typename T>
-    struct NonDeduced
-    {
-        using type = T;
-    };
-
-    template <typename T>
-    using NonDeducedT = typename NonDeduced<T>::type;
-
     /** @brief Follows the element stored under one key of a keyed source.
      *
      * Yields no value for an update in which the key is absent from the
@@ -49,7 +40,7 @@ namespace bq::signal::detail
      */
     template <typename TStorage, typename TKey, typename TValue>
     auto pick(Signal<TStorage, KeyedElements<TKey, TValue>> source,
-            NonDeducedT<TKey> key)
+            btl::make_type_t<TKey> key)
     {
         return std::move(source).map(
                 [key=std::move(key)](KeyedElements<TKey, TValue> const& keyed)
@@ -62,7 +53,7 @@ namespace bq::signal::detail
                 });
     }
 
-    /** @brief Asserts that a signal has a value, and drops the optional.
+    /** @brief Requires that a signal has a value, and drops the optional.
      *
      * An empty value is a hard error rather than a state to recover from: the
      * caller has said the value is there by construction, so its absence is a

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -1,21 +1,17 @@
 #pragma once
 
-#include "bq/signal/datacontext.h"
-#include "bq/signal/frameinfo.h"
 #include "bq/signal/signal.h"
-#include "bq/signal/signalresult.h"
-#include "bq/signal/signaltraits.h"
-#include "bq/signal/updateresult.h"
-#include "bq/signal/wrap.h"
 
-#include <btl/connection.h>
-#include <btl/uniqueid.h>
+#include <btl/demangle.h>
 
 #include <cassert>
 #include <map>
 #include <memory>
+#include <optional>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 #include <vector>
 
@@ -41,133 +37,11 @@ namespace bq::signal::detail
     template <typename T>
     using NonDeducedT = typename NonDeduced<T>::type;
 
-    /** @brief Signal of the element stored under one key of a keyed source.
+    /** @brief Follows the element stored under one key of a keyed source.
      *
-     * Reads a fixed key out of a signal of KeyedElements. The key need not be
-     * present at every update: while it is absent the signal holds the last
-     * value it saw, so it always has a value to report, and reports no change
-     * until the key returns.
-     *
-     * The latched value is per-context state, looked up by a UniqueId carried
-     * in the description, so every instantiation of one description into one
-     * context latches together while two contexts stay independent.
-     *
-     * A change to any element of the source is reported as a change of this
-     * signal, whether or not the picked element moved. Apply `tryCheck()` to
-     * suppress the repeats for an element type that can be compared.
-     */
-    template <typename TKey, typename TValue, typename TSignal>
-    class Pick
-    {
-    public:
-        /** @brief The latched value, held once per context.
-         *
-         * Carries no lock. A DataContext belongs to one SignalContext and its
-         * data is written only by that context's initialize and update passes,
-         * so instantiations sharing this state are advanced one after another
-         * on a single thread. Concurrency in bq is between contexts, and
-         * between contexts each thread reaches a different one of these.
-         */
-        struct ContextDataType
-        {
-            explicit ContextDataType(TValue value) :
-                value(std::move(value))
-            {
-            }
-
-            TValue value;
-        };
-
-        struct DataType
-        {
-            typename TSignal::DataType signalData;
-            std::shared_ptr<ContextDataType> contextData;
-        };
-
-        Pick(TSignal sig, TKey key, btl::UniqueId id) :
-            sig_(std::move(sig)),
-            key_(std::move(key)),
-            id_(id)
-        {
-        }
-
-        /** @brief Initializes the signal into @p context.
-         *
-         * Instantiations of one description are the only owners of their
-         * latch, so a context holding no live instantiation has nothing to
-         * latch and the key must be present in the source. The caller owes
-         * that: build a pick when its key appears, and drop it no later than
-         * the update that observes the key leaving.
-         *
-         * @throws std::runtime_error if the key is absent from the source and
-         *         the context holds no earlier value for it.
-         */
-        DataType initialize(DataContext& context, FrameInfo const& frame) const
-        {
-            auto signalData = sig_.initialize(context, frame);
-
-            auto contextData = context.findData<ContextDataType>(id_);
-            if (!contextData)
-            {
-                auto keyed = sig_.evaluate(context, signalData)
-                    .template get<0>();
-
-                auto i = keyed->find(key_);
-                if (i == keyed->end())
-                    throw std::runtime_error(
-                            "pick: key is absent and nothing has been latched");
-
-                contextData = context.initializeData<ContextDataType>(id_,
-                        i->second);
-            }
-
-            return { std::move(signalData), std::move(contextData) };
-        }
-
-        SignalResult<TValue const&> evaluate(DataContext&,
-                DataType const& data) const
-        {
-            return SignalResult<TValue const&>(data.contextData->value);
-        }
-
-        UpdateResult update(DataContext& context, DataType& data,
-                FrameInfo const& frame)
-        {
-            UpdateResult result = sig_.update(context, data.signalData, frame);
-
-            if (!result.didChange)
-                return result;
-
-            auto keyed = sig_.evaluate(context, data.signalData)
-                .template get<0>();
-
-            auto i = keyed->find(key_);
-            if (i == keyed->end())
-            {
-                result.didChange = false;
-                return result;
-            }
-
-            data.contextData->value = i->second;
-
-            return result;
-        }
-
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
-        {
-            return sig_.observe(context, data.signalData,
-                    std::forward<TCallback>(callback));
-        }
-
-    private:
-        TSignal sig_;
-        TKey key_;
-        btl::UniqueId id_;
-    };
-
-    /** @brief Builds a signal of one element of a keyed source.
+     * Yields no value for an update in which the key is absent from the
+     * source. A consumer that requires the element to be there says so with
+     * requirePresent().
      *
      * @param source A keyed source, normally the result of shareKeyed().
      * @param key    The key to follow. It is carried by value and is the only
@@ -177,14 +51,38 @@ namespace bq::signal::detail
     auto pick(Signal<TStorage, KeyedElements<TKey, TValue>> source,
             NonDeducedT<TKey> key)
     {
-        using Storage = SignalStorageType<TStorage,
-              KeyedElements<TKey, TValue>>;
+        return std::move(source).map(
+                [key=std::move(key)](KeyedElements<TKey, TValue> const& keyed)
+                {
+                    auto i = keyed->find(key);
+                    if (i == keyed->end())
+                        return std::optional<TValue>();
 
-        return wrap(Pick<TKey, TValue, Storage>(
-                    std::move(source).unwrap(),
-                    std::move(key),
-                    makeUniqueId()
-                    ));
+                    return std::optional<TValue>(i->second);
+                });
+    }
+
+    /** @brief Asserts that a signal has a value, and drops the optional.
+     *
+     * An empty value is a hard error rather than a state to recover from: the
+     * caller has said the value is there by construction, so its absence is a
+     * bug in whatever was supposed to keep it there. For a pick that means the
+     * caller owes the key's presence — build a pick when its key appears, and
+     * drop it no later than the update that observes the key leaving.
+     *
+     * @throws std::runtime_error if the signal has no value.
+     */
+    template <typename TStorage, typename T>
+    auto requirePresent(Signal<TStorage, std::optional<T>> source)
+    {
+        return std::move(source).map([](std::optional<T> const& value) -> T
+                {
+                    if (!value)
+                        throw std::runtime_error("requirePresent: no value of "
+                                + btl::demangle(typeid(T).name()));
+
+                    return *value;
+                });
     }
 
     /** @brief Shares a signal of a vector as a signal of KeyedElements.

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -2,17 +2,14 @@
 
 #include <bq/signal/signal.h>
 
-#include <btl/demangle.h>
 #include <btl/typetraits.h>
 
-#include <cassert>
 #include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#include <typeinfo>
 #include <utility>
 #include <vector>
 
@@ -61,16 +58,27 @@ namespace bq::signal::detail
      * caller owes the key's presence — build a pick when its key appears, and
      * drop it no later than the update that observes the key leaving.
      *
+     * The throw leaves the surrounding pass unfinished: whether it surfaces
+     * from evaluate() or from update() depends on what is downstream, and a
+     * SignalContext that throws out of update() has advanced only some of its
+     * entries. Discard the context rather than driving it again.
+     *
+     * @param description Names the missing value in the error, since nothing
+     *                    about an empty optional says which one it was.
+     *
      * @throws std::runtime_error if the signal has no value.
      */
     template <typename TStorage, typename T>
-    auto requirePresent(Signal<TStorage, std::optional<T>> source)
+    auto requirePresent(Signal<TStorage, std::optional<T>> source,
+            std::string description)
     {
-        return std::move(source).map([](std::optional<T> const& value) -> T
+        return std::move(source).map(
+                [description=std::move(description)]
+                (std::optional<T> const& value) -> T
                 {
                     if (!value)
-                        throw std::runtime_error("requirePresent: no value of "
-                                + btl::demangle(typeid(T).name()));
+                        throw std::runtime_error(
+                                "requirePresent: no value for " + description);
 
                     return *value;
                 });
@@ -82,26 +90,32 @@ namespace bq::signal::detail
      * lookup instead of a scan, so that following every element of a source
      * costs O(n log n) per update rather than O(n^2).
      *
+     * `keyFn` is invoked as a const function, so it cannot carry state. It
+     * lives in the description, which every context over that description
+     * shares, so state in it would be state outside any context.
+     *
      * @param keyFn Maps an element to its key. Keys must be unique within one
-     *              source; a duplicate is a debug assert and the first
-     *              occurrence wins.
+     *              source; a duplicate means the caller keyed on the wrong
+     *              thing, so it is an error rather than something to resolve.
+     *
+     * @throws std::runtime_error if two elements share a key.
      */
     template <typename TStorage, typename T, typename TFunc>
     auto shareKeyed(Signal<TStorage, std::vector<T>> source, TFunc&& keyFn)
     {
-        using TKey = std::decay_t<std::invoke_result_t<TFunc&, T const&>>;
+        using TKey = std::decay_t<std::invoke_result_t<TFunc const&, T const&>>;
 
         return std::move(source)
             .map([keyFn=std::forward<TFunc>(keyFn)]
-                    (std::vector<T> const& items) mutable
+                    (std::vector<T> const& items)
                 {
                     auto keyed = std::make_shared<std::map<TKey, T>>();
 
                     for (auto const& item : items)
                     {
-                        auto inserted = keyed->insert({ keyFn(item), item });
-                        assert(inserted.second);
-                        (void)inserted;
+                        if (!keyed->insert({ keyFn(item), item }).second)
+                            throw std::runtime_error(
+                                    "shareKeyed: duplicate key");
                     }
 
                     return KeyedElements<TKey, T>(std::move(keyed));

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "../datacontext.h"
-#include "../frameinfo.h"
-#include "../signal.h"
-#include "../signalresult.h"
-#include "../signaltraits.h"
-#include "../updateresult.h"
-#include "../wrap.h"
+#include "bq/signal/datacontext.h"
+#include "bq/signal/frameinfo.h"
+#include "bq/signal/signal.h"
+#include "bq/signal/signalresult.h"
+#include "bq/signal/signaltraits.h"
+#include "bq/signal/updateresult.h"
+#include "bq/signal/wrap.h"
 
 #include <btl/connection.h>
 #include <btl/uniqueid.h>
@@ -15,23 +15,46 @@
 #include <map>
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace bq::signal::detail
 {
+    /** @brief A source's elements arranged for lookup by key.
+     *
+     * Held behind a shared pointer because a shared signal copies its value
+     * into every consumer's data on every changed frame. Passing the map by
+     * value would make that copy O(n) per consumer, so following all n
+     * elements of one source would cost O(n^2) per update in copies alone.
+     */
+    template <typename TKey, typename TValue>
+    using KeyedElements = std::shared_ptr<std::map<TKey, TValue> const>;
+
+    /** @brief Blocks template argument deduction for a parameter. */
+    template <typename T>
+    struct Identity
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    using IdentityT = typename Identity<T>::type;
+
     /** @brief Signal of the element stored under one key of a keyed source.
      *
-     * Reads a fixed key out of a signal of `std::map<TKey, TValue>`. The key
-     * need not be present at every update: while it is absent the signal holds
-     * the last value it saw, so it always has a value to report and reports no
-     * change until the key returns.
+     * Reads a fixed key out of a signal of KeyedElements. The key need not be
+     * present at every update: while it is absent the signal holds the last
+     * value it saw, so it always has a value to report, and reports no change
+     * until the key returns.
      *
      * The latched value is per-context state, looked up by a UniqueId carried
      * in the description, so every instantiation of one description into one
      * context latches together while two contexts stay independent.
+     *
+     * A change to any element of the source is reported as a change of this
+     * signal, whether or not the picked element moved. Apply `tryCheck()` to
+     * suppress the repeats for an element type that can be compared.
      */
     template <typename TKey, typename TValue, typename TSignal>
     class Pick
@@ -39,7 +62,7 @@ namespace bq::signal::detail
     public:
         struct ContextDataType
         {
-            ContextDataType(TValue value) :
+            explicit ContextDataType(TValue value) :
                 value(std::move(value))
             {
             }
@@ -62,6 +85,12 @@ namespace bq::signal::detail
 
         /** @brief Initializes the signal into @p context.
          *
+         * Instantiations of one description are the only owners of their
+         * latch, so a context holding no live instantiation has nothing to
+         * latch and the key must be present in the source. The caller owes
+         * that: build a pick when its key appears, and drop it no later than
+         * the update that observes the key leaving.
+         *
          * @throws std::runtime_error if the key is absent from the source and
          *         the context holds no earlier value for it.
          */
@@ -72,11 +101,11 @@ namespace bq::signal::detail
             auto contextData = context.findData<ContextDataType>(id_);
             if (!contextData)
             {
-                auto const& keyed = sig_.evaluate(context, signalData)
+                auto keyed = sig_.evaluate(context, signalData)
                     .template get<0>();
 
-                auto i = keyed.find(key_);
-                if (i == keyed.end())
+                auto i = keyed->find(key_);
+                if (i == keyed->end())
                     throw std::runtime_error(
                             "pick: key is absent and nothing has been latched");
 
@@ -101,11 +130,11 @@ namespace bq::signal::detail
             if (!result.didChange)
                 return result;
 
-            auto const& keyed = sig_.evaluate(context, data.signalData)
+            auto keyed = sig_.evaluate(context, data.signalData)
                 .template get<0>();
 
-            auto i = keyed.find(key_);
-            if (i == keyed.end())
+            auto i = keyed->find(key_);
+            if (i == keyed->end())
             {
                 result.didChange = false;
                 return result;
@@ -137,9 +166,11 @@ namespace bq::signal::detail
      *               thing that distinguishes one pick from another.
      */
     template <typename TStorage, typename TKey, typename TValue>
-    auto pick(Signal<TStorage, std::map<TKey, TValue>> source, TKey key)
+    auto pick(Signal<TStorage, KeyedElements<TKey, TValue>> source,
+            IdentityT<TKey> key)
     {
-        using Storage = SignalStorageType<TStorage, std::map<TKey, TValue>>;
+        using Storage = SignalStorageType<TStorage,
+              KeyedElements<TKey, TValue>>;
 
         return wrap(Pick<TKey, TValue, Storage>(
                     std::move(source).unwrap(),
@@ -148,7 +179,7 @@ namespace bq::signal::detail
                     ));
     }
 
-    /** @brief Shares a signal of a vector as a signal of a key to element map.
+    /** @brief Shares a signal of a vector as a signal of KeyedElements.
      *
      * Keying rather than sharing the vector itself is what keeps a pick a
      * lookup instead of a scan, so that following every element of a source
@@ -167,16 +198,16 @@ namespace bq::signal::detail
             .map([keyFn=std::forward<TFunc>(keyFn)]
                     (std::vector<T> const& items) mutable
                 {
-                    std::map<TKey, T> keyed;
+                    auto keyed = std::make_shared<std::map<TKey, T>>();
 
                     for (auto const& item : items)
                     {
-                        auto inserted = keyed.insert({ keyFn(item), item });
+                        auto inserted = keyed->insert({ keyFn(item), item });
                         assert(inserted.second);
-                        (void) inserted;
+                        (void)inserted;
                     }
 
-                    return keyed;
+                    return KeyedElements<TKey, T>(std::move(keyed));
                 })
             .share();
     }

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "../datacontext.h"
+#include "../frameinfo.h"
+#include "../signal.h"
+#include "../signalresult.h"
+#include "../signaltraits.h"
+#include "../updateresult.h"
+#include "../wrap.h"
+
+#include <btl/connection.h>
+#include <btl/uniqueid.h>
+
+#include <cassert>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace bq::signal::detail
+{
+    /** @brief Signal of the element stored under one key of a keyed source.
+     *
+     * Reads a fixed key out of a signal of `std::map<TKey, TValue>`. The key
+     * need not be present at every update: while it is absent the signal holds
+     * the last value it saw, so it always has a value to report and reports no
+     * change until the key returns.
+     *
+     * The latched value is per-context state, looked up by a UniqueId carried
+     * in the description, so every instantiation of one description into one
+     * context latches together while two contexts stay independent.
+     */
+    template <typename TKey, typename TValue, typename TSignal>
+    class Pick
+    {
+    public:
+        struct ContextDataType
+        {
+            ContextDataType(TValue value) :
+                value(std::move(value))
+            {
+            }
+
+            TValue value;
+        };
+
+        struct DataType
+        {
+            typename TSignal::DataType signalData;
+            std::shared_ptr<ContextDataType> contextData;
+        };
+
+        Pick(TSignal sig, TKey key, btl::UniqueId id) :
+            sig_(std::move(sig)),
+            key_(std::move(key)),
+            id_(id)
+        {
+        }
+
+        /** @brief Initializes the signal into @p context.
+         *
+         * @throws std::runtime_error if the key is absent from the source and
+         *         the context holds no earlier value for it.
+         */
+        DataType initialize(DataContext& context, FrameInfo const& frame) const
+        {
+            auto signalData = sig_.initialize(context, frame);
+
+            auto contextData = context.findData<ContextDataType>(id_);
+            if (!contextData)
+            {
+                auto const& keyed = sig_.evaluate(context, signalData)
+                    .template get<0>();
+
+                auto i = keyed.find(key_);
+                if (i == keyed.end())
+                    throw std::runtime_error(
+                            "pick: key is absent and nothing has been latched");
+
+                contextData = context.initializeData<ContextDataType>(id_,
+                        i->second);
+            }
+
+            return { std::move(signalData), std::move(contextData) };
+        }
+
+        SignalResult<TValue const&> evaluate(DataContext&,
+                DataType const& data) const
+        {
+            return SignalResult<TValue const&>(data.contextData->value);
+        }
+
+        UpdateResult update(DataContext& context, DataType& data,
+                FrameInfo const& frame)
+        {
+            UpdateResult result = sig_.update(context, data.signalData, frame);
+
+            if (!result.didChange)
+                return result;
+
+            auto const& keyed = sig_.evaluate(context, data.signalData)
+                .template get<0>();
+
+            auto i = keyed.find(key_);
+            if (i == keyed.end())
+            {
+                result.didChange = false;
+                return result;
+            }
+
+            data.contextData->value = i->second;
+
+            return result;
+        }
+
+        template <typename TCallback>
+        btl::connection observe(DataContext& context, DataType& data,
+                TCallback&& callback)
+        {
+            return sig_.observe(context, data.signalData,
+                    std::forward<TCallback>(callback));
+        }
+
+    private:
+        TSignal sig_;
+        TKey key_;
+        btl::UniqueId id_;
+    };
+
+    /** @brief Builds a signal of one element of a keyed source.
+     *
+     * @param source A keyed source, normally the result of shareKeyed().
+     * @param key    The key to follow. It is carried by value and is the only
+     *               thing that distinguishes one pick from another.
+     */
+    template <typename TStorage, typename TKey, typename TValue>
+    auto pick(Signal<TStorage, std::map<TKey, TValue>> source, TKey key)
+    {
+        using Storage = SignalStorageType<TStorage, std::map<TKey, TValue>>;
+
+        return wrap(Pick<TKey, TValue, Storage>(
+                    std::move(source).unwrap(),
+                    std::move(key),
+                    makeUniqueId()
+                    ));
+    }
+
+    /** @brief Shares a signal of a vector as a signal of a key to element map.
+     *
+     * Keying rather than sharing the vector itself is what keeps a pick a
+     * lookup instead of a scan, so that following every element of a source
+     * costs O(n log n) per update rather than O(n^2).
+     *
+     * @param keyFn Maps an element to its key. Keys must be unique within one
+     *              source; a duplicate is a debug assert and the first
+     *              occurrence wins.
+     */
+    template <typename TStorage, typename T, typename TFunc>
+    auto shareKeyed(Signal<TStorage, std::vector<T>> source, TFunc&& keyFn)
+    {
+        using TKey = std::decay_t<std::invoke_result_t<TFunc&, T const&>>;
+
+        return std::move(source)
+            .map([keyFn=std::forward<TFunc>(keyFn)]
+                    (std::vector<T> const& items) mutable
+                {
+                    std::map<TKey, T> keyed;
+
+                    for (auto const& item : items)
+                    {
+                        auto inserted = keyed.insert({ keyFn(item), item });
+                        assert(inserted.second);
+                        (void) inserted;
+                    }
+
+                    return keyed;
+                })
+            .share();
+    }
+} // namespace bq::signal::detail

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -17,6 +17,8 @@ libbqdep = declare_dependency(
   )
 
 bqtest = executable('bqtest',
+  'test/datacontexttest.cpp',
+  'test/picktest.cpp',
   'test/signaltest.cpp',
   'test/signalcontexttest.cpp',
   'test/streamtest.cpp',

--- a/src/bq/test/datacontexttest.cpp
+++ b/src/bq/test/datacontexttest.cpp
@@ -27,9 +27,9 @@ TEST(dataContext, expiredIdCanBeInitializedAgain)
     EXPECT_EQ(7, *context.findData<int>(id));
 }
 
-// Two ids are independent, and re-initializing an expired one leaves the other
-// alone.
-TEST(dataContext, expiryOfOneIdLeavesOthersAlone)
+// Re-initializing an expired id replaces only that id's data. A live id held
+// across the same sequence keeps both its entry and the value behind it.
+TEST(dataContext, reinitializingAnExpiredIdLeavesLiveIdsAlone)
 {
     DataContext context;
     auto first = makeUniqueId();
@@ -42,8 +42,10 @@ TEST(dataContext, expiryOfOneIdLeavesOthersAlone)
         EXPECT_EQ(2, *data);
     }
 
-    context.initializeData<int>(second, 3);
+    auto replaced = context.initializeData<int>(second, 3);
 
+    EXPECT_EQ(3, *replaced);
+    EXPECT_EQ(3, *context.findData<int>(second));
     EXPECT_EQ(1, *context.findData<int>(first));
     EXPECT_EQ(1, *kept);
 }

--- a/src/bq/test/datacontexttest.cpp
+++ b/src/bq/test/datacontexttest.cpp
@@ -1,0 +1,49 @@
+#include <bq/signal/datacontext.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace bq::signal;
+
+// DataContext keeps weak references, so an id whose data has been released
+// still has an entry in the map. Initializing that id again is the normal way
+// a node that comes back after everything dropped it gets its state.
+TEST(dataContext, expiredIdCanBeInitializedAgain)
+{
+    DataContext context;
+    auto id = makeUniqueId();
+
+    {
+        auto data = context.initializeData<int>(id, 42);
+        EXPECT_EQ(42, *data);
+        EXPECT_EQ(42, *context.findData<int>(id));
+    }
+
+    EXPECT_EQ(nullptr, context.findData<int>(id));
+
+    auto data = context.initializeData<int>(id, 7);
+    EXPECT_EQ(7, *data);
+    EXPECT_EQ(7, *context.findData<int>(id));
+}
+
+// Two ids are independent, and re-initializing an expired one leaves the other
+// alone.
+TEST(dataContext, expiryOfOneIdLeavesOthersAlone)
+{
+    DataContext context;
+    auto first = makeUniqueId();
+    auto second = makeUniqueId();
+
+    auto kept = context.initializeData<int>(first, 1);
+
+    {
+        auto data = context.initializeData<int>(second, 2);
+        EXPECT_EQ(2, *data);
+    }
+
+    context.initializeData<int>(second, 3);
+
+    EXPECT_EQ(1, *context.findData<int>(first));
+    EXPECT_EQ(1, *kept);
+}

--- a/src/bq/test/picktest.cpp
+++ b/src/bq/test/picktest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -45,7 +46,9 @@ namespace
 } // namespace
 
 // A pick follows its own key's value while the rest of the membership moves
-// around it: elements inserted before it, elements removed, elements reordered.
+// around it. Each membership change carries a change to the picked element as
+// well, so a pick that stopped following would be caught rather than agreeing
+// by accident.
 TEST(pick, followsItsKeyAcrossMembershipChanges)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
@@ -55,22 +58,26 @@ TEST(pick, followsItsKeyAcrossMembershipChanges)
 
     EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
 
-    input.handle.set(std::vector<Item>{ { "c", 3 }, { "a", 1 }, { "b", 2 } });
+    // An element is inserted ahead of it.
+    input.handle.set(std::vector<Item>{ { "c", 3 }, { "a", 1 }, { "b", 20 } });
     context.update(FrameInfo(1, {}));
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
-
-    input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 2 } });
-    context.update(FrameInfo(2, {}));
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
-
-    input.handle.set(std::vector<Item>{ { "b", 2 }, { "c", 3 } });
-    context.update(FrameInfo(3, {}));
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
-
-    input.handle.set(std::vector<Item>{ { "b", 20 }, { "c", 3 } });
-    context.update(FrameInfo(4, {}));
-    EXPECT_TRUE(context.didChange<0>());
     EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
+
+    // Another element is removed.
+    input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 30 } });
+    context.update(FrameInfo(2, {}));
+    EXPECT_EQ(30, context.evaluate<0>().get<0>().value);
+
+    // It moves to the other end.
+    input.handle.set(std::vector<Item>{ { "b", 40 }, { "c", 3 } });
+    context.update(FrameInfo(3, {}));
+    EXPECT_EQ(40, context.evaluate<0>().get<0>().value);
+
+    // A pure reorder is invisible to a pick: the keyed source is the same map
+    // either way.
+    input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 40 } });
+    context.update(FrameInfo(4, {}));
+    EXPECT_EQ(40, context.evaluate<0>().get<0>().value);
 }
 
 // Every signal always has a value, so a pick whose key leaves the source holds
@@ -99,6 +106,33 @@ TEST(pick, latchesWhileItsKeyIsAbsent)
     context.update(FrameInfo(3, {}));
     EXPECT_TRUE(context.didChange<0>());
     EXPECT_EQ(30, context.evaluate<0>().get<0>().value);
+}
+
+// A pick reports a change whenever the source changes, even when the picked
+// element did not move. Suppressing the repeats is the caller's choice, made
+// with the facility bq already has for it.
+TEST(pick, reportsAChangeOfAnyElementAndCheckSuppressesIt)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+    auto shared = shareKeyed(input.signal, itemKey);
+
+    auto value = [](Item const& item)
+    {
+        return item.value;
+    };
+
+    auto context = makeSignalContext(
+            pick(shared, std::string("b")).map(value),
+            pick(shared, std::string("b")).map(value).check());
+
+    // Only "a" moves.
+    input.handle.set(std::vector<Item>{ { "a", 100 }, { "b", 2 } });
+    context.update(FrameInfo(1, {}));
+
+    EXPECT_TRUE(context.didChange<0>());
+    EXPECT_FALSE(context.didChange<1>());
+    EXPECT_EQ(2, context.evaluate<0>().get<0>());
+    EXPECT_EQ(2, context.evaluate<1>().get<0>());
 }
 
 // State lives in the SignalContext, so two contexts over one description share
@@ -142,10 +176,10 @@ TEST(pick, twoContextsOverOneDescriptionAreIndependent)
     EXPECT_EQ(30, first.evaluate<0>().get<0>().value);
 }
 
-// The mirror image: one description instantiated twice into one context finds
-// the same state through its UniqueId. The shared source is evaluated once per
-// pass rather than once per consumer, and both entries latch together.
-TEST(pick, oneDescriptionTwiceInOneContextSharesState)
+// The same sharing along the path a SignalContext actually takes: two entries
+// over one description, one source evaluation per pass, and both entries moving
+// and latching together.
+TEST(pick, twoContextEntriesOverOneDescriptionMoveTogether)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
     auto passes = std::make_shared<int>(0);
@@ -176,10 +210,41 @@ TEST(pick, oneDescriptionTwiceInOneContextSharesState)
     EXPECT_EQ(20, context.evaluate<1>().get<0>().value);
 }
 
-// Sharing is a lookup of the latch itself, not a coincidence of two copies
-// having seen the same values: a second instantiation made after the key has
-// already left the source finds the value the first one latched.
-TEST(pick, aLaterInstantiationInOneContextFindsTheLatch)
+// Two instantiations of one description in one context share their state, and
+// the source behind them is evaluated once per pass rather than once per
+// instantiation. The sharing is of the latch itself, not two copies happening
+// to have seen the same values: the second instantiation is made after the key
+// has already left the source, so without the sharing it would have nothing to
+// latch and would throw.
+TEST(pick, oneDescriptionTwiceInOneContextSharesState)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+    auto passes = std::make_shared<int>(0);
+
+    auto description = pick(countedShareKeyed(input.signal, passes),
+            std::string("b"));
+    auto& sig = description.unwrap();
+
+    DataContext context;
+
+    auto first = sig.initialize(context, FrameInfo(0, {}));
+    EXPECT_EQ(1, *passes);
+    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    sig.update(context, first, FrameInfo(1, {}));
+    EXPECT_EQ(2, *passes);
+    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+
+    auto second = sig.initialize(context, FrameInfo(1, {}));
+    EXPECT_EQ(2, *passes);
+    EXPECT_EQ(2, sig.evaluate(context, second).get<0>().value);
+}
+
+// The other side of that: instantiations are the only owners of the latch, so a
+// context that holds none of them has nothing to latch, and a pick built for a
+// key the source does not have has no value it could report.
+TEST(pick, initializingWithNoLatchAndNoKeyThrows)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
 
@@ -189,15 +254,15 @@ TEST(pick, aLaterInstantiationInOneContextFindsTheLatch)
 
     DataContext context;
 
-    auto first = sig.initialize(context, FrameInfo(0, {}));
-    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+    {
+        auto data = sig.initialize(context, FrameInfo(0, {}));
+        EXPECT_EQ(2, sig.evaluate(context, data).get<0>().value);
+    }
 
     input.handle.set(std::vector<Item>{ { "a", 1 } });
-    sig.update(context, first, FrameInfo(1, {}));
-    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
 
-    auto second = sig.initialize(context, FrameInfo(1, {}));
-    EXPECT_EQ(2, sig.evaluate(context, second).get<0>().value);
+    EXPECT_THROW(sig.initialize(context, FrameInfo(1, {})),
+            std::runtime_error);
 }
 
 // The state of a pick that nothing holds any more expires while its entry stays

--- a/src/bq/test/picktest.cpp
+++ b/src/bq/test/picktest.cpp
@@ -31,6 +31,23 @@ namespace
         return item.key;
     };
 
+    template <typename TFunc>
+    void expectThrowsContaining(TFunc&& func, std::string const& text)
+    {
+        try
+        {
+            func();
+        }
+        catch (std::runtime_error const& e)
+        {
+            EXPECT_NE(std::string::npos, std::string(e.what()).find(text))
+                << e.what();
+            return;
+        }
+
+        ADD_FAILURE() << "expected a std::runtime_error containing " << text;
+    }
+
     // Counts how many times the source is evaluated, from inside the shared
     // subgraph so that the count is a count of evaluation passes.
     template <typename TSignal>
@@ -107,13 +124,14 @@ TEST(pick, hasNoValueWhileItsKeyIsAbsent)
 }
 
 // A consumer that needs the element to be there says so, and gets a loud
-// failure rather than a quiet one when it is not.
-TEST(pick, requirePresentThrowsOnAnAbsentKey)
+// failure naming what was missing rather than a quiet one when it is not.
+TEST(pick, requirePresentThrowsWhenTheKeyLeaves)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
 
     auto description = requirePresent(
-            pick(shareKeyed(input.signal, itemKey), std::string("b")));
+            pick(shareKeyed(input.signal, itemKey), std::string("b")),
+            "element b");
     auto& sig = description.unwrap();
 
     DataContext context;
@@ -124,7 +142,36 @@ TEST(pick, requirePresentThrowsOnAnAbsentKey)
     input.handle.set(std::vector<Item>{ { "a", 1 } });
     sig.update(context, data, FrameInfo(1, {}));
 
-    EXPECT_THROW(sig.evaluate(context, data), std::runtime_error);
+    expectThrowsContaining([&] { sig.evaluate(context, data); },
+            "element b");
+}
+
+// The obligation a caller owes is to build a pick when its key appears. Getting
+// that wrong fails at once, on the initial evaluation, rather than surfacing
+// later as a value that is quietly wrong.
+TEST(pick, requirePresentThrowsWhenTheKeyWasNeverThere)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 } });
+
+    auto description = requirePresent(
+            pick(shareKeyed(input.signal, itemKey), std::string("b")),
+            "element b");
+
+    expectThrowsContaining([&] { makeSignalContext(description); },
+            "element b");
+}
+
+// A key the caller thought was unique but is not means the wrong thing was
+// keyed on, so it fails rather than silently dropping an element.
+TEST(pick, shareKeyedThrowsOnADuplicateKey)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "a", 2 } });
+
+    auto description = pick(shareKeyed(input.signal, itemKey),
+            std::string("a"));
+
+    expectThrowsContaining([&] { makeSignalContext(description); },
+            "duplicate key");
 }
 
 // A pick reports a change whenever the source changes, even when the picked
@@ -141,8 +188,8 @@ TEST(pick, reportsAChangeOfAnyElementAndCheckSuppressesIt)
     };
 
     auto context = makeSignalContext(
-            requirePresent(pick(shared, std::string("b"))).map(value),
-            requirePresent(pick(shared, std::string("b")))
+            requirePresent(pick(shared, std::string("b")), "b").map(value),
+            requirePresent(pick(shared, std::string("b")), "b")
                 .map(value)
                 .check());
 

--- a/src/bq/test/picktest.cpp
+++ b/src/bq/test/picktest.cpp
@@ -1,0 +1,226 @@
+#include <bq/signal/detail/pick.h>
+
+#include <bq/signal/datacontext.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace bq::signal;
+using bq::signal::detail::pick;
+using bq::signal::detail::shareKeyed;
+
+namespace
+{
+    struct Item
+    {
+        std::string key;
+        int value;
+    };
+
+    auto itemKey = [](Item const& item)
+    {
+        return item.key;
+    };
+
+    // Counts how many times the source is evaluated, from inside the shared
+    // subgraph so that the count is a count of evaluation passes.
+    template <typename TSignal>
+    auto countedShareKeyed(TSignal source, std::shared_ptr<int> passes)
+    {
+        return shareKeyed(
+                std::move(source).map([passes](std::vector<Item> const& items)
+                    {
+                        ++*passes;
+                        return items;
+                    }),
+                itemKey);
+    }
+} // namespace
+
+// A pick follows its own key's value while the rest of the membership moves
+// around it: elements inserted before it, elements removed, elements reordered.
+TEST(pick, followsItsKeyAcrossMembershipChanges)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+
+    auto context = makeSignalContext(
+            pick(shareKeyed(input.signal, itemKey), std::string("b")));
+
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "c", 3 }, { "a", 1 }, { "b", 2 } });
+    context.update(FrameInfo(1, {}));
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 2 } });
+    context.update(FrameInfo(2, {}));
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "b", 2 }, { "c", 3 } });
+    context.update(FrameInfo(3, {}));
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "b", 20 }, { "c", 3 } });
+    context.update(FrameInfo(4, {}));
+    EXPECT_TRUE(context.didChange<0>());
+    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
+}
+
+// Every signal always has a value, so a pick whose key leaves the source holds
+// the last value it saw and reports no change. It follows the key again once
+// the key comes back.
+TEST(pick, latchesWhileItsKeyIsAbsent)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+
+    auto context = makeSignalContext(
+            pick(shareKeyed(input.signal, itemKey), std::string("b")));
+
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    context.update(FrameInfo(1, {}));
+    EXPECT_FALSE(context.didChange<0>());
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 10 } });
+    context.update(FrameInfo(2, {}));
+    EXPECT_FALSE(context.didChange<0>());
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 10 }, { "b", 30 } });
+    context.update(FrameInfo(3, {}));
+    EXPECT_TRUE(context.didChange<0>());
+    EXPECT_EQ(30, context.evaluate<0>().get<0>().value);
+}
+
+// State lives in the SignalContext, so two contexts over one description share
+// nothing: each evaluates the source for itself and each keeps its own latch.
+// Driving one must leave the other exactly where it was.
+TEST(pick, twoContextsOverOneDescriptionAreIndependent)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+    auto passes = std::make_shared<int>(0);
+
+    auto description = pick(countedShareKeyed(input.signal, passes),
+            std::string("b"));
+
+    auto first = makeSignalContext(description);
+    auto second = makeSignalContext(description);
+
+    EXPECT_EQ(2, *passes);
+    EXPECT_EQ(2, first.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+
+    // The key leaves, and only the first context is driven. It latches; the
+    // second has not seen the change at all.
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    first.update(FrameInfo(1, {}));
+    EXPECT_EQ(3, *passes);
+    EXPECT_FALSE(first.didChange<0>());
+    EXPECT_EQ(2, first.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+
+    // The key returns with a new value, still only for the first context.
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 30 } });
+    first.update(FrameInfo(2, {}));
+    EXPECT_EQ(30, first.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+
+    // Driving the second context moves it alone. It never saw the value the
+    // first context latched on the way.
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 40 } });
+    second.update(FrameInfo(1, {}));
+    EXPECT_EQ(40, second.evaluate<0>().get<0>().value);
+    EXPECT_EQ(30, first.evaluate<0>().get<0>().value);
+}
+
+// The mirror image: one description instantiated twice into one context finds
+// the same state through its UniqueId. The shared source is evaluated once per
+// pass rather than once per consumer, and both entries latch together.
+TEST(pick, oneDescriptionTwiceInOneContextSharesState)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+    auto passes = std::make_shared<int>(0);
+
+    auto description = pick(countedShareKeyed(input.signal, passes),
+            std::string("b"));
+
+    auto context = makeSignalContext(description, description);
+
+    EXPECT_EQ(1, *passes);
+    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, context.evaluate<1>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 20 } });
+    context.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(2, *passes);
+    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(20, context.evaluate<1>().get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    context.update(FrameInfo(2, {}));
+
+    EXPECT_EQ(3, *passes);
+    EXPECT_FALSE(context.didChange<0>());
+    EXPECT_FALSE(context.didChange<1>());
+    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(20, context.evaluate<1>().get<0>().value);
+}
+
+// Sharing is a lookup of the latch itself, not a coincidence of two copies
+// having seen the same values: a second instantiation made after the key has
+// already left the source finds the value the first one latched.
+TEST(pick, aLaterInstantiationInOneContextFindsTheLatch)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+
+    auto description = pick(shareKeyed(input.signal, itemKey),
+            std::string("b"));
+    auto& sig = description.unwrap();
+
+    DataContext context;
+
+    auto first = sig.initialize(context, FrameInfo(0, {}));
+    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    sig.update(context, first, FrameInfo(1, {}));
+    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+
+    auto second = sig.initialize(context, FrameInfo(1, {}));
+    EXPECT_EQ(2, sig.evaluate(context, second).get<0>().value);
+}
+
+// The state of a pick that nothing holds any more expires while its entry stays
+// in the DataContext's map. Initializing the same description into the same
+// context again must start over from the current source rather than trip over
+// the stale entry.
+TEST(pick, canBeInitializedAgainAfterItsStateExpired)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+
+    auto description = pick(shareKeyed(input.signal, itemKey),
+            std::string("b"));
+    auto& sig = description.unwrap();
+
+    DataContext context;
+
+    {
+        auto data = sig.initialize(context, FrameInfo(0, {}));
+        EXPECT_EQ(2, sig.evaluate(context, data).get<0>().value);
+    }
+
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 5 } });
+
+    auto data = sig.initialize(context, FrameInfo(1, {}));
+    EXPECT_EQ(5, sig.evaluate(context, data).get<0>().value);
+}

--- a/src/bq/test/picktest.cpp
+++ b/src/bq/test/picktest.cpp
@@ -15,6 +15,7 @@
 
 using namespace bq::signal;
 using bq::signal::detail::pick;
+using bq::signal::detail::requirePresent;
 using bq::signal::detail::shareKeyed;
 
 namespace
@@ -56,56 +57,74 @@ TEST(pick, followsItsKeyAcrossMembershipChanges)
     auto context = makeSignalContext(
             pick(shareKeyed(input.signal, itemKey), std::string("b")));
 
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, context.evaluate<0>().get<0>()->value);
 
     // An element is inserted ahead of it.
     input.handle.set(std::vector<Item>{ { "c", 3 }, { "a", 1 }, { "b", 20 } });
     context.update(FrameInfo(1, {}));
-    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(20, context.evaluate<0>().get<0>()->value);
 
     // Another element is removed.
     input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 30 } });
     context.update(FrameInfo(2, {}));
-    EXPECT_EQ(30, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(30, context.evaluate<0>().get<0>()->value);
 
     // It moves to the other end.
     input.handle.set(std::vector<Item>{ { "b", 40 }, { "c", 3 } });
     context.update(FrameInfo(3, {}));
-    EXPECT_EQ(40, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(40, context.evaluate<0>().get<0>()->value);
 
     // A pure reorder is invisible to a pick: the keyed source is the same map
     // either way.
     input.handle.set(std::vector<Item>{ { "c", 3 }, { "b", 40 } });
     context.update(FrameInfo(4, {}));
-    EXPECT_EQ(40, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(40, context.evaluate<0>().get<0>()->value);
 }
 
-// Every signal always has a value, so a pick whose key leaves the source holds
-// the last value it saw and reports no change. It follows the key again once
-// the key comes back.
-TEST(pick, latchesWhileItsKeyIsAbsent)
+// A key that is not in the source has no value. It is reported as such rather
+// than as a stale one, and the pick follows the key again if it comes back.
+TEST(pick, hasNoValueWhileItsKeyIsAbsent)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
 
     auto context = makeSignalContext(
             pick(shareKeyed(input.signal, itemKey), std::string("b")));
 
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, context.evaluate<0>().get<0>()->value);
 
     input.handle.set(std::vector<Item>{ { "a", 1 } });
     context.update(FrameInfo(1, {}));
-    EXPECT_FALSE(context.didChange<0>());
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+    EXPECT_FALSE(context.evaluate<0>().get<0>().has_value());
 
     input.handle.set(std::vector<Item>{ { "a", 10 } });
     context.update(FrameInfo(2, {}));
-    EXPECT_FALSE(context.didChange<0>());
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
+    EXPECT_FALSE(context.evaluate<0>().get<0>().has_value());
 
+    // The key returns and is picked up again.
     input.handle.set(std::vector<Item>{ { "a", 10 }, { "b", 30 } });
     context.update(FrameInfo(3, {}));
-    EXPECT_TRUE(context.didChange<0>());
-    EXPECT_EQ(30, context.evaluate<0>().get<0>().value);
+    EXPECT_EQ(30, context.evaluate<0>().get<0>()->value);
+}
+
+// A consumer that needs the element to be there says so, and gets a loud
+// failure rather than a quiet one when it is not.
+TEST(pick, requirePresentThrowsOnAnAbsentKey)
+{
+    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+
+    auto description = requirePresent(
+            pick(shareKeyed(input.signal, itemKey), std::string("b")));
+    auto& sig = description.unwrap();
+
+    DataContext context;
+
+    auto data = sig.initialize(context, FrameInfo(0, {}));
+    EXPECT_EQ(2, sig.evaluate(context, data).get<0>().value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    sig.update(context, data, FrameInfo(1, {}));
+
+    EXPECT_THROW(sig.evaluate(context, data), std::runtime_error);
 }
 
 // A pick reports a change whenever the source changes, even when the picked
@@ -122,8 +141,10 @@ TEST(pick, reportsAChangeOfAnyElementAndCheckSuppressesIt)
     };
 
     auto context = makeSignalContext(
-            pick(shared, std::string("b")).map(value),
-            pick(shared, std::string("b")).map(value).check());
+            requirePresent(pick(shared, std::string("b"))).map(value),
+            requirePresent(pick(shared, std::string("b")))
+                .map(value)
+                .check());
 
     // Only "a" moves.
     input.handle.set(std::vector<Item>{ { "a", 100 }, { "b", 2 } });
@@ -136,8 +157,8 @@ TEST(pick, reportsAChangeOfAnyElementAndCheckSuppressesIt)
 }
 
 // State lives in the SignalContext, so two contexts over one description share
-// nothing: each evaluates the source for itself and each keeps its own latch.
-// Driving one must leave the other exactly where it was.
+// nothing: each evaluates the source for itself, and driving one must leave the
+// other exactly where it was.
 TEST(pick, twoContextsOverOneDescriptionAreIndependent)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
@@ -150,73 +171,35 @@ TEST(pick, twoContextsOverOneDescriptionAreIndependent)
     auto second = makeSignalContext(description);
 
     EXPECT_EQ(2, *passes);
-    EXPECT_EQ(2, first.evaluate<0>().get<0>().value);
-    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+    EXPECT_EQ(2, first.evaluate<0>().get<0>()->value);
+    EXPECT_EQ(2, second.evaluate<0>().get<0>()->value);
 
-    // The key leaves, and only the first context is driven. It latches; the
-    // second has not seen the change at all.
+    // The key leaves, and only the first context is driven. The second has not
+    // seen the change at all.
     input.handle.set(std::vector<Item>{ { "a", 1 } });
     first.update(FrameInfo(1, {}));
     EXPECT_EQ(3, *passes);
-    EXPECT_FALSE(first.didChange<0>());
-    EXPECT_EQ(2, first.evaluate<0>().get<0>().value);
-    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+    EXPECT_FALSE(first.evaluate<0>().get<0>().has_value());
+    EXPECT_EQ(2, second.evaluate<0>().get<0>()->value);
 
     // The key returns with a new value, still only for the first context.
     input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 30 } });
     first.update(FrameInfo(2, {}));
-    EXPECT_EQ(30, first.evaluate<0>().get<0>().value);
-    EXPECT_EQ(2, second.evaluate<0>().get<0>().value);
+    EXPECT_EQ(30, first.evaluate<0>().get<0>()->value);
+    EXPECT_EQ(2, second.evaluate<0>().get<0>()->value);
 
     // Driving the second context moves it alone. It never saw the value the
-    // first context latched on the way.
+    // first context passed through on the way.
     input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 40 } });
     second.update(FrameInfo(1, {}));
-    EXPECT_EQ(40, second.evaluate<0>().get<0>().value);
-    EXPECT_EQ(30, first.evaluate<0>().get<0>().value);
+    EXPECT_EQ(40, second.evaluate<0>().get<0>()->value);
+    EXPECT_EQ(30, first.evaluate<0>().get<0>()->value);
 }
 
-// The same sharing along the path a SignalContext actually takes: two entries
-// over one description, one source evaluation per pass, and both entries moving
-// and latching together.
-TEST(pick, twoContextEntriesOverOneDescriptionMoveTogether)
-{
-    auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
-    auto passes = std::make_shared<int>(0);
-
-    auto description = pick(countedShareKeyed(input.signal, passes),
-            std::string("b"));
-
-    auto context = makeSignalContext(description, description);
-
-    EXPECT_EQ(1, *passes);
-    EXPECT_EQ(2, context.evaluate<0>().get<0>().value);
-    EXPECT_EQ(2, context.evaluate<1>().get<0>().value);
-
-    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 20 } });
-    context.update(FrameInfo(1, {}));
-
-    EXPECT_EQ(2, *passes);
-    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
-    EXPECT_EQ(20, context.evaluate<1>().get<0>().value);
-
-    input.handle.set(std::vector<Item>{ { "a", 1 } });
-    context.update(FrameInfo(2, {}));
-
-    EXPECT_EQ(3, *passes);
-    EXPECT_FALSE(context.didChange<0>());
-    EXPECT_FALSE(context.didChange<1>());
-    EXPECT_EQ(20, context.evaluate<0>().get<0>().value);
-    EXPECT_EQ(20, context.evaluate<1>().get<0>().value);
-}
-
-// Two instantiations of one description in one context share their state, and
-// the source behind them is evaluated once per pass rather than once per
-// instantiation. The sharing is of the latch itself, not two copies happening
-// to have seen the same values: the second instantiation is made after the key
-// has already left the source, so without the sharing it would have nothing to
-// latch and would throw.
-TEST(pick, oneDescriptionTwiceInOneContextSharesState)
+// One description instantiated twice into one context finds the state of the
+// shared source it already has there: the source is evaluated once per pass
+// rather than once per consumer.
+TEST(pick, oneDescriptionTwiceInOneContextSharesTheSource)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
     auto passes = std::make_shared<int>(0);
@@ -229,46 +212,58 @@ TEST(pick, oneDescriptionTwiceInOneContextSharesState)
 
     auto first = sig.initialize(context, FrameInfo(0, {}));
     EXPECT_EQ(1, *passes);
-    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+    EXPECT_EQ(2, sig.evaluate(context, first).get<0>()->value);
 
-    input.handle.set(std::vector<Item>{ { "a", 1 } });
+    // A second instantiation into the same context adds no evaluation of its
+    // own, at initialization or afterwards.
+    auto second = sig.initialize(context, FrameInfo(0, {}));
+    EXPECT_EQ(1, *passes);
+    EXPECT_EQ(2, sig.evaluate(context, second).get<0>()->value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 20 } });
     sig.update(context, first, FrameInfo(1, {}));
-    EXPECT_EQ(2, *passes);
-    EXPECT_EQ(2, sig.evaluate(context, first).get<0>().value);
+    sig.update(context, second, FrameInfo(1, {}));
 
-    auto second = sig.initialize(context, FrameInfo(1, {}));
     EXPECT_EQ(2, *passes);
-    EXPECT_EQ(2, sig.evaluate(context, second).get<0>().value);
+    EXPECT_EQ(20, sig.evaluate(context, first).get<0>()->value);
+    EXPECT_EQ(20, sig.evaluate(context, second).get<0>()->value);
 }
 
-// The other side of that: instantiations are the only owners of the latch, so a
-// context that holds none of them has nothing to latch, and a pick built for a
-// key the source does not have has no value it could report.
-TEST(pick, initializingWithNoLatchAndNoKeyThrows)
+// The same sharing along the path a SignalContext actually takes: two entries
+// over one description, one source evaluation per pass, both entries agreeing.
+TEST(pick, twoContextEntriesOverOneDescriptionMoveTogether)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
+    auto passes = std::make_shared<int>(0);
 
-    auto description = pick(shareKeyed(input.signal, itemKey),
+    auto description = pick(countedShareKeyed(input.signal, passes),
             std::string("b"));
-    auto& sig = description.unwrap();
 
-    DataContext context;
+    auto context = makeSignalContext(description, description);
 
-    {
-        auto data = sig.initialize(context, FrameInfo(0, {}));
-        EXPECT_EQ(2, sig.evaluate(context, data).get<0>().value);
-    }
+    EXPECT_EQ(1, *passes);
+    EXPECT_EQ(2, context.evaluate<0>().get<0>()->value);
+    EXPECT_EQ(2, context.evaluate<1>().get<0>()->value);
+
+    input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 20 } });
+    context.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(2, *passes);
+    EXPECT_EQ(20, context.evaluate<0>().get<0>()->value);
+    EXPECT_EQ(20, context.evaluate<1>().get<0>()->value);
 
     input.handle.set(std::vector<Item>{ { "a", 1 } });
+    context.update(FrameInfo(2, {}));
 
-    EXPECT_THROW(sig.initialize(context, FrameInfo(1, {})),
-            std::runtime_error);
+    EXPECT_EQ(3, *passes);
+    EXPECT_FALSE(context.evaluate<0>().get<0>().has_value());
+    EXPECT_FALSE(context.evaluate<1>().get<0>().has_value());
 }
 
-// The state of a pick that nothing holds any more expires while its entry stays
-// in the DataContext's map. Initializing the same description into the same
-// context again must start over from the current source rather than trip over
-// the stale entry.
+// The per-context state of a graph that nothing holds any more expires while
+// its entries stay in the DataContext's map. Initializing the same description
+// into the same context again must start over from the current source rather
+// than trip over the stale entries.
 TEST(pick, canBeInitializedAgainAfterItsStateExpired)
 {
     auto input = makeInput(std::vector<Item>{ { "a", 1 }, { "b", 2 } });
@@ -281,11 +276,11 @@ TEST(pick, canBeInitializedAgainAfterItsStateExpired)
 
     {
         auto data = sig.initialize(context, FrameInfo(0, {}));
-        EXPECT_EQ(2, sig.evaluate(context, data).get<0>().value);
+        EXPECT_EQ(2, sig.evaluate(context, data).get<0>()->value);
     }
 
     input.handle.set(std::vector<Item>{ { "a", 1 }, { "b", 5 } });
 
     auto data = sig.initialize(context, FrameInfo(1, {}));
-    EXPECT_EQ(5, sig.evaluate(context, data).get<0>().value);
+    EXPECT_EQ(5, sig.evaluate(context, data).get<0>()->value);
 }


### PR DESCRIPTION
Steps 0 and 1 of the implementation order in `docs/design/arraysignal.md`, stacked
on #110 (which carries the revised design). Nothing here is public API yet, and
nothing depends on it: `forEach`, the array node, `concat`, `map`, `scatter` and
`join` are step 2+ and land separately.

## Step 0 — `DataContext::initializeData`

The context holds weak references, so an entry whose data has been released
lingers in the map. A key that goes away, is dropped by every consumer, and then
comes back has to initialize over that stale entry — a legal sequence that fired
the debug assert. The assert now only rejects an id whose data is still alive.

`src/bq/test/datacontexttest.cpp` exercises the expire-then-reinitialise sequence
directly, and `pick.canBeInitializedAgainAfterItsStateExpired` covers it through
a real signal graph. Both abort on the previous assert.

## Step 1 — the pick construction

Three function templates in `bq::signal::detail`, in `detail/pick.h`. **No custom
signal node and no per-context state** — the whole construction is `map` and
`share`:

- `shareKeyed(source, keyFn)` maps a signal of a vector once into a signal of a
  key-to-element map and shares it, so following an element is a lookup rather
  than a scan.
- `pick(shared, key)` is a plain `map` yielding `AnySignal<std::optional<T>>`,
  empty for any update in which the key is absent.
- `requirePresent(sig, description)` is a second plain `map` that drops the
  optional and throws, for a consumer that needs the element to be there — the
  `forEach` delegate will.

### Why an optional rather than a latch

The design doc specified a **latch** (hold the last value seen when the key
leaves). That is withdrawn, and the doc is corrected here. A key's presence
cannot be encoded in the type system and cannot be guaranteed by construction, so
its absence has to surface at runtime; latching turns that into a silently stale
value, which hides the bug that caused it. It also did not buy what it promised —
it removed the ordering argument from `evaluate` only by moving it to
`initialize`, where a context holding no live instantiation had nothing to latch
and had to fail anyway.

The obligation stands and is now enforced loudly instead: build a pick when its
key appears, and drop it no later than the update that observes the key leaving.

## What the tests establish

`src/bq/test/picktest.cpp`, 10 tests, all green:

1. A pick follows its key across inserts, removals and moves of other elements,
   with the picked element changing at each step so a pick that stopped
   following would be caught. A pure reorder is invisible to it.
2. An absent key yields `nullopt` — not a throw, not a stale value — and a key
   that leaves and returns is picked up again. `requirePresent` throws both when
   the key leaves and when it was never there, and a duplicate key throws too;
   each is matched on its message.
3. Two `SignalContext`s over one description are wholly independent: each
   evaluates the source for itself, and driving one leaves the other exactly
   where it was, in both directions.
4. One description instantiated twice into **one** context finds the shared
   source's state already there and evaluates it once per pass, not once per
   consumer — pinned both directly against a `DataContext` and through a
   `SignalContext`.

## Findings recorded rather than worked around

From the two clean-context review rounds; all are in the design doc.

- **A shared node copies its value into every consumer on every changed frame**
  (`sharedcontrol.h:103`, `:199`). Sharing the map by value would cost one full
  copy per consumer per update — the same O(n²) keying exists to remove — so the
  shared signal carries a `shared_ptr` to an immutable map. The constraint
  belongs to `Shared`; a by-reference evaluate path would lift it.
- **A pick reports a change whenever any element changes**, not only its own,
  since that is what the shared source reports and the element type carries no
  comparison requirement. `tryCheck()` at the point of use is bq's existing
  answer, so this is documented and tested rather than worked around.
- **`b_ndebug` is off project-wide**, so `assert` is live in every build type. A
  debug-assert / release-throw pair does not exist here — the assert would always
  win and the throw would be unreachable — so hard errors are a throw alone. That
  is why a duplicate key throws rather than asserting.
- **A throw ends the pass, not just the node.** With a `check` or `share`
  downstream the exception surfaces from `SignalContext::update()` with the
  context part-advanced. Nothing is corrupted and the next frame recovers, but
  these are discard-the-context errors, not recoverable ones.
- `shareKeyed` invokes `keyFn` as const, so a stateful key function no longer
  compiles: its state would live in the description, shared by every context.

Also noted for follow-up, not fixed: `DataContext` never prunes expired entries,
which becomes load-bearing once ids are minted at churn rate.

`src/bq/AGENTS.md` gains a threading section recording why per-context signal
state needs no lock — a `DataContext` belongs to one `SignalContext` and is
advanced by a single synchronous pass, so concurrency in bq is between contexts.
That is independent of this construction and is the durable home for the rule.

Built and tested green under clang-cl 18 (Debug and Release) and MSVC 17 (Debug).
