### PR TITLE
Add the array node: ArraySignal, forEach, concat, map and join

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -10,6 +10,13 @@ before editing the corresponding area.
 - **`Any` prefix = type erasure.** `AnySignal<T>`, `AnyWidget`, `AnyShape`,
   `AnyWidgetModifier` are the type-erased forms of their concrete templated
   counterparts (e.g. `Signal<TStorage, Ts...>`). Store and pass the `Any` form.
+- **`bq::signal::ArraySignal<T>` is the one exception**, and deliberately so. The
+  `Any` prefix marks the erased half of a pair whose other half is storage-typed,
+  and that pair exists so a chain of combinators can stay free of virtual
+  dispatch. An array is heap-backed regardless, so a storage-typed twin would buy
+  nothing and double the surface: `ArraySignal` is type-erased by construction.
+  Do not add an `AnyArraySignal` alias, and do not restore the symmetry with
+  `Signal` by giving it a storage parameter.
 - Project is *Reactive*; the libraries are `bq` (signal core) and `bqui` (UI).
   The repo is still named `reactive` from before the rename.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
 # Conventions & gotchas
 
-*Last verified against `9cbe4cb` (2026-07-20).*
+*Last verified against `8677be3` (2026-07-21).*
 
 Idioms and traps that are not obvious from reading a single file. Know these
 before editing the corresponding area.
@@ -10,13 +10,14 @@ before editing the corresponding area.
 - **`Any` prefix = type erasure.** `AnySignal<T>`, `AnyWidget`, `AnyShape`,
   `AnyWidgetModifier` are the type-erased forms of their concrete templated
   counterparts (e.g. `Signal<TStorage, Ts...>`). Store and pass the `Any` form.
-- **`bq::signal::ArraySignal<T>` is the one exception**, and deliberately so. The
-  `Any` prefix marks the erased half of a pair whose other half is storage-typed,
-  and that pair exists so a chain of combinators can stay free of virtual
-  dispatch. An array is heap-backed regardless, so a storage-typed twin would buy
-  nothing and double the surface: `ArraySignal` is type-erased by construction.
-  Do not add an `AnyArraySignal` alias, and do not restore the symmetry with
-  `Signal` by giving it a storage parameter.
+- **`bq::signal::ArraySignal<T>` is the one exception.** The `Any` prefix marks
+  the erased half of a pair whose other half is storage-typed, and that pair
+  exists so a chain of combinators can stay free of virtual dispatch. An array is
+  heap-backed regardless, so the per-element indirection a storage-typed twin
+  would avoid is already paid: it would buy nothing and double the surface.
+  `ArraySignal` is therefore type-erased by construction, and the asymmetry with
+  `Signal` is the decision rather than an oversight. The rule that follows is in
+  `docs/style-guide.md`.
 - Project is *Reactive*; the libraries are `bq` (signal core) and `bqui` (UI).
   The repo is still named `reactive` from before the rename.
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -398,6 +398,13 @@ ignored by everything downstream — which is exactly `dynamicBox`'s bug. This i
 the third site that mints identity, alongside construction of a constant item and
 `forEach`.
 
+The signal is deduplicated with `tryCheck()` first, so a repeat of the value it
+already holds is not a rebuild. That protection is real only where `T` is
+equality-comparable: `tryCheck()` is *silently* a passthrough where it is not, so
+an `AnySignal<AnyWidget>` rebuilds on every change its source reports, equal or
+not. That is the trap already recorded under *Skipping repeats is a property of
+the data*, met here for the first time.
+
 ### `forEach` — the entry
 
 ```
@@ -873,15 +880,18 @@ document made and then had to withdraw.
   reaches a `map` through the identity change above, not through re-running `f`
   inside a node that outlives it.
 
-- **No per-array id space is needed.** Ids come from the same global counter as
-  every other `UniqueId`, so they are distinct across nodes by construction and
+- **No per-array id space is needed.** Ids come from the same counter as every
+  other `bq::signal` id, so they are distinct across nodes by construction and
   `concat` needs no re-namespacing — the conclusion the draft reached, but by way
-  of a per-context allocator that turns out to be unnecessary.
+  of a per-context allocator that turns out to be unnecessary. **Every** node
+  that builds an array mints its own, `map` included; a `map` that forwarded its
+  source's ids would make `concat(a, a.map(f))` a duplicate-key error, and that
+  is the shape of the branch a container makes and rejoins. Concatenating an
+  array with *itself* remains an error, which is correct.
 
-One thing the node does that the draft does not mention: it reports `didChange`
-only when the **id sequence** changed. A value change therefore does not rebuild
-the fan-in, which is what makes `join`'s re-initialisation branch a
-membership-change cost rather than a per-frame one.
+- **`join`'s per-identity share mints a `DataContext` id at churn rate**, and
+  `DataContext` never prunes. See *Future directions*: what was a noted
+  pre-existing wart is now a prerequisite, not an observation.
 
 The reactive subtree constructor, `AnySignal<ArraySignal<T>>`, is still not
 built; it remains where *Open questions* leaves it.
@@ -1316,11 +1326,15 @@ that the discarded builder may carry a genuinely changed widget — is in
 *Rationale* above and is not merely a cleanup. Both are moot once `dynamicBox`
 is deleted in favour of the unified engine.
 
-**`DataContext` never prunes.** `data_` holds `weak_ptr`s and an expired entry is
-reclaimed only when the *same* id is initialised again (`datacontext.h:70-79`).
-Every id here is minted fresh, so a long-lived window whose list churns
-accumulates dead map nodes for the life of the context. Pre-existing, but this is
-the first design that mints ids at churn rate, so it becomes load-bearing here.
+**`DataContext` never prunes** — and this is now a **prerequisite, not a future
+direction.** `data_` holds `weak_ptr`s and an expired entry is reclaimed only
+when the *same* id is initialised again (`datacontext.h:70-79`). Every other
+`initializeData` caller mints its id when the description is constructed, so the
+map is bounded by the size of the graph. `join` mints one per element identity
+per context, at update time, because that is where the per-identity share is
+built — so a long-lived window whose list churns grows `data_` without bound for
+the life of the context. Prune before the unified layout engine ships (step 4),
+or the churn becomes a leak in every dynamic list.
 
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
@@ -1388,6 +1402,10 @@ Steps 0 to 2 are done; the rest is outstanding.
 
 3. **`scatter`.** Structurally the same node as `forEach` with a different
    source; the size-alignment check lives here.
+
+3b. **Prune `DataContext`.** A prerequisite for step 4 rather than a cleanup —
+   `join` mints an id per element identity at update time. See *Future
+   directions*.
 
 4. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
    `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -160,21 +160,24 @@ oversight.
 
 This split is the load-bearing idea; everything else follows from it.
 
-**Value dynamism** — the structure is fixed and the contents change. A list of
-three `AnySignal<T>` leaves is value-dynamic: there are always exactly three
-items, in the same order, and each one's value varies over time. Identity is
-**stable by construction** — item *k* is item *k* forever — so no identity
-machinery is needed, and none should be paid for.
+**Value dynamism** — the structure is fixed and the contents change. Three items,
+in the same order forever, each one's value varying over time. Identity is
+**stable by construction** — item *k* is item *k* forever.
 
 **Structural dynamism** — membership itself changes: the list grows, shrinks, or
 reorders. This is the *only* place identity is needed, because "which item is
 this?" no longer has a positional answer. `forEach` is what supplies it.
 
-`ArraySignal<T>` expresses both. Its literal forms (a value, a signal, a nested
-braced list) are value-dynamic. Structural dynamism enters an `ArraySignal` only
-through `forEach` — or through the reactive-subtree constructor, which is
-structural dynamism at the coarsest possible granularity (the whole subtree is
-replaced).
+Both enter an `ArraySignal` through **`forEach`**, and value dynamism lives
+*inside* an element rather than at the element: the delegate is handed a signal,
+and the element's value — what the delegate built from that signal — never
+changes afterwards. `ArraySignal`'s own constructors are all constant. The
+alternative, a constructor taking a bare `AnySignal<T>`, is rejected under
+*Construction*: an element with no delegate has nowhere to put the variation but
+the element itself.
+
+The reactive-subtree constructor is structural dynamism at the coarsest possible
+granularity (the whole subtree is replaced), and is still unbuilt.
 
 ## `ArraySignal<T>`
 
@@ -200,11 +203,9 @@ supported source type:
 | Constructor takes | Meaning |
 | --- | --- |
 | `T` (or anything convertible to `T`) | a single constant item |
-| `AnySignal<T>` | a single item whose value varies |
-| `AnySignal<std::vector<T>>` | a varying list of items |
 | `std::initializer_list<ArraySignal<T>>` | a fixed list of children |
 | `std::vector<ArraySignal<T>>` | ditto, built at runtime |
-| `AnySignal<ArraySignal<T>>` | a reactive subtree (see below) |
+| `AnySignal<ArraySignal<T>>` | a reactive subtree (see below; unbuilt) |
 
 Two reasons. First, **acceptance is precisely controlled**: each form is opted
 into by writing a constructor, so an accidentally-convertible type cannot slip
@@ -370,12 +371,14 @@ Six things. Every one has an existing `bq` pattern to copy.
 | Constructor takes | Meaning |
 | --- | --- |
 | `T` (or anything convertible to `T`) | a single constant item |
-| `AnySignal<T>` | a single item whose value varies |
 | `std::initializer_list<ArraySignal<T>>` | a fixed list of children |
 | `std::vector<ArraySignal<T>>` | ditto, built at runtime |
 
 `{a, b, c}` compiles, nesting falls out for free, and the type is a uniform
 recursive tree as described above.
+
+**Every constructor is constant**, and that is the whole rule. Anything that
+varies enters through `forEach`.
 
 **`AnySignal<std::vector<T>>` is deliberately not a constructor.** In the spike
 it was, implemented as `source.map(idx).share()` (`arraysignal.h:450-457`),
@@ -386,24 +389,23 @@ identity preservation; it is the bug this design exists to remove. To turn a
 varying list into an `ArraySignal` you must go through `forEach` and say what the
 key is.
 
-The single-item `AnySignal<T>` constructor is kept, and it **rebuilds** when the
-value changes. That is honest and accepted: if an `AnySignal<AnyWidget>` genuinely
-changes, resetting that element's state is unavoidable (see *Rationale*). It is
-one element and nothing else in the array is disturbed.
+**The single-item `AnySignal<T>` constructor is gone too**, and for the same
+reason one step down. Earlier drafts kept it and accepted that a changed value
+rebuilds that element. But an element built from a bare signal has nowhere for
+the variation to live *except* the element: there is no delegate, so nothing was
+handed a signal to keep. Every other entry to the array puts the variation inside
+what the delegate built, which is why the delegate and every `map` run exactly
+once and stay run.
 
-A rebuild is expressed as a **new identity for that element**, not as a new value
-at a fixed one. It has to be: `map` runs once per identity, so an element that
-kept its identity through a value change would have its new value silently
-ignored by everything downstream — which is exactly `dynamicBox`'s bug. This is
-the third site that mints identity, alongside construction of a constant item and
-`forEach`.
+Keeping it would have cost the whole identity algebra. A value change at fixed
+identity is silently ignored by everything downstream — `dynamicBox`'s bug — so
+the constructor would have had to mint a *new* identity per value change, adding
+a third minting site and making "`map` runs once per identity" mean two different
+things depending on which constructor an element came from. A single varying item
+goes through `forEach` with a key, like every other varying thing.
 
-The signal is deduplicated with `tryCheck()` first, so a repeat of the value it
-already holds is not a rebuild. That protection is real only where `T` is
-equality-comparable: `tryCheck()` is *silently* a passthrough where it is not, so
-an `AnySignal<AnyWidget>` rebuilds on every change its source reports, equal or
-not. That is the trap already recorded under *Skipping repeats is a property of
-the data*, met here for the first time.
+So: **only construction of a constant item and `forEach` mint identity**, and an
+element's value never changes once built.
 
 ### `forEach` — the entry
 
@@ -462,6 +464,34 @@ and simply cannot be exited; you `map` it to something joinable first.
 
 This restriction was checked against the real work, not assumed — see *One layout
 engine*, where both fan-ins land in this form and no third shape is needed.
+
+#### `join` is a node, not a `Join`
+
+**Settled, and the one place where reusing an existing operator is wrong.** The
+obvious implementation is to `map` the elements into a `combine` and let
+`Signal::join` follow it. It does produce the right values, and it is a trap:
+`Join::update` rebuilds and **re-initialises its whole inner signal whenever the
+outer one changes** (`join.h:88-92`), and here the outer signal changes on every
+membership change. Every surviving element would be re-initialised — every `map`
+cache, every `withPrevious` fold, every `iterate` inside a survivor's `U` back to
+its initial value — because one neighbour arrived.
+
+That failure is invisible in the values; it shows only in accumulated state,
+which is exactly the state this whole design exists to protect. It is also the
+spike's original failure mode wearing a different hat.
+
+So the exit is its own node, holding **one inner data per identity** in its
+per-context `DataType`, keyed by the element's id. An update carries a survivor's
+data across untouched, initialises only what arrived, and releases only what
+left. A survivor is never re-initialised, so nothing downstream has to defend
+against it.
+
+The tempting patch — leave the generic `Join` in place and `.share()` each
+element's signal once per identity so re-initialisation finds its state again —
+works, and should be recognised as the wrong fix. It makes correctness rest on
+every element being shared, and it mints a `UniqueId` per identity at update
+time, which grows `DataContext` at membership-churn rate. The node has neither
+property: it adds no `DataContext` entry at all.
 
 ### What is gone
 
@@ -609,13 +639,12 @@ looks right and silently throws away user state.
   changes — the new value arrives through the signal the delegate already holds.
   Nothing is constructed on a value change, so nothing is destroyed. **This is
   what preserves widget state.**
-- **`map` is value-level.** Its function is `U -> V`, and it is re-run whenever
-  the element it reads is rebuilt — which for a value-dynamic element is every
-  value change, since a rebuild is a new identity. Perfect for data; ruinous for
-  widgets, because building a widget here reconstructs it — and everything it
-  holds — whenever that happens. Nothing in the type system distinguishes a
-  `map` over a `forEach`-keyed array, where it does run exactly once, from a
-  `map` over a value-dynamic one, where it does not.
+- **`map` is value-level.** Its function is `U -> V`, and it runs exactly once
+  per identity, because the `U` it reads cannot change — the delegate produced it
+  once and it wraps the signals that vary. What makes `map` the wrong place to
+  build a widget is not that it re-runs; it is that it is handed a *value* and
+  never the item's signal, so a widget built here can only be rebuilt when the
+  identity is replaced, and has no way to receive a changed value otherwise.
 
 The rule, stated plainly, is the one sentence to carry out of this document:
 
@@ -831,19 +860,19 @@ Not once per identity globally. Two contexts realise two independent sets of
 `U`s, which is correct: contexts are parallel, and widget state must not leak
 between them. Do not write code that assumes a global call count.
 
-### A value change at fixed identity rebuilds, and that is accepted
+### An element's value never changes
 
-If the single-item `AnySignal<T>` constructor's value changes, or an
-`AnySignal<AnyWidget>` genuinely changes, that element's state resets. This is
-unavoidable and is not a trap to be engineered around — *Rationale* explains why
-structural matching is wrong rather than merely hard, and widget memoisation
-cannot rescue it because `widget::Button(...)` and `signal::input` necessarily
-mint fresh identity on every call.
+Not a limitation but the invariant everything else rests on: a value is built
+when its identity appears and is kept until the identity leaves. `map` therefore
+runs exactly once per identity, and what varies varies *inside* the value,
+through the signal the delegate was handed.
 
-The first draft recorded a "first value wins, and it cannot be asserted" rule
-here. That rule described `forEach`'s delegate — which does run exactly once —
-and was wrongly generalised to every path into the array. It is stated on
-`forEach` above and removed from here.
+An earlier draft recorded the opposite here — that a value change at fixed
+identity resets that element's state, and that this was accepted. It described
+the `AnySignal<T>` constructor, which no longer exists (see *Construction*). The
+underlying point stands where it belongs: a `forEach` whose *key* changes retires
+the old identity and builds a new one, and *Rationale* is why matching them up
+instead would be wrong rather than merely hard.
 
 ### There is no frame-lag hazard
 
@@ -854,44 +883,26 @@ diamond (membership → builders → hints → obbs → elements), not a cycle.
 
 ## Corrections from the implementation
 
-Five things the built node settles differently from the draft above. The prose
-has been amended; they are collected here because each one is a claim this
-document made and then had to withdraw.
+Two things the built node settles differently from the draft above. The prose
+has been amended; they are collected here because each is a claim this document
+made and then had to withdraw.
 
 - **There is no `SharedArraySignal`.** Sharing is intrinsic — see *Sharing is
   intrinsic*. The consequence is that copying a description no longer implies
   independent tables; only a second `SignalContext` does.
 
-- **`join` must share each element's signal once per identity.** A membership
-  change rebuilds the fan-in, which re-initialises every element's signal, and a
-  `map` cache or a `withPrevious` fold inside a *surviving* element's `U` lives
-  in that per-instantiation data and would restart. Sharing at the top of each
-  element, once per identity, moves that state into the `DataContext` where
-  re-initialisation finds it again. Without it the spike's exact failure — a
-  sibling's fold resetting on an unrelated insert — reappears, and the test that
-  covers it is the one that catches it.
-
-- **A value change at fixed identity is a new identity**, not a new value at the
-  old one. See *Construction*.
-
-- **The two accounts of `map` were incompatible** — "re-run on every value
-  change, implemented as a per-element `sig.map(f)`" against "runs once per
-  identity, takes `U const&`". The second is what is built. Value dynamism
-  reaches a `map` through the identity change above, not through re-running `f`
-  inside a node that outlives it.
-
-- **No per-array id space is needed.** Ids come from the same counter as every
-  other `bq::signal` id, so they are distinct across nodes by construction and
-  `concat` needs no re-namespacing — the conclusion the draft reached, but by way
-  of a per-context allocator that turns out to be unnecessary. **Every** node
-  that builds an array mints its own, `map` included; a `map` that forwarded its
+- **Every node that builds an array mints its own ids**, `map` included, and no
+  per-array id space is needed to make them distinct. A `map` that forwarded its
   source's ids would make `concat(a, a.map(f))` a duplicate-key error, and that
   is the shape of the branch a container makes and rejoins. Concatenating an
   array with *itself* remains an error, which is correct.
 
-- **`join`'s per-identity share mints a `DataContext` id at churn rate**, and
-  `DataContext` never prunes. See *Future directions*: what was a noted
-  pre-existing wart is now a prerequisite, not an observation.
+An earlier revision of this section carried three more, all of which were
+symptoms of building the exit on the generic `join` rather than as its own node
+— see *`join` is a node, not a `Join`*. They are gone with that choice, and the
+identity algebra the draft claimed holds unaltered: only construction of a
+constant item and `forEach` mint identity, and `map` runs exactly once per
+identity because the value it reads cannot change.
 
 The reactive subtree constructor, `AnySignal<ArraySignal<T>>`, is still not
 built; it remains where *Open questions* leaves it.
@@ -1326,15 +1337,17 @@ that the discarded builder may carry a genuinely changed widget — is in
 *Rationale* above and is not merely a cleanup. Both are moot once `dynamicBox`
 is deleted in favour of the unified engine.
 
-**`DataContext` never prunes** — and this is now a **prerequisite, not a future
-direction.** `data_` holds `weak_ptr`s and an expired entry is reclaimed only
-when the *same* id is initialised again (`datacontext.h:70-79`). Every other
-`initializeData` caller mints its id when the description is constructed, so the
-map is bounded by the size of the graph. `join` mints one per element identity
-per context, at update time, because that is where the per-identity share is
-built — so a long-lived window whose list churns grows `data_` without bound for
-the life of the context. Prune before the unified layout engine ships (step 4),
-or the churn becomes a leak in every dynamic list.
+**`DataContext` never prunes.** `data_` holds `weak_ptr`s and an expired entry is
+reclaimed only when the *same* id is initialised again (`datacontext.h:70-79`).
+The array machinery itself mints **no** `DataContext` id per identity — an
+`ArrayId` keys only the nodes' own tables, and every `share()` in the
+implementation is built when the description is, not per element. What does mint
+at churn rate is a **delegate that builds something stateful**: a `forEach`
+delegate returning a widget creates that widget's `Input`s and `share()`s, each
+of which mints a `UniqueId` when the delegate runs. That is inherent to building
+per item and is not something this design can avoid, so a long-lived window whose
+list churns still accumulates dead entries. Pre-existing, but this is the first
+design that reaches it at churn rate.
 
 **PR #99 (dynamic windows)** is open, and makes `App`'s window list
 `AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
@@ -1393,19 +1406,17 @@ Steps 0 to 2 are done; the rest is outstanding.
    get independent state; and the same description instantiated twice into *one*
    context shares the source. Nothing else proceeds until this is green.
 
-2. **The node: `forEach`, `concat`, `map`, `join`.** *Done.* One node,
-   `detail::ArrayOnce`, carries the key→id map and the `U` table in its
-   `DataType`; the array holds it behind a `.share()`, which is what makes that
-   data per-context and shared within one. `forEach` and `map` differ only in
-   their key, build and id functions. The two `join` fixes landed first, as
-   their own commit.
+2. **The node: `forEach`, `concat`, `map`, `join`.** *Done.* `detail::ArrayOnce`
+   carries the key→id map and the `U` table in its `DataType`; the array holds it
+   behind a `.share()`, which is what makes that data per-context and shared
+   within one. `forEach` and `map` differ only in their key, build and id
+   functions. The exit is a second node, `detail::ArrayJoin`, holding one inner
+   data per identity — see *`join` is a node, not a `Join`*. The two `join` fixes
+   landed first, as their own commit; they are still needed by `Signal::join`
+   generally, but the array exit no longer uses it.
 
 3. **`scatter`.** Structurally the same node as `forEach` with a different
    source; the size-alignment check lives here.
-
-3b. **Prune `DataContext`.** A prerequisite for step 4 rather than a cleanup —
-   `join` mints an id per element identity at update time. See *Future
-   directions*.
 
 4. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
    `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -243,28 +243,33 @@ values of `T`. The `initializer_list` element type being `ArraySignal<T>` rather
 than `T` is how that requirement is met **and** how nesting falls out for free,
 since every accepted form converts to `ArraySignal<T>`.
 
-### Identity is internal, and ids are minted per context at initialisation
+### Identity is internal, and an id is minted where its element is
 
-**Settled:** ids are allocated by the built signal, in its `DataContext` state,
-**when it is initialised into a context**. They are not allocated when the
-`ArraySignal` description is constructed, and they are not carried by the
-description.
+**Settled:** an id is allocated at the point the element it names comes into
+existence. For a `forEach` element that is inside the node, in its per-context
+table, when the key first appears — it can be nowhere else, since the key is not
+known until then. For a constant item it is when the `ArraySignal` is
+constructed, because the element exists from that moment and never changes.
 
-This follows directly from *Where state lives*. An id names an entry in the
-key→`U` table, that table is per-context, so the id space is per-context too.
+So the description does carry the constant items' ids. That is harmless, and the
+reason is the same one that makes the whole scheme safe: **an id never reaches
+user code**. No operator hands one out, nothing outside can construct or compare
+one, and an id names nothing but an entry in the per-context tables that match
+it. Two contexts over one constant element look their own values up under the
+same id and never meet.
 
-The reason it is safe is that **an id never reaches user code**. No operator
-hands one out, nothing outside can construct or compare one, and ids are never
-compared across contexts because there is no way to obtain one in the first
-place.
+An earlier draft required *every* id to be minted per context. That bought
+nothing for a constant — it would mean a node whose only job is to allocate an
+id — and the rule it was protecting is about where the *tables* live, not the
+ids.
 
 Two consequences worth stating, because both simplify the design relative to the
 first draft:
 
-- **`concat` needs no re-namespacing.** Each `forEach` node mints its own ids
-  from its own per-context allocator, so ids from different sources are distinct
-  by construction. The first draft's id-space-plus-index scheme, and the
-  pointer-derived ids that made ids irreproducible between runs, both go away.
+- **`concat` needs no re-namespacing.** Every node that builds an array mints
+  its own ids, so ids from different sources are distinct by construction. The
+  first draft's id-space-plus-index scheme, and the pointer-derived ids that
+  made ids irreproducible between runs, both go away.
 - **The user-facing key contract weakens, which is a gain.** `TKey` no longer has
   to be unique across the whole array — only **within a single `forEach`**. That
   is a far easier promise for a caller to keep, and it makes duplicate detection

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,8 +1,11 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, implementation started.** Steps 0 and 1 of
-> *Implementation order* have landed; everything from `forEach` onwards is
-> outstanding. The earlier implementation on PR #100 is a **superseded spike**:
+> **Status: revised design, implementation started.** Steps 0 to 2 of
+> *Implementation order* have landed; `scatter` and everything in `bqui` is
+> outstanding. Where the built node contradicts what is written below, the
+> correction is recorded under *Corrections from the implementation* and the
+> surrounding prose has been amended. The earlier implementation on PR #100 is
+> a **superseded spike**:
 > it put the per-identity table in the description rather than in the
 > `SignalContext`, which is a correctness defect, not a limitation. This revision
 > relocates that state and, as a consequence, removes five operators. Read the
@@ -13,7 +16,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `9c47767` (2026-07-21).*
+*Last verified against `74a744b` (2026-07-21).*
 
 ## The problem
 
@@ -328,9 +331,10 @@ it alive).
 
 Four consequences, all of which the rest of this document depends on:
 
-- **Copying a description and instantiating both copies yields two independent
-  tables.** That is correct and is exactly what copying a signal does. Sharing is
-  opt-in and explicit, precisely as `.share()` is.
+- **Two `SignalContext`s over one description yield two independent tables.**
+  Copies of the description do *not*: an array holds its elements behind a
+  `.share()`, so every copy carries the same `UniqueId` and every consumer within
+  one context finds the one table. See *Sharing is intrinsic*.
 - **The `U`s are unobservable from outside the graph.** They are built inside the
   node, in context state, and no operator hands one out. Anything you want to do
   with a `U` must therefore be expressed as an operator that runs *inside*.
@@ -385,7 +389,14 @@ key is.
 The single-item `AnySignal<T>` constructor is kept, and it **rebuilds** when the
 value changes. That is honest and accepted: if an `AnySignal<AnyWidget>` genuinely
 changes, resetting that element's state is unavoidable (see *Rationale*). It is
-one element, the identity is fixed, and nothing else in the array is disturbed.
+one element and nothing else in the array is disturbed.
+
+A rebuild is expressed as a **new identity for that element**, not as a new value
+at a fixed one. It has to be: `map` runs once per identity, so an element that
+kept its identity through a value change would have its new value silently
+ignored by everything downstream — which is exactly `dynamicBox`'s bug. This is
+the third site that mints identity, alongside construction of a constant item and
+`forEach`.
 
 ### `forEach` — the entry
 
@@ -562,7 +573,7 @@ an `AnySignal<std::map<ArrayId, W>>`, shares that, and hands each identity the
 identical `pick`. `forEach` and `scatter` differ only in where their source comes
 from.
 
-## Sharing: `SharedArraySignal`
+## Sharing is intrinsic
 
 The layout pipeline **branches**. The same `ArraySignal<Builder>` feeds the size
 hint fan-in and, after the obb round trip, the element fan-in. With a
@@ -570,15 +581,15 @@ description that is instantiated independently by each consumer, those two exits
 build two nodes, two key→`U` tables, and call the delegate twice — duplicating
 exactly the widget state that identity preservation exists to protect.
 
-So a shared form is **structurally required**, not an optimisation. It is the
-same relationship `Signal` has to a `.share()`d signal: `SharedArraySignal`
-carries a `UniqueId`, and every consumer instantiating it in one context finds
-the same table via `findData`.
+So sharing is **structurally required**, not an optimisation — and there is no
+separate `SharedArraySignal` type, because keeping the table in the node's
+`DataType` behind a `.share()` *is* sharing. `SharedControl` keys that data by a
+`UniqueId` carried in the description, so every consumer within one context
+finds one table and one evaluation per pass, and two contexts share nothing.
 
-**Implement only the shared form.** The consuming variant would have no user on
-day one, since every container branches. Its `map` therefore takes `U const&`
-rather than consuming. The consuming variant can be added later if a linear
-consumer ever appears; naming can be revisited then.
+A consuming variant would have no user on day one, since every container
+branches, so `map` takes `U const&`. It can be added later if a linear consumer
+ever appears; naming can be revisited then.
 
 ## `forEach` vs `map` — the central distinction
 
@@ -591,11 +602,13 @@ looks right and silently throws away user state.
   changes — the new value arrives through the signal the delegate already holds.
   Nothing is constructed on a value change, so nothing is destroyed. **This is
   what preserves widget state.**
-- **`map` is value-level.** Its function is `T -> U`, re-run on every value
-  change. Implemented as a per-element `sig.map(f)`, so the `Map` node is created
-  once per identity and `f` re-runs *inside* the already-built graph. Perfect for
-  data; ruinous for widgets, because building a widget here reconstructs it — and
-  everything it holds — on every change.
+- **`map` is value-level.** Its function is `U -> V`, and it is re-run whenever
+  the element it reads is rebuilt — which for a value-dynamic element is every
+  value change, since a rebuild is a new identity. Perfect for data; ruinous for
+  widgets, because building a widget here reconstructs it — and everything it
+  holds — whenever that happens. Nothing in the type system distinguishes a
+  `map` over a `forEach`-keyed array, where it does run exactly once, from a
+  `map` over a value-dynamic one, where it does not.
 
 The rule, stated plainly, is the one sentence to carry out of this document:
 
@@ -831,6 +844,47 @@ Retained from the first draft: the pipeline is acyclic and settles in one update
 pass, and `avg::Animated<T>` is an ordinary value that does not animate in the
 signal domain — it is interpreted by the render tree. The layout pipeline is a
 diamond (membership → builders → hints → obbs → elements), not a cycle.
+
+## Corrections from the implementation
+
+Five things the built node settles differently from the draft above. The prose
+has been amended; they are collected here because each one is a claim this
+document made and then had to withdraw.
+
+- **There is no `SharedArraySignal`.** Sharing is intrinsic — see *Sharing is
+  intrinsic*. The consequence is that copying a description no longer implies
+  independent tables; only a second `SignalContext` does.
+
+- **`join` must share each element's signal once per identity.** A membership
+  change rebuilds the fan-in, which re-initialises every element's signal, and a
+  `map` cache or a `withPrevious` fold inside a *surviving* element's `U` lives
+  in that per-instantiation data and would restart. Sharing at the top of each
+  element, once per identity, moves that state into the `DataContext` where
+  re-initialisation finds it again. Without it the spike's exact failure — a
+  sibling's fold resetting on an unrelated insert — reappears, and the test that
+  covers it is the one that catches it.
+
+- **A value change at fixed identity is a new identity**, not a new value at the
+  old one. See *Construction*.
+
+- **The two accounts of `map` were incompatible** — "re-run on every value
+  change, implemented as a per-element `sig.map(f)`" against "runs once per
+  identity, takes `U const&`". The second is what is built. Value dynamism
+  reaches a `map` through the identity change above, not through re-running `f`
+  inside a node that outlives it.
+
+- **No per-array id space is needed.** Ids come from the same global counter as
+  every other `UniqueId`, so they are distinct across nodes by construction and
+  `concat` needs no re-namespacing — the conclusion the draft reached, but by way
+  of a per-context allocator that turns out to be unnecessary.
+
+One thing the node does that the draft does not mention: it reports `didChange`
+only when the **id sequence** changed. A value change therefore does not rebuild
+the fan-in, which is what makes `join`'s re-initialisation branch a
+membership-change cost rather than a per-frame one.
+
+The reactive subtree constructor, `AnySignal<ArraySignal<T>>`, is still not
+built; it remains where *Open questions* leaves it.
 
 ## One layout engine
 
@@ -1308,7 +1362,7 @@ Written for a from-scratch implementation. The spike on PR #100 is superseded an
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
 
-Steps 0 and 1 are done; the rest is outstanding.
+Steps 0 to 2 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
    not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
@@ -1325,11 +1379,12 @@ Steps 0 and 1 are done; the rest is outstanding.
    get independent state; and the same description instantiated twice into *one*
    context shares the source. Nothing else proceeds until this is green.
 
-2. **The node: `forEach`, `concat`, `map`, `join`.** The `UniqueId` +
-   `findData` + `DataType` pattern from `SharedControl`, with the key→id map, the
-   `U` table and the membership order in context state. Re-land the two `join`
-   fixes from the spike here (or, better, as their own PR first — they are
-   independent bugs).
+2. **The node: `forEach`, `concat`, `map`, `join`.** *Done.* One node,
+   `detail::ArrayOnce`, carries the key→id map and the `U` table in its
+   `DataType`; the array holds it behind a `.share()`, which is what makes that
+   data per-context and shared within one. `forEach` and `map` differ only in
+   their key, build and id functions. The two `join` fixes landed first, as
+   their own commit.
 
 3. **`scatter`.** Structurally the same node as `forEach` with a different
    source; the size-alignment check lives here.

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -2,9 +2,8 @@
 
 > **Status: revised design, implementation started.** Steps 0 to 2 of
 > *Implementation order* have landed; `scatter` and everything in `bqui` is
-> outstanding. Where the built node contradicts what is written below, the
-> correction is recorded under *Corrections from the implementation* and the
-> surrounding prose has been amended. The earlier implementation on PR #100 is
+> outstanding, and this document has been amended to describe what was built
+> rather than what was first proposed. The earlier implementation on PR #100 is
 > a **superseded spike**:
 > it put the per-identity table in the description rather than in the
 > `SignalContext`, which is a correctness defect, not a limitation. This revision
@@ -16,7 +15,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `74a744b` (2026-07-21).*
+*Last verified against `8677be3` (2026-07-21).*
 
 ## The problem
 
@@ -205,7 +204,11 @@ supported source type:
 | `T` (or anything convertible to `T`) | a single constant item |
 | `std::initializer_list<ArraySignal<T>>` | a fixed list of children |
 | `std::vector<ArraySignal<T>>` | ditto, built at runtime |
-| `AnySignal<ArraySignal<T>>` | a reactive subtree (see below; unbuilt) |
+**Every one of them is constant**, and that is the rule: anything that varies
+enters through `forEach`, which asks for the key that says which item is which.
+The one candidate that would break the rule, a reactive subtree taking
+`AnySignal<ArraySignal<T>>`, is unbuilt and unsettled — see *The reactive
+subtree* and *Open questions*.
 
 Two reasons. First, **acceptance is precisely controlled**: each form is opted
 into by writing a constructor, so an accidentally-convertible type cannot slip
@@ -220,9 +223,8 @@ representation is free to change.
 ### It is a uniform recursive tree
 
 Because *everything* converts to `ArraySignal<T>`, including a braced list of
-`ArraySignal<T>`, the type is a tree: a **leaf** is a single item (constant or
-signal) or a signal-of-vector, and a **branch** is a list of children. This
-syntax must work:
+`ArraySignal<T>`, the type is a tree: a **leaf** is a single constant
+item, and a **branch** is a list of children. This syntax must work:
 
 ```cpp
 ArraySignal<AnyWidget> content = {
@@ -276,7 +278,12 @@ belongs to PR #99. See *Open questions*.
 
 ### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
-This constructor makes a whole subtree swappable — conditional branches, a
+**Unbuilt.** It is the one proposed constructor that is not constant, and the
+identity algebra does not yet account for it — see *Open questions*. Recorded
+here because the shape of the answer is settled even though the constructor is
+not.
+
+It would make a whole subtree swappable — conditional branches, a
 section of a list that changes shape wholesale. The rule on swap:
 
 > The new subtree's items are a **new set** and get **fresh ids**, unless
@@ -295,11 +302,11 @@ These are design constraints on the implementation, not incidental details.
 
 - **The "convertible to `T`" constructor must be SFINAE-constrained.** An
   unconstrained `template <typename U> ArraySignal(U&&)` is a better match than the
-  copy and move constructors for a non-const lvalue `ArraySignal`, and it will also
-  swallow `AnySignal<T>` and braced lists that were meant for the dedicated
-  constructors. Constrain it on `std::is_convertible_v<U, T>` *and* exclude
-  `ArraySignal` itself and every other accepted form. This is the single most
-  likely way to get a mysterious compile error or a silently wrong overload.
+  copy and move constructors for a non-const lvalue `ArraySignal`, and it would
+  swallow braced lists meant for the dedicated constructors. Constrain it on
+  `std::is_convertible_v<U, T>` *and* exclude `ArraySignal` itself. This is the
+  single most likely way to get a mysterious compile error or a silently wrong
+  overload.
 
 - **Prefer an explicit `std::initializer_list<ArraySignal<T>>` constructor.** In
   braced initialisation an `initializer_list` constructor wins over everything
@@ -322,13 +329,15 @@ broke.
 > An `ArraySignal` is a **description that builds a signal**. It never
 > participates in a `SignalContext` itself. Every piece of durable state the
 > built signal needs — the key→id map, the per-key `U` table, the membership
-> order — lives in that signal's `DataContext` data, found by a `btl::UniqueId`
-> carried in the description.
+> order, each element's instantiated data — lives in that signal's per-context
+> data.
 
-`SharedControl` is the pattern to copy verbatim: a `UniqueId` in the description,
-`context.findData<T>(id_)` on initialise, create on miss, hold the `shared_ptr`
-in the node's `DataType` (`DataContext` stores `weak_ptr`s, so nothing else keeps
-it alive).
+`SharedControl` is what supplies that, and the array uses it rather than
+reimplementing it: the nodes hold their tables in an ordinary `DataType`, and the
+array holds those nodes behind a `.share()`. `SharedControl` carries the
+`UniqueId`, does the `findData` on initialise and creates on miss, so the tables
+are per-`DataContext` without any node naming an id of its own. See *Sharing is
+intrinsic*.
 
 Four consequences, all of which the rest of this document depends on:
 
@@ -368,17 +377,9 @@ Six things. Every one has an existing `bq` pattern to copy.
 
 ### Construction
 
-| Constructor takes | Meaning |
-| --- | --- |
-| `T` (or anything convertible to `T`) | a single constant item |
-| `std::initializer_list<ArraySignal<T>>` | a fixed list of children |
-| `std::vector<ArraySignal<T>>` | ditto, built at runtime |
-
-`{a, b, c}` compiles, nesting falls out for free, and the type is a uniform
-recursive tree as described above.
-
-**Every constructor is constant**, and that is the whole rule. Anything that
-varies enters through `forEach`.
+The accepted forms are listed under *A constructor per supported type*, and they
+are all constant. `{a, b, c}` compiles, nesting falls out for free, and the type
+is a uniform recursive tree as described above.
 
 **`AnySignal<std::vector<T>>` is deliberately not a constructor.** In the spike
 it was, implemented as `source.map(idx).share()` (`arraysignal.h:450-457`),
@@ -431,7 +432,11 @@ the operator that lets a container reach *inside* the node.
 
 ### `concat`
 
-Joins arrays without touching ids, which are already distinct per node.
+Joins arrays without touching ids. **Every node that builds an array mints its
+own**, `map` included, so ids from two arrays are distinct however the two are
+related: `concat(a, a.map(f))` — the shape of the branch a container makes and
+rejoins — is well-formed. Concatenating an array with *itself* is not, and the
+exit says so rather than giving one identity two places in the list.
 
 ### `scatter` — the fan-out
 
@@ -471,7 +476,8 @@ engine*, where both fan-ins land in this form and no third shape is needed.
 obvious implementation is to `map` the elements into a `combine` and let
 `Signal::join` follow it. It does produce the right values, and it is a trap:
 `Join::update` rebuilds and **re-initialises its whole inner signal whenever the
-outer one changes** (`join.h:88-92`), and here the outer signal changes on every
+outer one changes** (the `didChange` branch of `Join::update`), and here the
+outer signal changes on every
 membership change. Every surviving element would be re-initialised — every `map`
 cache, every `withPrevious` fold, every `iterate` inside a survivor's `U` back to
 its initial value — because one neighbour arrived.
@@ -622,7 +628,18 @@ So sharing is **structurally required**, not an optimisation — and there is no
 separate `SharedArraySignal` type, because keeping the table in the node's
 `DataType` behind a `.share()` *is* sharing. `SharedControl` keys that data by a
 `UniqueId` carried in the description, so every consumer within one context
-finds one table and one evaluation per pass, and two contexts share nothing.
+finds one table, and two contexts share nothing.
+
+Be precise about what that does and does not cover. **The built values are
+shared** — the delegate and every `map` run once between the two branches, which
+is the whole requirement above. **The elements' instantiated state is not**: each
+exit gives every element its own inner data, exactly as instantiating any signal
+twice in one context does. A `withPrevious` inside a delegate's value therefore
+exists once per exit unless the delegate shares it, and the per-element
+evaluation is done once per exit rather than once per pass. That is `bq`'s
+ordinary rule rather than an exception to it, and it is the price of the exit
+being a node that owns its elements' data — see *`join` is a node, not a
+`Join`*.
 
 A consuming variant would have no user on day one, since every container
 branches, so `map` takes `U const&`. It can be added later if a linear consumer
@@ -672,10 +689,12 @@ into.
 
 `arraySignal.map(f, sig1, sig2)` — where `f` receives the item's value plus the
 current values of those signals — should be supported. It is **`combine` sugar
-per element**: the node is still created once per identity, and only values
-recompute. It introduces **no new footgun class**, because the dangerous case is
-already covered by the rule above ("don't construct in `.map`") and is
-unaffected by how many values `f` receives.
+per element**, and it is the one place `f` would run more than once per identity:
+`f` is re-run when one of those extra signals changes, inside a node built once
+when the identity appeared. That does not weaken the rule that an *element's
+value* never changes — the extra signals are not the element — and it introduces
+**no new footgun class**, because the dangerous case is already covered by the
+rule above ("don't construct in `.map`").
 
 The cost is worth stating: a shared signal feeding `n` items fans out to O(n)
 value recomputations when it changes. That is inherent, not a design flaw — all
@@ -881,32 +900,6 @@ pass, and `avg::Animated<T>` is an ordinary value that does not animate in the
 signal domain — it is interpreted by the render tree. The layout pipeline is a
 diamond (membership → builders → hints → obbs → elements), not a cycle.
 
-## Corrections from the implementation
-
-Two things the built node settles differently from the draft above. The prose
-has been amended; they are collected here because each is a claim this document
-made and then had to withdraw.
-
-- **There is no `SharedArraySignal`.** Sharing is intrinsic — see *Sharing is
-  intrinsic*. The consequence is that copying a description no longer implies
-  independent tables; only a second `SignalContext` does.
-
-- **Every node that builds an array mints its own ids**, `map` included, and no
-  per-array id space is needed to make them distinct. A `map` that forwarded its
-  source's ids would make `concat(a, a.map(f))` a duplicate-key error, and that
-  is the shape of the branch a container makes and rejoins. Concatenating an
-  array with *itself* remains an error, which is correct.
-
-An earlier revision of this section carried three more, all of which were
-symptoms of building the exit on the generic `join` rather than as its own node
-— see *`join` is a node, not a `Join`*. They are gone with that choice, and the
-identity algebra the draft claimed holds unaltered: only construction of a
-constant item and `forEach` mint identity, and `map` runs exactly once per
-identity because the value it reads cannot change.
-
-The reactive subtree constructor, `AnySignal<ArraySignal<T>>`, is still not
-built; it remains where *Open questions* leaves it.
-
 ## One layout engine
 
 This is the headline finding, and it was not the goal when the design started.
@@ -978,12 +971,11 @@ need. The honest accounting:
 
 - **Construction.** The unified engine costs one extra node in the graph and N
   key allocations. Once.
-- **Steady state.** For a never-changing membership, the fan-in `Join`
-  initialises its inner signal once and thereafter behaves as a plain `combine` —
-  the re-initialisation branch at `join.h:88-92` is only taken when the *outer*
-  signal changes, and for fixed membership it never does. `scatter` matches
-  identity once at construction, not per emission. **Per frame, both paths do the
-  same work.**
+- **Steady state.** For a never-changing membership the fan-in initialises each
+  element once and thereafter does what a plain `combine` does: the reconcile
+  branch is only taken when the membership changes, and for a fixed list it never
+  does. `scatter` matches identity once at construction, not per emission. **Per
+  frame, both paths do the same work.**
 
 A per-frame cost would be a real argument against unifying. A one-off
 construction cost is not.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,6 +1,6 @@
 # Style guide
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `8677be3` (2026-07-21).*
 
 Prescriptive rules for how code and docs are written here — the rubric a review
 (human or agent) checks a change against. It grows as we settle on how things
@@ -24,6 +24,9 @@ should be shaped. Where a rule has a *why* or a mechanism, it points at
 - Use the `Any`-prefixed, type-erased forms (`AnySignal<T>`, `AnyWidget`,
   `AnyShape`, …) in public signatures and in prose. Only refer to the concrete
   `Signal<TStorage, Ts...>` form when explaining the type erasure itself.
+- `bq::signal::ArraySignal<T>` is the one type-erased public type without the
+  prefix. Do not add an `AnyArraySignal` alias, and do not give it a storage
+  parameter to restore the symmetry with `Signal`. (Why: `conventions.md`.)
 - Public headers go under `src/<lib>/include/<lib>/` (the include firewall).
 
 ## Templates and builders

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -59,10 +59,10 @@ copy for a new node's per-context state.
   `handle.set`.
 - Derive/combine: `map` (`bq/signal/map.h`), `merge` (`bq/signal/merge.h`),
   `combine`/`join`/`conditional` (same folder). `constant` (`bq/signal/constant.h`).
-- Lists whose *membership* changes: `ArraySignal<T>` and `forEach`/`map`/`concat`
-  /`join` (`bq/signal/arraysignal.h`), built over `bq/signal/detail/pick.h`. Its
-  design record, and the parts still outstanding, are in
-  `docs/design/arraysignal.md`.
+- Lists whose *membership* changes: `ArraySignal<T>`, entered by `forEach` and
+  left by `join`, with `concat` and `ArraySignal::map` between
+  (`bq/signal/arraysignal.h`), built over `bq/signal/detail/pick.h`. Its design
+  record, and the parts still outstanding, are in `docs/design/arraysignal.md`.
 - Streams: `pipe` (`bq/stream/pipe.h`) → `{handle, stream}`, `handle.push`;
   `iterate` (`bq/stream/iterate.h`) folds a stream into a signal; `collect`.
 

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -59,6 +59,10 @@ copy for a new node's per-context state.
   `handle.set`.
 - Derive/combine: `map` (`bq/signal/map.h`), `merge` (`bq/signal/merge.h`),
   `combine`/`join`/`conditional` (same folder). `constant` (`bq/signal/constant.h`).
+- Lists whose *membership* changes: `ArraySignal<T>` and `forEach`/`map`/`concat`
+  /`join` (`bq/signal/arraysignal.h`), built over `bq/signal/detail/pick.h`. Its
+  design record, and the parts still outstanding, are in
+  `docs/design/arraysignal.md`.
 - Streams: `pipe` (`bq/stream/pipe.h`) → `{handle, stream}`, `handle.push`;
   `iterate` (`bq/stream/iterate.h`) folds a stream into a signal; `collect`.
 

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -6,7 +6,6 @@
 #include "constant.h"
 #include "datacontext.h"
 #include "frameinfo.h"
-#include "join.h"
 #include "signal.h"
 #include "signalresult.h"
 #include "signaltraits.h"
@@ -111,15 +110,13 @@ namespace bq::signal
 
         /** @brief Whether `U` is accepted as a single constant item of `T`.
          *
-         * A signal and an array of their own have their own constructors, so an
-         * unconstrained forwarding constructor would swallow both — and it
-         * would be a better match than the copy constructor for a non-const
-         * array lvalue besides.
+         * An array has its own constructors, so an unconstrained forwarding
+         * constructor would swallow it — and it would be a better match than
+         * the copy constructor for a non-const array lvalue besides.
          */
         template <typename U, typename T>
         constexpr bool isPlainItem =
             std::is_convertible_v<U, T>
-            && !std::is_convertible_v<U, AnySignal<T>>
             && !IsArraySignal<std::decay_t<U>>::value;
 
         /** @brief Builds one value per key and keeps it while the key is
@@ -265,41 +262,31 @@ namespace bq::signal
                         std::move(idFunc)));
         }
 
-        /** @brief One element whose value comes from a signal.
+        /** @brief One element that never changes.
          *
-         * A new value is a new identity. Nothing built this value from an
-         * identity that outlives the change, so whatever an operator built
-         * once per identity has to be built again — which is the rebuild an
-         * array of a varying single item is defined to cost. Only this element
-         * is disturbed.
+         * It has no inner signal at all. The identity is minted when the
+         * element is initialized into a context, so the description carries
+         * none and two contexts over it are unrelated.
          */
         template <typename T>
-        class ArraySingle
+        class ArrayConstant
         {
         public:
-            using Storage = typename AnySignal<T>::StorageType;
             using Elements = ArrayElements<T>;
 
             struct DataType
             {
-                typename Storage::DataType innerData;
                 Elements elements;
             };
 
-            ArraySingle(Storage sig) :
-                sig_(std::move(sig))
+            ArrayConstant(T value) :
+                value_(std::move(value))
             {
             }
 
-            DataType initialize(DataContext& context,
-                    FrameInfo const& frame) const
+            DataType initialize(DataContext&, FrameInfo const&) const
             {
-                DataType data { sig_.initialize(context, frame), {} };
-
-                setValue(data, sig_.evaluate(context, data.innerData)
-                        .template get<0>());
-
-                return data;
+                return DataType { Elements { { makeArrayId(), value_ } } };
             }
 
             SignalResult<Elements const&> evaluate(DataContext&,
@@ -308,15 +295,97 @@ namespace bq::signal
                 return SignalResult<Elements const&>(data.elements);
             }
 
+            UpdateResult update(DataContext&, DataType&, FrameInfo const&)
+            {
+                return {};
+            }
+
+            btl::connection observe(DataContext&, DataType&,
+                    std::function<void()>)
+            {
+                return {};
+            }
+
+        private:
+            T value_;
+        };
+
+        /** @brief Fans an array of signals in, keeping each identity's state.
+         *
+         * A membership change would make the generic Join rebuild and
+         * re-initialize its whole inner signal, which starts every surviving
+         * element over. This node keeps one inner data **per identity**
+         * instead: an update carries a survivor's data across untouched,
+         * initializes only what arrived, and releases only what left.
+         *
+         * That is what makes a surviving element's state safe from its
+         * neighbours, and it is a property of the node rather than of anything
+         * the elements do — nothing here needs the elements to be shared.
+         */
+        template <typename X>
+        class ArrayJoin
+        {
+        public:
+            using Elements = ArrayElements<AnySignal<X>>;
+            using Storage = typename AnySignal<Elements>::StorageType;
+            using InnerData = SignalDataTypeT<AnySignal<X>>;
+
+            struct DataType
+            {
+                typename Storage::DataType innerData;
+                Elements elements;
+                std::map<ArrayId, InnerData> datas;
+            };
+
+            ArrayJoin(Storage sig) :
+                sig_(std::move(sig))
+            {
+            }
+
+            DataType initialize(DataContext& context,
+                    FrameInfo const& frame) const
+            {
+                DataType data { sig_.initialize(context, frame), {}, {} };
+
+                data.elements = sig_.evaluate(context, data.innerData)
+                    .template get<0>();
+
+                for (auto const& element : data.elements)
+                {
+                    data.datas.emplace(element.id,
+                            element.value.unwrap().initialize(context, frame));
+                }
+
+                return data;
+            }
+
+            SignalResult<std::vector<X>> evaluate(DataContext& context,
+                    DataType const& data) const
+            {
+                std::vector<X> result;
+                result.reserve(data.elements.size());
+
+                for (auto const& element : data.elements)
+                {
+                    result.push_back(element.value.unwrap().evaluate(context,
+                                data.datas.at(element.id)).template get<0>());
+                }
+
+                return SignalResult<std::vector<X>>(std::move(result));
+            }
+
             UpdateResult update(DataContext& context, DataType& data,
                     FrameInfo const& frame)
             {
                 UpdateResult r = sig_.update(context, data.innerData, frame);
 
                 if (r.didChange)
+                    reconcile(context, data, frame);
+
+                for (auto& element : data.elements)
                 {
-                    setValue(data, sig_.evaluate(context, data.innerData)
-                            .template get<0>());
+                    r = r + element.value.unwrap().update(context,
+                            data.datas.at(element.id), frame);
                 }
 
                 return r;
@@ -325,15 +394,48 @@ namespace bq::signal
             btl::connection observe(DataContext& context, DataType& data,
                     std::function<void()> callback)
             {
-                return sig_.observe(context, data.innerData,
-                        std::move(callback));
+                btl::connection c = sig_.observe(context, data.innerData,
+                        callback);
+
+                for (auto& element : data.elements)
+                {
+                    c += element.value.unwrap().observe(context,
+                            data.datas.at(element.id), callback);
+                }
+
+                return c;
             }
 
         private:
-            static void setValue(DataType& data, T const& value)
+            void reconcile(DataContext& context, DataType& data,
+                    FrameInfo const& frame) const
             {
-                data.elements.clear();
-                data.elements.push_back({ makeArrayId(), value });
+                Elements elements = sig_.evaluate(context, data.innerData)
+                    .template get<0>();
+
+                std::map<ArrayId, InnerData> datas;
+
+                for (auto const& element : elements)
+                {
+                    auto surviving = data.datas.find(element.id);
+                    if (surviving != data.datas.end())
+                    {
+                        datas.emplace(element.id,
+                                std::move(surviving->second));
+                    }
+                    else
+                    {
+                        datas.emplace(element.id,
+                                element.value.unwrap().initialize(context,
+                                    frame));
+                    }
+                }
+
+                // Assigning last is what releases the departed elements, and
+                // it releases them only once everything that arrived has been
+                // initialized.
+                data.elements = std::move(elements);
+                data.datas = std::move(datas);
             }
 
             Storage sig_;
@@ -352,16 +454,19 @@ namespace bq::signal
      * itself one and nesting needs no special case in a consumer:
      *
      * @code
-     * ArraySignal<int> values = { 1, 2, someSignal, otherArray };
+     * ArraySignal<int> values = { 1, 2, otherArray };
      * @endcode
      *
      * `{}` is the empty list, and `{x}` is a one-element list — which exports
      * the same sequence as the single item `x` would.
      *
-     * A list whose membership varies is not a constructor: it is forEach(),
-     * which asks for the key that says which item is which. There is no
-     * constructor from AnySignal<std::vector<T>>, because keying such a list by
-     * position is not identity preservation.
+     * **Every constructor is constant.** Anything that varies enters through
+     * forEach(), which asks for the key that says which item is which — a
+     * varying list, and equally a single varying item. Constructing from a
+     * signal would leave the variation nowhere to live but the element itself,
+     * which means rebuilding the element, which is the state loss identity
+     * exists to prevent. Only construction of a constant item and forEach()
+     * mint identity.
      *
      * The type is type-erased by construction and has no storage-typed twin;
      * there is deliberately no `AnyArraySignal`.
@@ -396,41 +501,28 @@ namespace bq::signal
         {
         }
 
-        /** @brief Constructs a single item whose value varies over time.
-         *
-         * A changed value rebuilds this element, and only this element. The
-         * signal is deduplicated first, so a repeat of the value it already
-         * holds is not a rebuild — but only where `T` is equality-comparable,
-         * since tryCheck() is silently a passthrough where it is not.
-         */
-        template <typename TStorage>
-        ArraySignal(Signal<TStorage, T> value) :
-            ArraySignal(ElementsSignal(wrap(detail::ArraySingle<T>(
-                                AnySignal<T>(value.tryCheck()).unwrap()))))
-        {
-        }
-
         /** @brief Constructs a single constant item. */
         template <typename U, typename = std::enable_if_t<
             detail::isPlainItem<U, T>
             >>
         ArraySignal(U&& value) :
-            ArraySignal(AnySignal<T>(constant(T(std::forward<U>(value)))))
+            ArraySignal(ElementsSignal(wrap(detail::ArrayConstant<T>(
+                                T(std::forward<U>(value))))))
         {
         }
 
-        /** @brief Builds one value per element, once per identity.
+        /** @brief Builds one value per element, exactly once per identity.
          *
          * `func` is invoked when an identity appears and its result is kept
-         * until the identity leaves, so it is not re-invoked because a value
-         * changed — a value change reaches what was built through the signals
-         * that were wired into it.
+         * until the identity leaves. It is never re-invoked, because the value
+         * it reads cannot change: an element's value is built once when its
+         * identity appears, and variation lives inside the signals that value
+         * wraps rather than in the value itself.
          *
-         * That still makes this the wrong place to construct anything holding
-         * state that must survive: an element of a value-dynamic array gets a
-         * new identity whenever its value changes, and `func` runs again for
-         * it. Transform data here; build in forEach(), where the identity is
-         * keyed and outlives the value.
+         * Transform data here; build in forEach(). Both take a function from an
+         * element to something else and the type system cannot tell them apart,
+         * but only forEach() hands its delegate the signal that carries the
+         * item's changing value.
          */
         template <typename TFunc>
         auto map(TFunc func) const
@@ -605,28 +697,14 @@ namespace bq::signal
      * to be a signal: an array of anything else has nothing to fan in. Map it
      * to something joinable first.
      *
-     * Each element's signal is shared once per identity, so a membership change
-     * rebuilds the fan-in without disturbing what a surviving element's signal
-     * has accumulated.
+     * A membership change initializes what arrived and releases what left. A
+     * surviving element is carried across untouched, so whatever its signal has
+     * accumulated survives its neighbours coming and going without the caller
+     * having to share anything.
      */
     template <typename X>
     AnySignal<std::vector<X>> join(ArraySignal<AnySignal<X>> array)
     {
-        auto shared = array.map([](AnySignal<X> const& sig)
-            {
-                return AnySignal<X>(sig.share());
-            });
-
-        return shared.elements()
-            .map([](detail::ArrayElements<AnySignal<X>> const& elements)
-                {
-                    std::vector<AnySignal<X>> sigs;
-                    sigs.reserve(elements.size());
-                    for (auto const& element : elements)
-                        sigs.push_back(element.value);
-
-                    return AnySignal<std::vector<X>>(combine(std::move(sigs)));
-                })
-            .join();
+        return wrap(detail::ArrayJoin<X>(array.elements().unwrap()));
     }
 } // namespace bq::signal

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -114,7 +114,7 @@ namespace bq::signal
         {
         };
 
-        /** @brief Whether `U` is accepted as a single constant item of `T`.
+        /** @brief Whether 'U' is accepted as a single constant item of 'T'.
          *
          * An array has its own constructors, so an unconstrained forwarding
          * constructor would swallow it — and it would be a better match than
@@ -148,7 +148,7 @@ namespace bq::signal
          * two independent sets of values, and two consumers within one context
          * find the one table.
          *
-         * `keyFunc` and `buildFunc` are invoked as const functions. They live
+         * 'keyFunc' and 'buildFunc' are invoked as const functions. They live
          * in the description, which every context shares, so state in them
          * would be state outside any context. The built value is copied into
          * the exported element sequence, so it must be copy-constructible.
@@ -427,7 +427,7 @@ namespace bq::signal
                 requireDistinct(elements);
 
                 // Arrivals are initialized into their own storage first, so
-                // nothing in `data` has moved if one of them throws.
+                // nothing in 'data' has moved if one of them throws.
                 std::map<ArrayId, InnerData> datas;
                 std::set<ArrayId> arrived;
 
@@ -495,8 +495,8 @@ namespace bq::signal
      * ArraySignal<int> values = { 1, 2, otherArray };
      * @endcode
      *
-     * `{}` is the empty list, and `{x}` is a one-element list — which exports
-     * the same sequence as the single item `x` would.
+     * '{}' is the empty list, and '{x}' is a one-element list — which exports
+     * the same sequence as the single item 'x' would.
      *
      * **Every constructor is constant.** Anything that varies enters through
      * forEach(), which asks for the key that says which item is which — a
@@ -507,7 +507,7 @@ namespace bq::signal
      * mint identity.
      *
      * The type is type-erased by construction and has no storage-typed twin;
-     * there is deliberately no `AnyArraySignal`.
+     * there is deliberately no 'AnyArraySignal'.
      *
      * An array is shared: it holds its elements behind a share(), so two
      * consumers of one array within one SignalContext see **one set of built
@@ -557,7 +557,7 @@ namespace bq::signal
 
         /** @brief Builds one value per element, exactly once per identity.
          *
-         * `func` is invoked when an identity appears and its result is kept
+         * 'func' is invoked when an identity appears and its result is kept
          * until the identity leaves. It is never re-invoked, because the value
          * it reads cannot change: an element's value is built once when its
          * identity appears, and variation lives inside the signals that value
@@ -646,7 +646,7 @@ namespace bq::signal
     /** @brief Keys a changing list and builds one value per key.
      *
      * The entry into the array domain, and the only operator that mints
-     * identity from a key. `delegate` receives the item's value as a signal and
+     * identity from a key. 'delegate' receives the item's value as a signal and
      * is invoked once per key per context. It is not re-invoked when the item's
      * value changes — the new value arrives through the signal the delegate
      * already holds — so nothing the delegate built is destroyed by a value
@@ -659,11 +659,11 @@ namespace bq::signal
      * departing item and its replacement briefly coexist — a value holding a
      * resource that only one owner may have cannot be built here.
      *
-     * `keyFn` and `delegate` are invoked as const functions, and run for every
+     * 'keyFn' and 'delegate' are invoked as const functions, and run for every
      * item on every change and once per key respectively. Keys must be unique
      * within this call and need not be unique anywhere else.
      *
-     * `source` is any signal of a `std::vector<T>`, type-erased or not. `T` is
+     * 'source' is any signal of a 'std::vector<T>', type-erased or not. 'T' is
      * the element type the delegate is handed; a source of some other element
      * type goes through an ordinary map() first, which says at the call site
      * what the conversion is.
@@ -717,7 +717,7 @@ namespace bq::signal
      *
      * Separately built arrays have distinct identities by construction, so
      * nothing is re-keyed. With the empty array as its identity element this is
-     * a monoid, which is the same statement as `{a, {b, c}}` and `{a, b, c}`
+     * a monoid, which is the same statement as '{a, {b, c}}' and '{a, b, c}'
      * exporting the same list.
      *
      * Concatenating an array with *itself* is the one case that is not

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -32,11 +32,17 @@ namespace bq::signal
     {
         /** @brief The identity of one element of one array.
          *
-         * An id never reaches user code: it is minted by an array's node, in
-         * that node's per-context state, and is only ever matched within the
-         * node that minted it. It is orderable so that it can key a map;
-         * nothing else about it means anything, and in particular its order
-         * says nothing about the order of the elements.
+         * A distinct type rather than a bare btl::UniqueId because it is drawn
+         * from the same counter as the ids that key a DataContext and means
+         * something different: this one names an entry in an array node's own
+         * table. Were they one type, looking an element up in the DataContext —
+         * or the reverse — would compile and quietly find nothing.
+         *
+         * An id never reaches user code: it is minted where the element is,
+         * and is only ever matched within the node that minted it. It is
+         * orderable so that it can key a map; nothing else about it means
+         * anything, and in particular its order says nothing about the order of
+         * the elements.
          */
         class ArrayId
         {
@@ -118,6 +124,19 @@ namespace bq::signal
         constexpr bool isPlainItem =
             std::is_convertible_v<U, T>
             && !IsArraySignal<std::decay_t<U>>::value;
+
+        /** @brief Whether forEach() accepts this key function and delegate.
+         *
+         * Constrained at the call so that a callable of the wrong shape is
+         * reported where it was written rather than as a failure deep inside
+         * the node. Only invocability can be constrained, not the results:
+         * those are what the key and the built value are deduced *from*, so
+         * there is nothing to give is_invocable_r to compare against.
+         */
+        template <typename TKeyFunc, typename TDelegate, typename T>
+        constexpr bool isForEachCallable =
+            std::is_invocable_v<TKeyFunc const&, T const&>
+            && std::is_invocable_v<TDelegate const&, AnySignal<T>>;
 
         /** @brief Builds one value per key and keeps it while the key is
          * there.
@@ -262,51 +281,19 @@ namespace bq::signal
 
         /** @brief One element that never changes.
          *
-         * It has no inner signal at all. The identity is minted when the
-         * element is initialized into a context, so the description carries
-         * none and two contexts over it are unrelated.
+         * A constant needs no node: the identity is minted here, once, and the
+         * element is then an ordinary constant signal. It is the one identity
+         * the description carries, which is harmless because it names nothing
+         * outside the per-context tables that match it — two contexts over one
+         * constant element look their own values up under the same id and never
+         * meet.
          */
         template <typename T>
-        class ArrayConstant
+        AnySignal<ArrayElements<T>> constantElement(T value)
         {
-        public:
-            using Elements = ArrayElements<T>;
-
-            struct DataType
-            {
-                Elements elements;
-            };
-
-            ArrayConstant(T value) :
-                value_(std::move(value))
-            {
-            }
-
-            DataType initialize(DataContext&, FrameInfo const&) const
-            {
-                return DataType { Elements { { makeArrayId(), value_ } } };
-            }
-
-            SignalResult<Elements const&> evaluate(DataContext&,
-                    DataType const& data) const
-            {
-                return SignalResult<Elements const&>(data.elements);
-            }
-
-            UpdateResult update(DataContext&, DataType&, FrameInfo const&)
-            {
-                return {};
-            }
-
-            btl::connection observe(DataContext&, DataType&,
-                    std::function<void()>)
-            {
-                return {};
-            }
-
-        private:
-            T value_;
-        };
+            return constant(ArrayElements<T> {
+                    { makeArrayId(), std::move(value) } });
+        }
 
         /** @brief Fans an array of signals in, keeping each identity's state.
          *
@@ -563,8 +550,8 @@ namespace bq::signal
             detail::isPlainItem<U, T>
             >>
         ArraySignal(U&& value) :
-            ArraySignal(ElementsSignal(wrap(detail::ArrayConstant<T>(
-                                T(std::forward<U>(value))))))
+            ArraySignal(detail::constantElement<T>(
+                        T(std::forward<U>(value))))
         {
         }
 
@@ -581,7 +568,9 @@ namespace bq::signal
          * but only forEach() hands its delegate the signal that carries the
          * item's changing value.
          */
-        template <typename TFunc>
+        template <typename TFunc, typename = std::enable_if_t<
+            std::is_invocable_v<TFunc const&, T const&>
+            >>
         auto map(TFunc func) const
         {
             using Element = detail::ArrayElement<T>;
@@ -674,12 +663,20 @@ namespace bq::signal
      * item on every change and once per key respectively. Keys must be unique
      * within this call and need not be unique anywhere else.
      *
+     * `source` is any signal of a `std::vector<T>`, type-erased or not. `T` is
+     * the element type the delegate is handed; a source of some other element
+     * type goes through an ordinary map() first, which says at the call site
+     * what the conversion is.
+     *
      * @throws std::runtime_error if two items share a key. Thrown from an
      *         update, this leaves the source advanced and the table not, so
      *         the context should be discarded rather than driven again.
      */
-    template <typename T, typename TKeyFunc, typename TDelegate>
-    auto forEach(AnySignal<std::vector<T>> source, TKeyFunc keyFn,
+    template <typename TStorage, typename T, typename TKeyFunc,
+             typename TDelegate, typename = std::enable_if_t<
+                 detail::isForEachCallable<TKeyFunc, TDelegate, T>
+                 >>
+    auto forEach(Signal<TStorage, std::vector<T>> source, TKeyFunc keyFn,
             TDelegate delegate)
     {
         using Key = std::decay_t<std::invoke_result_t<
@@ -706,11 +703,14 @@ namespace bq::signal
     }
 
     /** @overload */
-    template <typename T, typename TKeyFunc, typename TDelegate>
+    template <typename T, typename TKeyFunc, typename TDelegate,
+             typename = std::enable_if_t<
+                 detail::isForEachCallable<TKeyFunc, TDelegate, T>
+                 >>
     auto forEach(std::vector<T> source, TKeyFunc keyFn, TDelegate delegate)
     {
-        return forEach(AnySignal<std::vector<T>>(constant(std::move(source))),
-                std::move(keyFn), std::move(delegate));
+        return forEach(constant(std::move(source)), std::move(keyFn),
+                std::move(delegate));
     }
 
     /** @brief Concatenates arrays, preserving order and every identity.

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "detail/pick.h"
-
 #include "combine.h"
 #include "constant.h"
 #include "datacontext.h"
+#include "detail/pick.h"
 #include "frameinfo.h"
 #include "signal.h"
 #include "signalresult.h"
@@ -18,6 +17,7 @@
 #include <functional>
 #include <initializer_list>
 #include <map>
+#include <set>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -129,19 +129,22 @@ namespace bq::signal
          * two independent sets of values, and two consumers within one context
          * find the one table.
          *
-         * `keyFunc`, `buildFunc` and `idFunc` are invoked as const functions.
-         * They live in the description, which every context shares, so state in
-         * them would be state outside any context.
+         * `keyFunc` and `buildFunc` are invoked as const functions. They live
+         * in the description, which every context shares, so state in them
+         * would be state outside any context. The built value is copied into
+         * the exported element sequence, so it must be copy-constructible.
          *
          * @throws std::runtime_error if two elements of one update share a key.
+         *         Thrown from a refresh, this discards whatever was built for
+         *         the keys already visited, so a build with side effects that
+         *         need undoing does not belong here.
          */
-        template <typename TSource, typename TKeyFunc, typename TBuildFunc,
-                 typename TIdFunc>
+        template <typename TSource, typename TKeyFunc, typename TBuildFunc>
         class ArrayOnce
         {
         public:
-            using Storage = typename AnySignal<std::vector<TSource>>::
-                StorageType;
+            using Storage =
+                typename AnySignal<std::vector<TSource>>::StorageType;
 
             using Key = std::decay_t<std::invoke_result_t<
                 TKeyFunc const&, TSource const&>>;
@@ -158,12 +161,10 @@ namespace bq::signal
                 Elements elements;
             };
 
-            ArrayOnce(Storage sig, TKeyFunc keyFunc, TBuildFunc buildFunc,
-                    TIdFunc idFunc) :
+            ArrayOnce(Storage sig, TKeyFunc keyFunc, TBuildFunc buildFunc) :
                 sig_(std::move(sig)),
                 keyFunc_(std::move(keyFunc)),
-                buildFunc_(std::move(buildFunc)),
-                idFunc_(std::move(idFunc))
+                buildFunc_(std::move(buildFunc))
             {
             }
 
@@ -227,7 +228,7 @@ namespace bq::signal
                     ArrayElement<Value> element =
                         previous != data.built.end()
                         ? previous->second
-                        : ArrayElement<Value>{ (*idFunc_)(key),
+                        : ArrayElement<Value>{ makeArrayId(),
                             (*buildFunc_)(key, item) };
 
                     built.insert({ key, element });
@@ -247,19 +248,16 @@ namespace bq::signal
             Storage sig_;
             mutable btl::CopyWrapper<TKeyFunc> keyFunc_;
             mutable btl::CopyWrapper<TBuildFunc> buildFunc_;
-            mutable btl::CopyWrapper<TIdFunc> idFunc_;
         };
 
-        template <typename TSource, typename TKeyFunc, typename TBuildFunc,
-                 typename TIdFunc>
+        template <typename TSource, typename TKeyFunc, typename TBuildFunc>
         auto makeArrayOnce(AnySignal<std::vector<TSource>> source,
-                TKeyFunc keyFunc, TBuildFunc buildFunc, TIdFunc idFunc)
+                TKeyFunc keyFunc, TBuildFunc buildFunc)
         {
-            return wrap(ArrayOnce<TSource, TKeyFunc, TBuildFunc, TIdFunc>(
+            return wrap(ArrayOnce<TSource, TKeyFunc, TBuildFunc>(
                         std::move(source).unwrap(),
                         std::move(keyFunc),
-                        std::move(buildFunc),
-                        std::move(idFunc)));
+                        std::move(buildFunc)));
         }
 
         /** @brief One element that never changes.
@@ -321,6 +319,14 @@ namespace bq::signal
          * That is what makes a surviving element's state safe from its
          * neighbours, and it is a property of the node rather than of anything
          * the elements do — nothing here needs the elements to be shared.
+         *
+         * observe() connects the elements that are there when it is called and
+         * is **not** rewired by a later membership change: an element that
+         * arrives afterwards is not observed, and one that leaves stays in the
+         * returned connection. Nothing in the toolkit observes a signal today.
+         *
+         * @throws std::runtime_error if one identity appears twice, which means
+         *         an array was concatenated with itself.
          */
         template <typename X>
         class ArrayJoin
@@ -349,6 +355,8 @@ namespace bq::signal
 
                 data.elements = sig_.evaluate(context, data.innerData)
                     .template get<0>();
+
+                requireDistinct(data.elements);
 
                 for (auto const& element : data.elements)
                 {
@@ -379,14 +387,28 @@ namespace bq::signal
             {
                 UpdateResult r = sig_.update(context, data.innerData, frame);
 
+                std::set<ArrayId> arrived;
                 if (r.didChange)
-                    reconcile(context, data, frame);
+                    arrived = reconcile(context, data, frame);
 
                 for (auto& element : data.elements)
                 {
+                    // An arrival was initialized against this very frame, so
+                    // updating it too would advance it twice — for anything
+                    // that folds, that is a wrong value rather than wasted
+                    // work.
+                    if (arrived.count(element.id))
+                        continue;
+
                     r = r + element.value.unwrap().update(context,
                             data.datas.at(element.id), frame);
                 }
+
+                // Nothing collected an arrival's own request to be driven
+                // again, so ask for the next frame on its behalf rather than
+                // let a newly built animation sit still.
+                if (!arrived.empty())
+                    r.nextUpdate = min(r.nextUpdate, signal_time_t(0));
 
                 return r;
             }
@@ -407,13 +429,31 @@ namespace bq::signal
             }
 
         private:
-            void reconcile(DataContext& context, DataType& data,
+            // Returns the identities that arrived, which the caller owes an
+            // update this frame no longer.
+            std::set<ArrayId> reconcile(DataContext& context, DataType& data,
                     FrameInfo const& frame) const
             {
                 Elements elements = sig_.evaluate(context, data.innerData)
                     .template get<0>();
 
+                requireDistinct(elements);
+
+                // Arrivals are initialized into their own storage first, so
+                // nothing in `data` has moved if one of them throws.
                 std::map<ArrayId, InnerData> datas;
+                std::set<ArrayId> arrived;
+
+                for (auto const& element : elements)
+                {
+                    if (data.datas.count(element.id))
+                        continue;
+
+                    datas.emplace(element.id,
+                            element.value.unwrap().initialize(context, frame));
+
+                    arrived.insert(element.id);
+                }
 
                 for (auto const& element : elements)
                 {
@@ -423,12 +463,6 @@ namespace bq::signal
                         datas.emplace(element.id,
                                 std::move(surviving->second));
                     }
-                    else
-                    {
-                        datas.emplace(element.id,
-                                element.value.unwrap().initialize(context,
-                                    frame));
-                    }
                 }
 
                 // Assigning last is what releases the departed elements, and
@@ -436,6 +470,23 @@ namespace bq::signal
                 // initialized.
                 data.elements = std::move(elements);
                 data.datas = std::move(datas);
+
+                return arrived;
+            }
+
+            static void requireDistinct(Elements const& elements)
+            {
+                std::set<ArrayId> seen;
+
+                for (auto const& element : elements)
+                {
+                    if (!seen.insert(element.id).second)
+                    {
+                        throw std::runtime_error("ArraySignal: one identity "
+                                "appears twice, which means an array was "
+                                "concatenated with itself");
+                    }
+                }
             }
 
             Storage sig_;
@@ -472,9 +523,15 @@ namespace bq::signal
      * there is deliberately no `AnyArraySignal`.
      *
      * An array is shared: it holds its elements behind a share(), so two
-     * consumers of one array within one SignalContext see one set of built
-     * values and one evaluation per pass. Two SignalContexts over one array
-     * share nothing at all.
+     * consumers of one array within one SignalContext see **one set of built
+     * values** — the delegate and every map() run once between them, which is
+     * what identity exists to protect. What is not shared is the elements'
+     * instantiated state: each consumer of the exit instantiates the element
+     * signals for itself, exactly as instantiating any signal twice in one
+     * context does. Share inside the delegate if an element's own state has to
+     * be one thing across two consumers.
+     *
+     * Two SignalContexts over one array share nothing at all.
      */
     template <typename T>
     class ArraySignal
@@ -544,11 +601,7 @@ namespace bq::signal
                         {
                             return element.id;
                         },
-                        std::move(build),
-                        [](detail::ArrayId const&)
-                        {
-                            return detail::makeArrayId();
-                        }));
+                        std::move(build)));
         }
 
         /** @brief The identified elements.
@@ -649,11 +702,7 @@ namespace bq::signal
         return ArraySignal<U>::fromElements(detail::makeArrayOnce(
                     std::move(shared),
                     std::move(keyFn),
-                    std::move(build),
-                    [](Key const&)
-                    {
-                        return detail::makeArrayId();
-                    }));
+                    std::move(build)));
     }
 
     /** @overload */

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -109,6 +109,19 @@ namespace bq::signal
         {
         };
 
+        /** @brief Whether `U` is accepted as a single constant item of `T`.
+         *
+         * A signal and an array of their own have their own constructors, so an
+         * unconstrained forwarding constructor would swallow both — and it
+         * would be a better match than the copy constructor for a non-const
+         * array lvalue besides.
+         */
+        template <typename U, typename T>
+        constexpr bool isPlainItem =
+            std::is_convertible_v<U, T>
+            && !std::is_convertible_v<U, AnySignal<T>>
+            && !IsArraySignal<std::decay_t<U>>::value;
+
         /** @brief Builds one value per key and keeps it while the key is
          * there.
          *
@@ -385,19 +398,21 @@ namespace bq::signal
 
         /** @brief Constructs a single item whose value varies over time.
          *
-         * A changed value rebuilds this element, and only this element.
+         * A changed value rebuilds this element, and only this element. The
+         * signal is deduplicated first, so a repeat of the value it already
+         * holds is not a rebuild — but only where `T` is equality-comparable,
+         * since tryCheck() is silently a passthrough where it is not.
          */
-        ArraySignal(AnySignal<T> value) :
+        template <typename TStorage>
+        ArraySignal(Signal<TStorage, T> value) :
             ArraySignal(ElementsSignal(wrap(detail::ArraySingle<T>(
-                                std::move(value).unwrap()))))
+                                AnySignal<T>(value.tryCheck()).unwrap()))))
         {
         }
 
         /** @brief Constructs a single constant item. */
         template <typename U, typename = std::enable_if_t<
-            std::is_convertible_v<U, T>
-            && !std::is_convertible_v<U, AnySignal<T>>
-            && !detail::IsArraySignal<std::decay_t<U>>::value
+            detail::isPlainItem<U, T>
             >>
         ArraySignal(U&& value) :
             ArraySignal(AnySignal<T>(constant(T(std::forward<U>(value)))))
@@ -438,9 +453,9 @@ namespace bq::signal
                             return element.id;
                         },
                         std::move(build),
-                        [](detail::ArrayId const& id)
+                        [](detail::ArrayId const&)
                         {
-                            return id;
+                            return detail::makeArrayId();
                         }));
         }
 
@@ -505,13 +520,18 @@ namespace bq::signal
      *
      * Eviction is strict. When a key leaves, its identity is dropped and what
      * the delegate built for it is destroyed in that same update; a key that
-     * leaves and returns is a new item, exactly as a changed key is.
+     * leaves and returns is a new item, exactly as a changed key is. The
+     * update builds the new table before it retires the old one, so a
+     * departing item and its replacement briefly coexist — a value holding a
+     * resource that only one owner may have cannot be built here.
      *
      * `keyFn` and `delegate` are invoked as const functions, and run for every
      * item on every change and once per key respectively. Keys must be unique
      * within this call and need not be unique anywhere else.
      *
-     * @throws std::runtime_error if two items share a key.
+     * @throws std::runtime_error if two items share a key. Thrown from an
+     *         update, this leaves the source advanced and the table not, so
+     *         the context should be discarded rather than driven again.
      */
     template <typename T, typename TKeyFunc, typename TDelegate>
     auto forEach(AnySignal<std::vector<T>> source, TKeyFunc keyFn,
@@ -554,10 +574,16 @@ namespace bq::signal
 
     /** @brief Concatenates arrays, preserving order and every identity.
      *
-     * Identities are distinct between arrays by construction, so nothing is
-     * re-keyed. With the empty array as its identity element this is a monoid,
-     * which is the same statement as `{a, {b, c}}` and `{a, b, c}` exporting
-     * the same list.
+     * Separately built arrays have distinct identities by construction, so
+     * nothing is re-keyed. With the empty array as its identity element this is
+     * a monoid, which is the same statement as `{a, {b, c}}` and `{a, b, c}`
+     * exporting the same list.
+     *
+     * Concatenating an array with *itself* is the one case that is not
+     * well-formed: its identities would appear twice, which the next operator
+     * over the result reports as a duplicate key. Arrays derived from a common
+     * source are fine — every operator that builds an array mints its own
+     * identities.
      */
     template <typename T>
     ArraySignal<T> concat(std::vector<ArraySignal<T>> arrays)

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -1,0 +1,606 @@
+#pragma once
+
+#include "detail/pick.h"
+
+#include "combine.h"
+#include "constant.h"
+#include "datacontext.h"
+#include "frameinfo.h"
+#include "join.h"
+#include "signal.h"
+#include "signalresult.h"
+#include "signaltraits.h"
+#include "updateresult.h"
+
+#include <btl/connection.h>
+#include <btl/copywrapper.h>
+#include <btl/uniqueid.h>
+
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace bq::signal
+{
+    template <typename T>
+    class ArraySignal;
+
+    namespace detail
+    {
+        /** @brief The identity of one element of one array.
+         *
+         * An id never reaches user code: it is minted by an array's node, in
+         * that node's per-context state, and is only ever matched within the
+         * node that minted it. It is orderable so that it can key a map;
+         * nothing else about it means anything, and in particular its order
+         * says nothing about the order of the elements.
+         */
+        class ArrayId
+        {
+        public:
+            explicit ArrayId(btl::UniqueId id) :
+                id_(id)
+            {
+            }
+
+            bool operator==(ArrayId const& rhs) const
+            {
+                return id_ == rhs.id_;
+            }
+
+            bool operator!=(ArrayId const& rhs) const
+            {
+                return id_ != rhs.id_;
+            }
+
+            bool operator<(ArrayId const& rhs) const
+            {
+                return id_ < rhs.id_;
+            }
+
+        private:
+            btl::UniqueId id_;
+        };
+
+        inline ArrayId makeArrayId()
+        {
+            return ArrayId(makeUniqueId());
+        }
+
+        /** @brief One element of an array: its identity and what was built
+         * for it.
+         *
+         * Equality is identity alone, so comparing two element sequences asks
+         * whether the membership changed and nothing more. The value cannot
+         * differ at a fixed identity: it is built once when the identity
+         * appears and kept until the identity leaves.
+         */
+        template <typename T>
+        struct ArrayElement
+        {
+            ArrayId id;
+            T value;
+
+            bool operator==(ArrayElement const& rhs) const
+            {
+                return id == rhs.id;
+            }
+
+            bool operator!=(ArrayElement const& rhs) const
+            {
+                return id != rhs.id;
+            }
+        };
+
+        template <typename T>
+        using ArrayElements = std::vector<ArrayElement<T>>;
+
+        template <typename T>
+        struct IsArraySignal : std::false_type
+        {
+        };
+
+        template <typename T>
+        struct IsArraySignal<ArraySignal<T>> : std::true_type
+        {
+        };
+
+        /** @brief Builds one value per key and keeps it while the key is
+         * there.
+         *
+         * The key to id map and the built values live in this node's DataType,
+         * which an array always holds behind a share(). SharedControl keys that
+         * data by a UniqueId carried in the description, so the table is
+         * created once per DataContext: two contexts over one description build
+         * two independent sets of values, and two consumers within one context
+         * find the one table.
+         *
+         * `keyFunc`, `buildFunc` and `idFunc` are invoked as const functions.
+         * They live in the description, which every context shares, so state in
+         * them would be state outside any context.
+         *
+         * @throws std::runtime_error if two elements of one update share a key.
+         */
+        template <typename TSource, typename TKeyFunc, typename TBuildFunc,
+                 typename TIdFunc>
+        class ArrayOnce
+        {
+        public:
+            using Storage = typename AnySignal<std::vector<TSource>>::
+                StorageType;
+
+            using Key = std::decay_t<std::invoke_result_t<
+                TKeyFunc const&, TSource const&>>;
+
+            using Value = std::decay_t<std::invoke_result_t<
+                TBuildFunc const&, Key const&, TSource const&>>;
+
+            using Elements = ArrayElements<Value>;
+
+            struct DataType
+            {
+                typename Storage::DataType innerData;
+                std::map<Key, ArrayElement<Value>> built;
+                Elements elements;
+            };
+
+            ArrayOnce(Storage sig, TKeyFunc keyFunc, TBuildFunc buildFunc,
+                    TIdFunc idFunc) :
+                sig_(std::move(sig)),
+                keyFunc_(std::move(keyFunc)),
+                buildFunc_(std::move(buildFunc)),
+                idFunc_(std::move(idFunc))
+            {
+            }
+
+            DataType initialize(DataContext& context,
+                    FrameInfo const& frame) const
+            {
+                DataType data { sig_.initialize(context, frame), {}, {} };
+
+                refresh(data, sig_.evaluate(context, data.innerData)
+                        .template get<0>());
+
+                return data;
+            }
+
+            SignalResult<Elements const&> evaluate(DataContext&,
+                    DataType const& data) const
+            {
+                return SignalResult<Elements const&>(data.elements);
+            }
+
+            UpdateResult update(DataContext& context, DataType& data,
+                    FrameInfo const& frame)
+            {
+                UpdateResult r = sig_.update(context, data.innerData, frame);
+
+                if (r.didChange)
+                {
+                    r.didChange = refresh(data,
+                            sig_.evaluate(context, data.innerData)
+                            .template get<0>());
+                }
+
+                return r;
+            }
+
+            btl::connection observe(DataContext& context, DataType& data,
+                    std::function<void()> callback)
+            {
+                return sig_.observe(context, data.innerData,
+                        std::move(callback));
+            }
+
+        private:
+            // Returns whether the membership changed, which is the whole of
+            // what an update can change: a value is built once per identity.
+            bool refresh(DataType& data,
+                    std::vector<TSource> const& source) const
+            {
+                std::map<Key, ArrayElement<Value>> built;
+                Elements elements;
+                elements.reserve(source.size());
+
+                for (auto const& item : source)
+                {
+                    Key key = (*keyFunc_)(item);
+
+                    if (built.count(key))
+                        throw std::runtime_error("ArraySignal: duplicate key");
+
+                    auto previous = data.built.find(key);
+                    ArrayElement<Value> element =
+                        previous != data.built.end()
+                        ? previous->second
+                        : ArrayElement<Value>{ (*idFunc_)(key),
+                            (*buildFunc_)(key, item) };
+
+                    built.insert({ key, element });
+                    elements.push_back(std::move(element));
+                }
+
+                bool const changed = elements != data.elements;
+
+                // Assigning the new table here is what retires a departed
+                // key's value, in the same update that observed it leave.
+                data.built = std::move(built);
+                data.elements = std::move(elements);
+
+                return changed;
+            }
+
+            Storage sig_;
+            mutable btl::CopyWrapper<TKeyFunc> keyFunc_;
+            mutable btl::CopyWrapper<TBuildFunc> buildFunc_;
+            mutable btl::CopyWrapper<TIdFunc> idFunc_;
+        };
+
+        template <typename TSource, typename TKeyFunc, typename TBuildFunc,
+                 typename TIdFunc>
+        auto makeArrayOnce(AnySignal<std::vector<TSource>> source,
+                TKeyFunc keyFunc, TBuildFunc buildFunc, TIdFunc idFunc)
+        {
+            return wrap(ArrayOnce<TSource, TKeyFunc, TBuildFunc, TIdFunc>(
+                        std::move(source).unwrap(),
+                        std::move(keyFunc),
+                        std::move(buildFunc),
+                        std::move(idFunc)));
+        }
+
+        /** @brief One element whose value comes from a signal.
+         *
+         * A new value is a new identity. Nothing built this value from an
+         * identity that outlives the change, so whatever an operator built
+         * once per identity has to be built again — which is the rebuild an
+         * array of a varying single item is defined to cost. Only this element
+         * is disturbed.
+         */
+        template <typename T>
+        class ArraySingle
+        {
+        public:
+            using Storage = typename AnySignal<T>::StorageType;
+            using Elements = ArrayElements<T>;
+
+            struct DataType
+            {
+                typename Storage::DataType innerData;
+                Elements elements;
+            };
+
+            ArraySingle(Storage sig) :
+                sig_(std::move(sig))
+            {
+            }
+
+            DataType initialize(DataContext& context,
+                    FrameInfo const& frame) const
+            {
+                DataType data { sig_.initialize(context, frame), {} };
+
+                setValue(data, sig_.evaluate(context, data.innerData)
+                        .template get<0>());
+
+                return data;
+            }
+
+            SignalResult<Elements const&> evaluate(DataContext&,
+                    DataType const& data) const
+            {
+                return SignalResult<Elements const&>(data.elements);
+            }
+
+            UpdateResult update(DataContext& context, DataType& data,
+                    FrameInfo const& frame)
+            {
+                UpdateResult r = sig_.update(context, data.innerData, frame);
+
+                if (r.didChange)
+                {
+                    setValue(data, sig_.evaluate(context, data.innerData)
+                            .template get<0>());
+                }
+
+                return r;
+            }
+
+            btl::connection observe(DataContext& context, DataType& data,
+                    std::function<void()> callback)
+            {
+                return sig_.observe(context, data.innerData,
+                        std::move(callback));
+            }
+
+        private:
+            static void setValue(DataType& data, T const& value)
+            {
+                data.elements.clear();
+                data.elements.push_back({ makeArrayId(), value });
+            }
+
+            Storage sig_;
+        };
+    } // namespace detail
+
+    /** @brief An immutable description of a list whose contents and membership
+     * may both change over time.
+     *
+     * An array is a value, not a container: it has no mutating operations, and
+     * dynamism reaches it from upstream. Each element carries an identity,
+     * which is what lets an operator build something once per item and keep it
+     * across insertions, removals and reorderings of its siblings.
+     *
+     * Every accepted source converts to an array, so a braced list of them is
+     * itself one and nesting needs no special case in a consumer:
+     *
+     * @code
+     * ArraySignal<int> values = { 1, 2, someSignal, otherArray };
+     * @endcode
+     *
+     * `{}` is the empty list, and `{x}` is a one-element list — which exports
+     * the same sequence as the single item `x` would.
+     *
+     * A list whose membership varies is not a constructor: it is forEach(),
+     * which asks for the key that says which item is which. There is no
+     * constructor from AnySignal<std::vector<T>>, because keying such a list by
+     * position is not identity preservation.
+     *
+     * The type is type-erased by construction and has no storage-typed twin;
+     * there is deliberately no `AnyArraySignal`.
+     *
+     * An array is shared: it holds its elements behind a share(), so two
+     * consumers of one array within one SignalContext see one set of built
+     * values and one evaluation per pass. Two SignalContexts over one array
+     * share nothing at all.
+     */
+    template <typename T>
+    class ArraySignal
+    {
+    public:
+        using Elements = detail::ArrayElements<T>;
+        using ElementsSignal = AnySignal<Elements>;
+
+        /** @brief Constructs the empty list. */
+        ArraySignal() :
+            ArraySignal(ElementsSignal(constant(Elements())))
+        {
+        }
+
+        /** @brief Constructs a list of children, flattened in order. */
+        ArraySignal(std::initializer_list<ArraySignal<T>> children) :
+            ArraySignal(std::vector<ArraySignal<T>>(children))
+        {
+        }
+
+        /** @overload */
+        ArraySignal(std::vector<ArraySignal<T>> children) :
+            ArraySignal(concatElements(std::move(children)))
+        {
+        }
+
+        /** @brief Constructs a single item whose value varies over time.
+         *
+         * A changed value rebuilds this element, and only this element.
+         */
+        ArraySignal(AnySignal<T> value) :
+            ArraySignal(ElementsSignal(wrap(detail::ArraySingle<T>(
+                                std::move(value).unwrap()))))
+        {
+        }
+
+        /** @brief Constructs a single constant item. */
+        template <typename U, typename = std::enable_if_t<
+            std::is_convertible_v<U, T>
+            && !std::is_convertible_v<U, AnySignal<T>>
+            && !detail::IsArraySignal<std::decay_t<U>>::value
+            >>
+        ArraySignal(U&& value) :
+            ArraySignal(AnySignal<T>(constant(T(std::forward<U>(value)))))
+        {
+        }
+
+        /** @brief Builds one value per element, once per identity.
+         *
+         * `func` is invoked when an identity appears and its result is kept
+         * until the identity leaves, so it is not re-invoked because a value
+         * changed — a value change reaches what was built through the signals
+         * that were wired into it.
+         *
+         * That still makes this the wrong place to construct anything holding
+         * state that must survive: an element of a value-dynamic array gets a
+         * new identity whenever its value changes, and `func` runs again for
+         * it. Transform data here; build in forEach(), where the identity is
+         * keyed and outlives the value.
+         */
+        template <typename TFunc>
+        auto map(TFunc func) const
+        {
+            using Element = detail::ArrayElement<T>;
+
+            auto build = [func=std::move(func)](detail::ArrayId const&,
+                    Element const& element)
+                {
+                    return func(element.value);
+                };
+
+            using V = std::decay_t<std::invoke_result_t<decltype(build) const&,
+                  detail::ArrayId const&, Element const&>>;
+
+            return ArraySignal<V>::fromElements(detail::makeArrayOnce(
+                        elements_,
+                        [](Element const& element)
+                        {
+                            return element.id;
+                        },
+                        std::move(build),
+                        [](detail::ArrayId const& id)
+                        {
+                            return id;
+                        }));
+        }
+
+        /** @brief The identified elements.
+         *
+         * An operator's entry into the array, not part of the caller-facing
+         * surface.
+         */
+        ElementsSignal const& elements() const
+        {
+            return elements_;
+        }
+
+        /** @brief Wraps an element signal an operator produced.
+         *
+         * Not part of the caller-facing surface.
+         */
+        static ArraySignal fromElements(ElementsSignal elements)
+        {
+            return ArraySignal(std::move(elements));
+        }
+
+    private:
+        explicit ArraySignal(ElementsSignal elements) :
+            elements_(elements.share())
+        {
+        }
+
+        static ElementsSignal concatElements(
+                std::vector<ArraySignal<T>> children)
+        {
+            std::vector<ElementsSignal> sigs;
+            sigs.reserve(children.size());
+            for (auto const& child : children)
+                sigs.push_back(child.elements());
+
+            return combine(std::move(sigs))
+                .map([](std::vector<Elements> const& groups)
+                    {
+                        Elements result;
+                        for (auto const& group : groups)
+                        {
+                            result.insert(result.end(), group.begin(),
+                                    group.end());
+                        }
+
+                        return result;
+                    });
+        }
+
+        ElementsSignal elements_;
+    };
+
+    /** @brief Keys a changing list and builds one value per key.
+     *
+     * The entry into the array domain, and the only operator that mints
+     * identity from a key. `delegate` receives the item's value as a signal and
+     * is invoked once per key per context. It is not re-invoked when the item's
+     * value changes — the new value arrives through the signal the delegate
+     * already holds — so nothing the delegate built is destroyed by a value
+     * change. That is what preserves the state of what was built.
+     *
+     * Eviction is strict. When a key leaves, its identity is dropped and what
+     * the delegate built for it is destroyed in that same update; a key that
+     * leaves and returns is a new item, exactly as a changed key is.
+     *
+     * `keyFn` and `delegate` are invoked as const functions, and run for every
+     * item on every change and once per key respectively. Keys must be unique
+     * within this call and need not be unique anywhere else.
+     *
+     * @throws std::runtime_error if two items share a key.
+     */
+    template <typename T, typename TKeyFunc, typename TDelegate>
+    auto forEach(AnySignal<std::vector<T>> source, TKeyFunc keyFn,
+            TDelegate delegate)
+    {
+        using Key = std::decay_t<std::invoke_result_t<
+            TKeyFunc const&, T const&>>;
+
+        using U = std::decay_t<std::invoke_result_t<
+            TDelegate const&, AnySignal<T>>>;
+
+        auto shared = AnySignal<std::vector<T>>(source.share());
+        auto keyed = detail::shareKeyed(shared, keyFn);
+
+        auto build = [keyed, delegate=std::move(delegate)](Key const& key,
+                T const&)
+            {
+                return delegate(AnySignal<T>(detail::requirePresent(
+                                detail::pick(keyed, key),
+                                "an element of forEach")));
+            };
+
+        return ArraySignal<U>::fromElements(detail::makeArrayOnce(
+                    std::move(shared),
+                    std::move(keyFn),
+                    std::move(build),
+                    [](Key const&)
+                    {
+                        return detail::makeArrayId();
+                    }));
+    }
+
+    /** @overload */
+    template <typename T, typename TKeyFunc, typename TDelegate>
+    auto forEach(std::vector<T> source, TKeyFunc keyFn, TDelegate delegate)
+    {
+        return forEach(AnySignal<std::vector<T>>(constant(std::move(source))),
+                std::move(keyFn), std::move(delegate));
+    }
+
+    /** @brief Concatenates arrays, preserving order and every identity.
+     *
+     * Identities are distinct between arrays by construction, so nothing is
+     * re-keyed. With the empty array as its identity element this is a monoid,
+     * which is the same statement as `{a, {b, c}}` and `{a, b, c}` exporting
+     * the same list.
+     */
+    template <typename T>
+    ArraySignal<T> concat(std::vector<ArraySignal<T>> arrays)
+    {
+        return ArraySignal<T>(std::move(arrays));
+    }
+
+    /** @overload */
+    template <typename T, typename... Ts>
+    ArraySignal<T> concat(ArraySignal<T> first, Ts&&... rest)
+    {
+        return concat(std::vector<ArraySignal<T>>{ std::move(first),
+                ArraySignal<T>(std::forward<Ts>(rest))... });
+    }
+
+    /** @brief Fans the elements in, in membership order.
+     *
+     * The only exit from the array domain, and the reason the element type has
+     * to be a signal: an array of anything else has nothing to fan in. Map it
+     * to something joinable first.
+     *
+     * Each element's signal is shared once per identity, so a membership change
+     * rebuilds the fan-in without disturbing what a surviving element's signal
+     * has accumulated.
+     */
+    template <typename X>
+    AnySignal<std::vector<X>> join(ArraySignal<AnySignal<X>> array)
+    {
+        auto shared = array.map([](AnySignal<X> const& sig)
+            {
+                return AnySignal<X>(sig.share());
+            });
+
+        return shared.elements()
+            .map([](detail::ArrayElements<AnySignal<X>> const& elements)
+                {
+                    std::vector<AnySignal<X>> sigs;
+                    sigs.reserve(elements.size());
+                    for (auto const& element : elements)
+                        sigs.push_back(element.value);
+
+                    return AnySignal<std::vector<X>>(combine(std::move(sigs)));
+                })
+            .join();
+    }
+} // namespace bq::signal

--- a/src/bq/include/bq/signal/detail/pick.h
+++ b/src/bq/include/bq/signal/detail/pick.h
@@ -90,7 +90,7 @@ namespace bq::signal::detail
      * lookup instead of a scan, so that following every element of a source
      * costs O(n log n) per update rather than O(n^2).
      *
-     * `keyFn` is invoked as a const function, so it cannot carry state. It
+     * 'keyFn' is invoked as a const function, so it cannot carry state. It
      * lives in the description, which every context over that description
      * shares, so state in it would be state outside any context.
      *

--- a/src/bq/include/bq/signal/join.h
+++ b/src/bq/include/bq/signal/join.h
@@ -14,20 +14,44 @@ namespace bq::signal
     template <typename T, typename... Ts>
     class Signal;
 
+    template <typename... Ts>
+    class AnySignal;
+
     namespace detail
     {
         template <typename T>
-        auto toSignal(T&& t)
+        struct IsSignalObject : std::false_type
         {
-            return constant(std::forward<T>(t));
-        }
+        };
 
         template <typename T, typename... Ts>
-        Signal<T, Ts...> toSignal(Signal<T, Ts...> sig)
+        struct IsSignalObject<Signal<T, Ts...>> : std::true_type
         {
-            return sig;
+        };
+
+        template <typename... Ts>
+        struct IsSignalObject<AnySignal<Ts...>> : std::true_type
+        {
+        };
+
+        /** @brief Passes a signal through, and makes a constant of anything
+         * else.
+         *
+         * One function rather than an overload pair because an AnySignal is
+         * derived from Signal: a forwarding overload is an exact match for it
+         * where the Signal one is only a derived-to-base conversion, so the
+         * overload set would wrap a type-erased signal in a constant instead
+         * of passing it through.
+         */
+        template <typename T>
+        auto toSignal(T&& t)
+        {
+            if constexpr (IsSignalObject<std::decay_t<T>>::value)
+                return std::forward<T>(t);
+            else
+                return constant(std::forward<T>(t));
         }
-    } // anonymous namespace
+    } // namespace detail
 
     template <typename T>
     class Join
@@ -117,7 +141,8 @@ namespace bq::signal
     {
         if constexpr (btl::any(IsSignal<Ts>::value...))
         {
-            return wrap(Join<T>(std::move(sig).unwrap()));
+            using Storage = typename Signal<T, Ts...>::StorageType;
+            return wrap(Join<Storage>(std::move(sig).unwrap()));
         }
         else
         {

--- a/src/bq/include/bq/signal/join.h
+++ b/src/bq/include/bq/signal/join.h
@@ -112,6 +112,11 @@ namespace bq::signal
             if (r.didChange)
             {
                 data.innerSignal = makeInnerSignal(sig_.evaluate(context, data.outerData));
+
+                // The new data is built before the old is released, so a
+                // shared node the two inner signals have in common finds its
+                // context data still alive and keeps it. Releasing first would
+                // silently restart everything such a node holds.
                 data.innerData = data.innerSignal.initialize(context, frame);
             }
 

--- a/src/bq/include/bq/signal/signal.h
+++ b/src/bq/include/bq/signal/signal.h
@@ -214,7 +214,7 @@ namespace bq::signal
 
         auto join() const
         {
-            return wrap(Join<TStorage>(Super::sig_));
+            return wrap(Join<StorageType>(Super::sig_));
         }
 
         Signal clone() const

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -17,6 +17,7 @@ libbqdep = declare_dependency(
   )
 
 bqtest = executable('bqtest',
+  'test/arraysignaltest.cpp',
   'test/datacontexttest.cpp',
   'test/picktest.cpp',
   'test/signaltest.cpp',

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -24,8 +24,7 @@ static_assert(checkSignal<detail::ArrayJoin<int>>());
 static_assert(checkSignal<detail::ArrayOnce<
         int,
         std::function<int(int const&)>,
-        std::function<int(int const&, int const&)>,
-        std::function<detail::ArrayId(int const&)>
+        std::function<int(int const&, int const&)>
         >>());
 
 namespace
@@ -207,6 +206,62 @@ TEST(arraySignal, anEvictedValueIsDestroyed)
     EXPECT_FALSE((*built)[1].expired());
 }
 
+// An element that arrives during an update is initialized against that frame,
+// so it must not also be updated in it. A fold makes the difference visible:
+// advanced twice, an arrival's first value would be counted twice.
+TEST(arraySignal, anArrivingElementIsAdvancedOnce)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+
+    // Deliberately without the check() that itemValue() adds: it would hide a
+    // repeated advance rather than report it.
+    auto sums = join(forEach(
+                AnySignal<std::vector<Item>>(input.signal),
+                itemKey,
+                [](AnySignal<Item> item)
+                {
+                    return AnySignal<int>(item
+                            .map([](Item const& i)
+                                {
+                                    return i.value;
+                                })
+                            .withPrevious([](int sum, int value)
+                                {
+                                    return sum + value;
+                                },
+                                0));
+                }));
+
+    auto c = makeSignalContext(sums);
+
+    EXPECT_EQ(std::vector<int>{ 1 }, c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 5 } }));
+    c.update(FrameInfo(1, {}));
+
+    // b folded its first value exactly once, as a did at construction; were it
+    // advanced twice it would read 10. a reads 2 because a pick reports a
+    // change whenever any element of its source changes, so a's fold takes its
+    // unchanged value again — which is why itemValue() deduplicates and why
+    // this test does not.
+    EXPECT_EQ((std::vector<int>{ 2, 5 }), c.evaluate<0>().get<0>());
+}
+
+// Concatenating an array with itself makes one identity appear twice. The exit
+// reports it rather than quietly giving the two occurrences one set of state
+// and advancing it twice a frame.
+TEST(arraySignal, joinRejectsAnArrayConcatenatedWithItself)
+{
+    ArraySignal<AnySignal<int>> array = AnySignal<int>(constant(1));
+
+    expectThrowsContaining(
+            [&]
+            {
+                makeSignalContext(join(concat(array, array)));
+            },
+            "appears twice");
+}
+
 // A duplicate that appears only after the array has been running fails the
 // same way as one that was there from the start.
 TEST(arraySignal, forEachThrowsOnADuplicateKeyIntroducedByAnUpdate)
@@ -225,7 +280,11 @@ TEST(arraySignal, forEachThrowsOnADuplicateKeyIntroducedByAnUpdate)
 
     input.handle.set(items({ { "a", 1 }, { "a", 2 } }));
 
-    expectThrowsContaining([&] { c.update(FrameInfo(1, {})); },
+    expectThrowsContaining(
+            [&]
+            {
+                c.update(FrameInfo(1, {}));
+            },
             "duplicate key");
 }
 
@@ -495,7 +554,11 @@ TEST(arraySignal, forEachThrowsOnADuplicateKey)
                     return itemValue(std::move(item));
                 }));
 
-    expectThrowsContaining([&] { makeSignalContext(description); },
+    expectThrowsContaining(
+            [&]
+            {
+                makeSignalContext(description);
+            },
             "duplicate key");
 }
 

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -17,7 +17,9 @@
 
 using namespace bq::signal;
 
-static_assert(checkSignal<detail::ArraySingle<int>>());
+static_assert(checkSignal<detail::ArrayConstant<int>>());
+
+static_assert(checkSignal<detail::ArrayJoin<int>>());
 
 static_assert(checkSignal<detail::ArrayOnce<
         int,
@@ -143,14 +145,13 @@ TEST(arraySignal, arraysDerivedFromOneSourceConcatenate)
     EXPECT_EQ((std::vector<int>{ 2, 4, 3, 6 }), c.evaluate<0>().get<0>());
 }
 
-// A single item whose value varies is a rebuild of that element: it takes a
-// new identity, so what was built from it is built again.
-TEST(arraySignal, aVaryingSingleItemRebuildsItself)
+// Every constructor is constant, so a constructed element's value never
+// changes and nothing built from it is ever built twice.
+TEST(arraySignal, aConstructedElementIsBuiltOnce)
 {
-    auto input = makeInput(1);
     auto builds = std::make_shared<int>(0);
 
-    ArraySignal<int> array = { 0, AnySignal<int>(input.signal) };
+    ArraySignal<int> array = { 1, 2 };
 
     auto doubled = array.map([builds](int value)
         {
@@ -158,26 +159,16 @@ TEST(arraySignal, aVaryingSingleItemRebuildsItself)
             return 2 * value;
         });
 
-    auto c = makeSignalContext(values(doubled));
+    auto c = makeSignalContext(values(doubled), values(doubled));
 
-    EXPECT_EQ((std::vector<int>{ 0, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 2, 4 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 2, 4 }), c.evaluate<1>().get<0>());
     EXPECT_EQ(2, *builds);
 
-    input.handle.set(5);
     c.update(FrameInfo(1, {}));
 
-    EXPECT_EQ((std::vector<int>{ 0, 10 }), c.evaluate<0>().get<0>());
-
-    // Only the element that changed was rebuilt.
-    EXPECT_EQ(3, *builds);
-
-    // A repeat of the value it already holds is not a change, so it is not a
-    // rebuild either.
-    input.handle.set(5);
-    c.update(FrameInfo(2, {}));
-
-    EXPECT_EQ((std::vector<int>{ 0, 10 }), c.evaluate<0>().get<0>());
-    EXPECT_EQ(3, *builds);
+    EXPECT_EQ((std::vector<int>{ 2, 4 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
 }
 
 // An evicted value is destroyed rather than retained against the key coming

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -17,8 +17,6 @@
 
 using namespace bq::signal;
 
-static_assert(checkSignal<detail::ArrayConstant<int>>());
-
 static_assert(checkSignal<detail::ArrayJoin<int>>());
 
 static_assert(checkSignal<detail::ArrayOnce<
@@ -179,7 +177,7 @@ TEST(arraySignal, anEvictedValueIsDestroyed)
     auto built = std::make_shared<std::vector<std::weak_ptr<int>>>();
 
     auto c = makeSignalContext(join(forEach(
-                    AnySignal<std::vector<Item>>(input.signal),
+                    input.signal,
                     itemKey,
                     [built](AnySignal<Item> item)
                     {
@@ -216,7 +214,7 @@ TEST(arraySignal, anArrivingElementIsAdvancedOnce)
     // Deliberately without the check() that itemValue() adds: it would hide a
     // repeated advance rather than report it.
     auto sums = join(forEach(
-                AnySignal<std::vector<Item>>(input.signal),
+                input.signal,
                 itemKey,
                 [](AnySignal<Item> item)
                 {
@@ -269,7 +267,7 @@ TEST(arraySignal, forEachThrowsOnADuplicateKeyIntroducedByAnUpdate)
     auto input = makeInput(items({ { "a", 1 } }));
 
     auto c = makeSignalContext(join(forEach(
-                    AnySignal<std::vector<Item>>(input.signal),
+                    input.signal,
                     itemKey,
                     [](AnySignal<Item> item)
                     {
@@ -294,7 +292,7 @@ TEST(arraySignal, forEachBuildsOncePerKeyAndFollowsMembership)
     auto builds = std::make_shared<int>(0);
 
     auto c = makeSignalContext(join(forEach(
-                    AnySignal<std::vector<Item>>(input.signal),
+                    input.signal,
                     itemKey,
                     [builds](AnySignal<Item> item)
                     {
@@ -337,7 +335,7 @@ TEST(arraySignal, aReturningKeyIsANewIdentity)
     auto builds = std::make_shared<int>(0);
 
     auto c = makeSignalContext(join(forEach(
-                    AnySignal<std::vector<Item>>(input.signal),
+                    input.signal,
                     itemKey,
                     [builds](AnySignal<Item> item)
                     {
@@ -365,7 +363,7 @@ TEST(arraySignal, shrinksAndGrowsAgain)
     auto builds = std::make_shared<int>(0);
 
     auto c = makeSignalContext(join(forEach(
-                    AnySignal<std::vector<Item>>(input.signal),
+                    input.signal,
                     itemKey,
                     [builds](AnySignal<Item> item)
                     {
@@ -396,7 +394,7 @@ TEST(arraySignal, aSurvivingElementKeepsItsStateThroughItsNeighbours)
     auto input = makeInput(items({ { "a", 1 }, { "b", 10 } }));
 
     auto sums = join(forEach(
-                AnySignal<std::vector<Item>>(input.signal),
+                input.signal,
                 itemKey,
                 [](AnySignal<Item> item)
                 {
@@ -440,7 +438,7 @@ TEST(arraySignal, twoContextsAreIndependent)
     auto builds = std::make_shared<int>(0);
 
     auto description = join(forEach(
-                AnySignal<std::vector<Item>>(input.signal),
+                input.signal,
                 itemKey,
                 [builds](AnySignal<Item> item)
                 {
@@ -481,7 +479,7 @@ TEST(arraySignal, twoConsumersInOneContextShareTheBuiltValues)
     auto builds = std::make_shared<int>(0);
 
     auto array = forEach(
-            AnySignal<std::vector<Item>>(input.signal),
+            input.signal,
             itemKey,
             [builds](AnySignal<Item> item)
             {
@@ -510,7 +508,7 @@ TEST(arraySignal, mapRunsOncePerIdentity)
     auto maps = std::make_shared<int>(0);
 
     auto array = forEach(
-            AnySignal<std::vector<Item>>(input.signal),
+            input.signal,
             itemKey,
             [](AnySignal<Item> item)
             {
@@ -547,7 +545,7 @@ TEST(arraySignal, forEachThrowsOnADuplicateKey)
     auto input = makeInput(items({ { "a", 1 }, { "a", 2 } }));
 
     auto description = join(forEach(
-                AnySignal<std::vector<Item>>(input.signal),
+                input.signal,
                 itemKey,
                 [](AnySignal<Item> item)
                 {
@@ -560,6 +558,56 @@ TEST(arraySignal, forEachThrowsOnADuplicateKey)
                 makeSignalContext(description);
             },
             "duplicate key");
+}
+
+// The source is any signal of a vector, not only a type-erased one. Every other
+// test here passes the concrete signal makeInput() returns; this one pins the
+// erased form, which binds by deduction to the Signal base AnySignal derives
+// from and is subtle enough to be worth compiling on purpose.
+TEST(arraySignal, forEachTakesAnErasedSignal)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    AnySignal<std::vector<Item>> erased = input.signal;
+
+    auto c = makeSignalContext(join(forEach(erased, itemKey,
+                    [](AnySignal<Item> item)
+                    {
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "b", 20 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>{ 20 }, c.evaluate<0>().get<0>());
+}
+
+// A signal that is neither an input nor erased: the source only has to carry a
+// std::vector<T>.
+TEST(arraySignal, forEachTakesADerivedSignal)
+{
+    auto input = makeInput(2);
+
+    auto source = input.signal.map([](int count)
+        {
+            std::vector<Item> result;
+            for (int i = 0; i < count; ++i)
+                result.push_back({ std::to_string(i), i });
+
+            return result;
+        });
+
+    auto c = makeSignalContext(join(forEach(source, itemKey,
+                    [](AnySignal<Item> item)
+                    {
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 0, 1 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(3);
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 0, 1, 2 }), c.evaluate<0>().get<0>());
 }
 
 TEST(arraySignal, forEachTakesAPlainVector)

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -1,0 +1,433 @@
+#include <bq/signal/arraysignal.h>
+
+#include <bq/signal/constant.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+#include <bq/signal/signaltraits.h>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace bq::signal;
+
+static_assert(checkSignal<detail::ArraySingle<int>>());
+
+static_assert(checkSignal<detail::ArrayOnce<
+        int,
+        std::function<int(int const&)>,
+        std::function<int(int const&, int const&)>,
+        std::function<detail::ArrayId(int const&)>
+        >>());
+
+namespace
+{
+    struct Item
+    {
+        std::string key;
+        int value;
+    };
+
+    auto itemKey = [](Item const& item)
+    {
+        return item.key;
+    };
+
+    std::vector<Item> items(std::initializer_list<Item> list)
+    {
+        return std::vector<Item>(list);
+    }
+
+    // The value of every element, in membership order. Fanning an array of
+    // plain values in means giving each one a signal first, which is what a
+    // map once per identity does.
+    template <typename T>
+    AnySignal<std::vector<T>> values(ArraySignal<T> array)
+    {
+        return join(array.map([](T const& value)
+                    {
+                        return AnySignal<T>(constant(value));
+                    }));
+    }
+
+    // The item's value, deduplicated so that a fold over it advances only when
+    // this element moved. A pick reports a change whenever any element of its
+    // source changes, so without this every element's fold would follow every
+    // other element's.
+    AnySignal<int> itemValue(AnySignal<Item> item)
+    {
+        return item.map([](Item const& i)
+                {
+                    return i.value;
+                })
+            .check();
+    }
+
+    template <typename TFunc>
+    void expectThrowsContaining(TFunc&& func, std::string const& text)
+    {
+        try
+        {
+            func();
+        }
+        catch (std::runtime_error const& e)
+        {
+            EXPECT_NE(std::string::npos, std::string(e.what()).find(text))
+                << e.what();
+            return;
+        }
+
+        ADD_FAILURE() << "expected a std::runtime_error containing " << text;
+    }
+} // namespace
+
+TEST(arraySignal, bracedConstructionNestsAndFlattens)
+{
+    ArraySignal<int> array = { 1, 2, { 3, { 4, 5 } } };
+
+    auto c = makeSignalContext(values(array));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3, 4, 5 }), c.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, emptyAndSingletonBracesMeanWhatTheySay)
+{
+    ArraySignal<int> empty = {};
+    ArraySignal<int> singleton = { 7 };
+    ArraySignal<int> item = 7;
+
+    auto c = makeSignalContext(values(empty), values(singleton),
+            values(item));
+
+    EXPECT_EQ(std::vector<int>(), c.evaluate<0>().get<0>());
+    EXPECT_EQ(std::vector<int>{ 7 }, c.evaluate<1>().get<0>());
+    EXPECT_EQ(std::vector<int>{ 7 }, c.evaluate<2>().get<0>());
+}
+
+TEST(arraySignal, concatJoinsArraysInOrder)
+{
+    ArraySignal<int> first = { 1, 2 };
+    ArraySignal<int> second = { 3 };
+
+    auto c = makeSignalContext(values(concat(first, second, ArraySignal<int>(4))));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3, 4 }), c.evaluate<0>().get<0>());
+}
+
+// A single item whose value varies is a rebuild of that element: it takes a
+// new identity, so what was built from it is built again.
+TEST(arraySignal, aVaryingSingleItemRebuildsItself)
+{
+    auto input = makeInput(1);
+    auto builds = std::make_shared<int>(0);
+
+    ArraySignal<int> array = { 0, AnySignal<int>(input.signal) };
+
+    auto doubled = array.map([builds](int value)
+        {
+            ++*builds;
+            return 2 * value;
+        });
+
+    auto c = makeSignalContext(values(doubled));
+
+    EXPECT_EQ((std::vector<int>{ 0, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    input.handle.set(5);
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<int>{ 0, 10 }), c.evaluate<0>().get<0>());
+
+    // Only the element that changed was rebuilt.
+    EXPECT_EQ(3, *builds);
+}
+
+TEST(arraySignal, forEachBuildsOncePerKeyAndFollowsMembership)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto c = makeSignalContext(join(forEach(
+                    AnySignal<std::vector<Item>>(input.signal),
+                    itemKey,
+                    [builds](AnySignal<Item> item)
+                    {
+                        ++*builds;
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    // A value change reaches the built signal without rebuilding anything.
+    input.handle.set(items({ { "a", 10 }, { "b", 2 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 10, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    // A reorder keeps both identities and reports the new order.
+    input.handle.set(items({ { "b", 2 }, { "a", 10 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 2, 10 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    // Only the new key is built.
+    input.handle.set(items({ { "b", 2 }, { "c", 3 }, { "a", 10 } }));
+    c.update(FrameInfo(3, {}));
+    EXPECT_EQ((std::vector<int>{ 2, 3, 10 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+
+    input.handle.set(items({ { "c", 3 } }));
+    c.update(FrameInfo(4, {}));
+    EXPECT_EQ(std::vector<int>{ 3 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+}
+
+// A key that leaves is retired, so the same key coming back is a new item
+// rather than a resumption of the old one.
+TEST(arraySignal, aReturningKeyIsANewIdentity)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto c = makeSignalContext(join(forEach(
+                    AnySignal<std::vector<Item>>(input.signal),
+                    itemKey,
+                    [builds](AnySignal<Item> item)
+                    {
+                        ++*builds;
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ(1, *builds);
+
+    input.handle.set(items({}));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>(), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 2 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ(std::vector<int>{ 2 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+}
+
+// Removing the last element and adding one back is the sequence in which a
+// departed key's pick has to be dropped rather than asked for a stale value.
+TEST(arraySignal, shrinksAndGrowsAgain)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto c = makeSignalContext(join(forEach(
+                    AnySignal<std::vector<Item>>(input.signal),
+                    itemKey,
+                    [builds](AnySignal<Item> item)
+                    {
+                        ++*builds;
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    input.handle.set(items({ { "a", 1 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>{ 1 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    input.handle.set(items({ { "a", 1 }, { "c", 3 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 1, 3 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+}
+
+// A neighbour arriving or leaving must not disturb what a surviving element
+// has accumulated. The fold below is the sharp end of it: it is state inside
+// the built value, and it would silently restart from the current value if the
+// element's signal were rebuilt rather than kept.
+TEST(arraySignal, aSurvivingElementKeepsItsStateThroughItsNeighbours)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 10 } }));
+
+    auto sums = join(forEach(
+                AnySignal<std::vector<Item>>(input.signal),
+                itemKey,
+                [](AnySignal<Item> item)
+                {
+                    return AnySignal<int>(itemValue(std::move(item))
+                            .withPrevious([](int sum, int value)
+                                {
+                                    return sum + value;
+                                },
+                                0));
+                }));
+
+    auto c = makeSignalContext(sums);
+
+    EXPECT_EQ((std::vector<int>{ 1, 10 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 5 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 1, 15 }), c.evaluate<0>().get<0>());
+
+    // An unrelated insertion, ahead of b so that its position moves too.
+    input.handle.set(items({ { "c", 100 }, { "a", 1 }, { "b", 5 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 100, 1, 15 }), c.evaluate<0>().get<0>());
+
+    // An unrelated removal.
+    input.handle.set(items({ { "c", 100 }, { "b", 5 } }));
+    c.update(FrameInfo(3, {}));
+    EXPECT_EQ((std::vector<int>{ 100, 15 }), c.evaluate<0>().get<0>());
+
+    // And b's own fold is still running from where it was.
+    input.handle.set(items({ { "c", 100 }, { "b", 1 } }));
+    c.update(FrameInfo(4, {}));
+    EXPECT_EQ((std::vector<int>{ 100, 16 }), c.evaluate<0>().get<0>());
+}
+
+// Two contexts over one description share nothing: they build their own values
+// and their membership can be driven apart.
+TEST(arraySignal, twoContextsAreIndependent)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto description = join(forEach(
+                AnySignal<std::vector<Item>>(input.signal),
+                itemKey,
+                [builds](AnySignal<Item> item)
+                {
+                    ++*builds;
+                    return itemValue(std::move(item));
+                }));
+
+    auto first = makeSignalContext(description);
+    auto second = makeSignalContext(description);
+
+    // Once per identity per context, not once per identity.
+    EXPECT_EQ(2, *builds);
+    EXPECT_EQ(std::vector<int>{ 1 }, first.evaluate<0>().get<0>());
+    EXPECT_EQ(std::vector<int>{ 1 }, second.evaluate<0>().get<0>());
+
+    // Only the first context sees the new member.
+    input.handle.set(items({ { "a", 1 }, { "b", 2 } }));
+    first.update(FrameInfo(1, {}));
+    EXPECT_EQ(3, *builds);
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), first.evaluate<0>().get<0>());
+    EXPECT_EQ(std::vector<int>{ 1 }, second.evaluate<0>().get<0>());
+
+    // And only the second sees it leave again, while the first stays where it
+    // was left.
+    input.handle.set(items({ { "a", 3 } }));
+    second.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>{ 3 }, second.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), first.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+}
+
+// Two consumers of one array within one context share its built values, which
+// is what lets a container branch without duplicating what identity exists to
+// protect.
+TEST(arraySignal, twoConsumersInOneContextShareTheBuiltValues)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto array = forEach(
+            AnySignal<std::vector<Item>>(input.signal),
+            itemKey,
+            [builds](AnySignal<Item> item)
+            {
+                ++*builds;
+                return itemValue(std::move(item));
+            });
+
+    auto c = makeSignalContext(join(array), join(array));
+
+    EXPECT_EQ(2, *builds);
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<1>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 2 }, { "c", 3 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(3, *builds);
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 1, 2, 3 }), c.evaluate<1>().get<0>());
+}
+
+// map runs when an identity appears, not when its value changes.
+TEST(arraySignal, mapRunsOncePerIdentity)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto maps = std::make_shared<int>(0);
+
+    auto array = forEach(
+            AnySignal<std::vector<Item>>(input.signal),
+            itemKey,
+            [](AnySignal<Item> item)
+            {
+                return itemValue(std::move(item));
+            });
+
+    auto c = makeSignalContext(join(array.map([maps](AnySignal<int> const& sig)
+                    {
+                        ++*maps;
+                        return AnySignal<int>(sig.map([](int value)
+                                    {
+                                        return 10 * value;
+                                    }));
+                    })));
+
+    EXPECT_EQ(std::vector<int>{ 10 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, *maps);
+
+    input.handle.set(items({ { "a", 2 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>{ 20 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, *maps);
+
+    input.handle.set(items({ { "a", 2 }, { "b", 3 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 20, 30 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *maps);
+}
+
+// A duplicate key almost always means the caller keyed on the wrong thing, so
+// it fails rather than silently dropping or duplicating an element.
+TEST(arraySignal, forEachThrowsOnADuplicateKey)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "a", 2 } }));
+
+    auto description = join(forEach(
+                AnySignal<std::vector<Item>>(input.signal),
+                itemKey,
+                [](AnySignal<Item> item)
+                {
+                    return itemValue(std::move(item));
+                }));
+
+    expectThrowsContaining([&] { makeSignalContext(description); },
+            "duplicate key");
+}
+
+TEST(arraySignal, forEachTakesAPlainVector)
+{
+    auto c = makeSignalContext(join(forEach(
+                    items({ { "a", 1 }, { "b", 2 } }),
+                    itemKey,
+                    [](AnySignal<Item> item)
+                    {
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+}

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -115,9 +115,32 @@ TEST(arraySignal, concatJoinsArraysInOrder)
     ArraySignal<int> first = { 1, 2 };
     ArraySignal<int> second = { 3 };
 
-    auto c = makeSignalContext(values(concat(first, second, ArraySignal<int>(4))));
+    auto c = makeSignalContext(values(concat(first, second,
+                    ArraySignal<int>(4))));
 
     EXPECT_EQ((std::vector<int>{ 1, 2, 3, 4 }), c.evaluate<0>().get<0>());
+}
+
+// Every operator that builds an array mints its own identities, so two arrays
+// derived from one source can be concatenated. Without that, the branch a
+// container makes and then rejoins would collide with itself.
+TEST(arraySignal, arraysDerivedFromOneSourceConcatenate)
+{
+    ArraySignal<int> array = { 1, 2 };
+
+    auto doubled = array.map([](int value)
+        {
+            return 2 * value;
+        });
+
+    auto tripled = array.map([](int value)
+        {
+            return 3 * value;
+        });
+
+    auto c = makeSignalContext(values(concat(doubled, tripled)));
+
+    EXPECT_EQ((std::vector<int>{ 2, 4, 3, 6 }), c.evaluate<0>().get<0>());
 }
 
 // A single item whose value varies is a rebuild of that element: it takes a
@@ -147,6 +170,72 @@ TEST(arraySignal, aVaryingSingleItemRebuildsItself)
 
     // Only the element that changed was rebuilt.
     EXPECT_EQ(3, *builds);
+
+    // A repeat of the value it already holds is not a change, so it is not a
+    // rebuild either.
+    input.handle.set(5);
+    c.update(FrameInfo(2, {}));
+
+    EXPECT_EQ((std::vector<int>{ 0, 10 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+}
+
+// An evicted value is destroyed rather than retained against the key coming
+// back. Counting builds cannot see the difference; holding a weak reference to
+// what was built can.
+TEST(arraySignal, anEvictedValueIsDestroyed)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto built = std::make_shared<std::vector<std::weak_ptr<int>>>();
+
+    auto c = makeSignalContext(join(forEach(
+                    AnySignal<std::vector<Item>>(input.signal),
+                    itemKey,
+                    [built](AnySignal<Item> item)
+                    {
+                        // Lives exactly as long as what the delegate returns.
+                        auto marker = std::make_shared<int>(0);
+                        built->push_back(marker);
+
+                        return AnySignal<int>(item.map(
+                                    [marker](Item const& i)
+                                    {
+                                        return i.value;
+                                    }));
+                    })));
+
+    ASSERT_EQ(2u, built->size());
+    EXPECT_FALSE((*built)[0].expired());
+    EXPECT_FALSE((*built)[1].expired());
+
+    input.handle.set(items({ { "b", 2 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(std::vector<int>{ 2 }, c.evaluate<0>().get<0>());
+    EXPECT_TRUE((*built)[0].expired());
+    EXPECT_FALSE((*built)[1].expired());
+}
+
+// A duplicate that appears only after the array has been running fails the
+// same way as one that was there from the start.
+TEST(arraySignal, forEachThrowsOnADuplicateKeyIntroducedByAnUpdate)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+
+    auto c = makeSignalContext(join(forEach(
+                    AnySignal<std::vector<Item>>(input.signal),
+                    itemKey,
+                    [](AnySignal<Item> item)
+                    {
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ(std::vector<int>{ 1 }, c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "a", 2 } }));
+
+    expectThrowsContaining([&] { c.update(FrameInfo(1, {})); },
+            "duplicate key");
 }
 
 TEST(arraySignal, forEachBuildsOncePerKeyAndFollowsMembership)

--- a/src/bq/test/signaltest.cpp
+++ b/src/bq/test/signaltest.cpp
@@ -319,6 +319,57 @@ TEST(signal, join)
     EXPECT_EQ("?", r2.get<2>());
 }
 
+// A signal whose value is type-erased is still a signal, so joining it must
+// follow it rather than treat it as an ordinary value and hold it constant.
+TEST(signal, joinFollowsATypeErasedInnerSignal)
+{
+    auto inner = makeInput(10);
+    auto selector = makeInput(true);
+
+    auto outer = selector.signal.map([inner](bool)
+        {
+            return AnySignal<int>(inner.signal);
+        });
+
+    auto c = makeSignalContext(outer.join());
+
+    EXPECT_EQ(10, c.evaluate<0>().get<0>());
+
+    inner.handle.set(20);
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(20, c.evaluate<0>().get<0>());
+}
+
+// The same, on an outer signal that is itself type-erased: the storage type of
+// an AnySignal is not its (void) template argument, so joining one has to name
+// the storage rather than the argument.
+TEST(signal, joinWorksOnATypeErasedOuterSignal)
+{
+    auto first = makeInput(1);
+    auto second = makeInput(2);
+    auto selector = makeInput(true);
+
+    AnySignal<AnySignal<int>> outer = selector.signal.map(
+            [first, second](bool useFirst)
+            {
+                return useFirst ? AnySignal<int>(first.signal)
+                    : AnySignal<int>(second.signal);
+            });
+
+    auto c = makeSignalContext(outer.join());
+
+    EXPECT_EQ(1, c.evaluate<0>().get<0>());
+
+    selector.handle.set(false);
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(2, c.evaluate<0>().get<0>());
+
+    second.handle.set(22);
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ(22, c.evaluate<0>().get<0>());
+}
+
 TEST(signal, combine)
 {
     std::vector<int> v1 = { 10, 20, 30, 40, 50 };


### PR DESCRIPTION
Step 2 of `docs/design/arraysignal.md`, stacked on #111 (steps 0-1). Draft: it
will not merge until the layouts have been reworked on top of it.

### The two `join` fixes, first and on their own

Both are pre-existing and independent of this design; the superseded spike on
#100 found them.

- `Signal::join()` instantiated `Join<TStorage>`, but `TStorage` is `void` for an
  `AnySignal`; the storage type is named by `StorageType`. The free `join()`
  deduced the same `void` from a derived-to-base match.
- `detail::toSignal` was an overload pair, and an `AnySignal` is derived from
  `Signal`, so the forwarding overload was the better match and a type-erased
  inner signal was wrapped in a `constant` instead of joined. It is now one
  function with an `if constexpr`.

### The node

All durable state is in the `SignalContext`. One node, `detail::ArrayOnce`,
holds the key-to-id map and the built values in its `DataType`; the array holds
that node behind a `.share()`, so `SharedControl` keys the data by a `UniqueId`
carried in the description. `forEach` and `map` are that node with different
key, build and id functions.

`forEach` hands its delegate the pick construction from step 1, and honours what
`requirePresent` documents: a pick is built when its key appears and dropped in
the update that observes it leave.

### Acceptance tests

The three the design names, all in `src/bq/test/arraysignaltest.cpp`:

- shrink then grow;
- remove while a sibling still reads — a fold inside a surviving element's `U`
  is untouched by a neighbour's insertion or removal;
- two contexts, diverging membership.

The sibling test is load-bearing: dropping `join`'s per-identity `.share()`
reproduces the spike's failure exactly.

### Where the design did not survive contact

Recorded under *Corrections from the implementation* in the design doc, with the
surrounding prose amended:

- there is no separate `SharedArraySignal` — sharing is intrinsic, so copies of a
  description share within one context and only a second context is independent;
- `join` must share each element's signal once per identity, or a membership
  change restarts every survivor's per-instantiation state;
- a value change at fixed identity is a **new** identity, not a new value at the
  old one, otherwise `map` silently ignores it — which is `dynamicBox`'s bug;
- the doc's two accounts of `map` were incompatible; the once-per-identity one is
  what is built;
- no per-array id space is needed.

Out of scope and untouched: `scatter` (step 3), the `AnySignal<ArraySignal<T>>`
reactive subtree, and everything in `bqui`.

Verified with MSVC and clang-cl, Debug, whole project: builds clean and all four
test suites pass.