### PR TITLE
Add scatter, the array fan-out

### DIFF
--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,7 +1,7 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, implementation started.** Steps 0 to 2 of
-> *Implementation order* have landed; `scatter` and everything in `bqui` is
+> **Status: revised design, implementation started.** Steps 0 to 3 of
+> *Implementation order* have landed; everything in `bqui` is
 > outstanding, and this document has been amended to describe what was built
 > rather than what was first proposed. The earlier implementation on PR #100 is
 > a **superseded spike**:
@@ -15,7 +15,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `8677be3` (2026-07-21).*
+*Last verified against `86ddac5` (2026-07-21).*
 
 ## The problem
 
@@ -457,9 +457,17 @@ container expressible: fan the children's hints in, compute over all of them, an
 give each child its share back.
 
 The aggregate is positional and must be aligned with the current membership; the
-node checks its size on every update. That is the single remaining runtime
-contract, and it lives in one place instead of being re-asserted at each call
-site.
+node checks its size on every update in which a slice is read. That is the single
+remaining runtime contract, and it lives in one place instead of being re-asserted
+at each call site. What that check does and does not reach is *Alignment is a
+promise, and only its arity is checked* below.
+
+**`scatter` is `forEach`'s node with a different source**, as this document
+predicted, and it needed no new state of its own: the built array is `ArrayOnce`
+keyed by the element's identity, exactly as `map` is, and the slice signal is the
+`pick` construction over a `merge` of the array's own elements with the
+aggregate, keyed by identity and shared. The size check is the map that builds
+that keyed source.
 
 ### `join` — the only exit
 
@@ -862,12 +870,65 @@ concept in the public model; asserting instead would be the same failure with
 less to go on, since `b_ndebug` is off here and an assert takes the process down
 without a message.
 
-### `scatter`'s aggregate must be size-aligned with the current membership
+### Alignment is a promise, and only its arity is checked
 
-Checked in the node on every update. This is the same strength as the spike's
+`scatter`'s aggregate is positional, and the node checks that it has one entry
+per element. This is the same strength as the spike's
 `assert(obbs.size() == builders.size())` (`dynamicbox.h:70`) and the static
 engine's unchecked `obbs.at(index)` contract (`layout.cpp:37-47`), except that it
-is stated once and enforced in one place.
+is stated once and enforced in one place. A size check cannot catch a
+permutation, so it is worth being exact about what is left.
+
+**Through the intended construction, misalignment is unreachable.** When the
+aggregate is derived from the same array — `map` into `join`, then an ordinary
+`map` over the fanned-in vector — both the aggregate and the sequence `scatter`
+zips it against read the array's *one shared* element signal, which is evaluated
+once per pass. Every step between preserves order. So within a pass the two
+orders are the same order, by construction rather than by promise.
+
+Three things break that, and none is caught:
+
+- An aggregate derived from a **different array**, or supplied out of band. The
+  count can match while the entries describe other elements.
+- An **order-changing step** between the fan-in and `scatter` — a sort, or a
+  filter that is padded back to length.
+- An aggregate that describes an **earlier update's membership**, because it is
+  an input the caller pushes separately or because it is routed through a fold.
+  A membership change that keeps the count — one element swapped for another —
+  then hands the arrival its predecessor's slice.
+
+The last is the one a caller reaches by accident, and it is the same failure as
+*Nothing may be position-keyed across updates*, one level up.
+
+**A stronger cheap check was considered and rejected.** The node could require
+that the aggregate reports a change in every update in which the membership
+changed, which catches all three cases above. It also fires on a correct
+program: an aggregate that legitimately does not vary with a same-size
+membership change reports no change, and `stack` — which repeats one obb for
+every child (`stack.cpp:12-25`) — is exactly that. A hard error here takes the
+context down and the caller cannot suppress it, so a check that rejects correct
+code is worse than the hazard it removes. The size check is therefore the
+strongest check available that does not reintroduce keyed aggregates.
+
+**Folding the fan-in into `scatter` is the structural fix, and is not worth it
+yet.** A `scatter` that took a per-element contribution and an aggregate
+function would join internally, so the vector the aggregate function receives
+would be this array's current membership by construction — the third case above
+disappears, and the second becomes local (the function may still permute the
+vector it was just handed, and only its length can be checked). It does not
+remove the positional contract; it moves it one call inward, into the same
+`ObbMap`-shaped function that holds it today.
+
+Against that: a container needs the joined contributions for its **own upward
+size hint** as well as for the fan-out, so an internally-joining `scatter` forces
+a second `join` over the same array. Each exit gives every element its own inner
+data (*Sharing is intrinsic*), so that is a per-frame cost and a duplicated
+per-element instantiation, not a one-off — the kind of cost *Cost: the static
+path is lighter at construction, not at steady state* says is the one that
+counts. It could be avoided by having the operator also return the joined vector,
+at the price of a two-part return. **Recommendation: keep the positional
+aggregate.** Revisit if the layout rework produces a real misalignment, at which
+point the joined-vector-returning form is the shape to reach for.
 
 ### Nothing may be position-keyed across updates
 
@@ -1386,7 +1447,7 @@ Written for a from-scratch implementation. The spike on PR #100 is superseded an
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
 
-Steps 0 to 2 are done; the rest is outstanding.
+Steps 0 to 3 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
    not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
@@ -1412,8 +1473,11 @@ Steps 0 to 2 are done; the rest is outstanding.
    landed first, as their own commit; they are still needed by `Signal::join`
    generally, but the array exit no longer uses it.
 
-3. **`scatter`.** Structurally the same node as `forEach` with a different
-   source; the size-alignment check lives here.
+3. **`scatter`.** *Done.* Structurally the same node as `forEach` with a
+   different source — `ArrayOnce` keyed by identity, with the slice signal built
+   by the same `pick` construction over a keyed zip of the array's elements with
+   the aggregate. The size-alignment check is that zip; what it reaches is
+   *Alignment is a promise, and only its arity is checked*.
 
 4. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
    `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are

--- a/src/bq/AGENTS.md
+++ b/src/bq/AGENTS.md
@@ -60,9 +60,11 @@ copy for a new node's per-context state.
 - Derive/combine: `map` (`bq/signal/map.h`), `merge` (`bq/signal/merge.h`),
   `combine`/`join`/`conditional` (same folder). `constant` (`bq/signal/constant.h`).
 - Lists whose *membership* changes: `ArraySignal<T>`, entered by `forEach` and
-  left by `join`, with `concat` and `ArraySignal::map` between
+  left by `join`, with `concat`, `ArraySignal::map` and `scatter` between
   (`bq/signal/arraysignal.h`), built over `bq/signal/detail/pick.h`. Its design
   record, and the parts still outstanding, are in `docs/design/arraysignal.md`.
+  `scatter`'s aggregate is positional and only its arity is checked; what that
+  does and does not catch is in the design record.
 - Streams: `pipe` (`bq/stream/pipe.h`) → `{handle, stream}`, `handle.push`;
   `iterate` (`bq/stream/iterate.h`) folds a stream into a signal; `collect`.
 

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -5,6 +5,7 @@
 #include "datacontext.h"
 #include "detail/pick.h"
 #include "frameinfo.h"
+#include "merge.h"
 #include "signal.h"
 #include "signalresult.h"
 #include "signaltraits.h"
@@ -14,11 +15,14 @@
 #include <btl/copywrapper.h>
 #include <btl/uniqueid.h>
 
+#include <cstddef>
 #include <functional>
 #include <initializer_list>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -137,6 +141,11 @@ namespace bq::signal
         constexpr bool isForEachCallable =
             std::is_invocable_v<TKeyFunc const&, T const&>
             && std::is_invocable_v<TDelegate const&, AnySignal<T>>;
+
+        /** @brief Whether scatter() accepts this delegate. */
+        template <typename TFunc, typename T, typename W>
+        constexpr bool isScatterCallable =
+            std::is_invocable_v<TFunc const&, T const&, AnySignal<W>>;
 
         /** @brief Builds one value per key and keeps it while the key is
          * there.
@@ -293,6 +302,43 @@ namespace bq::signal
         {
             return constant(ArrayElements<T> {
                     { makeArrayId(), std::move(value) } });
+        }
+
+        /** @brief Attaches a positional aggregate to the identities it is
+         * aligned with, so that each entry can be followed by identity rather
+         * than by position.
+         *
+         * @throws std::runtime_error if the aggregate does not have one entry
+         *         per element, or if one identity appears twice — which the
+         *         node keyed by identity rejects first, so reaching it here
+         *         means that order has changed.
+         */
+        template <typename T, typename W>
+        KeyedElements<ArrayId, W> keyByIdentity(
+                ArrayElements<T> const& elements,
+                std::vector<W> const& aggregate)
+        {
+            if (elements.size() != aggregate.size())
+            {
+                throw std::runtime_error("scatter: aggregate size "
+                        + std::to_string(aggregate.size())
+                        + " does not match membership size "
+                        + std::to_string(elements.size()));
+            }
+
+            auto keyed = std::make_shared<std::map<ArrayId, W>>();
+
+            for (std::size_t i = 0; i != elements.size(); ++i)
+            {
+                if (!keyed->insert({ elements[i].id, aggregate[i] }).second)
+                {
+                    throw std::runtime_error("scatter: one identity appears "
+                            "twice, which means an array was concatenated "
+                            "with itself");
+                }
+            }
+
+            return KeyedElements<ArrayId, W>(std::move(keyed));
         }
 
         /** @brief Fans an array of signals in, keeping each identity's state.
@@ -738,6 +784,71 @@ namespace bq::signal
     {
         return concat(std::vector<ArraySignal<T>>{ std::move(first),
                 ArraySignal<T>(std::forward<Ts>(rest))... });
+    }
+
+    /** @brief Hands every element its own slice of an aggregate computed over
+     * all of them.
+     *
+     * The fan-out half of a container: fan the elements in with join(), compute
+     * over all of them at once, and give each one its share back. `func` is
+     * invoked once per identity per context, as map()'s function is, and
+     * receives the element's value together with a signal carrying that
+     * element's entry of every later aggregate. Nothing is rebuilt when the
+     * aggregate changes.
+     *
+     * Every element's slice signal reports a change whenever **any** element's
+     * slice does, because they all read one shared source. Suppress the repeats
+     * with `.check()` where they matter — anything that folds over a slice
+     * accumulates its unchanged value again without it.
+     *
+     * `aggregate` is **positional**: its entry `i` belongs to element `i` of
+     * the current membership. The correspondence is a promise the caller makes
+     * and only its arity is checked, on every update in which a slice is read.
+     * An aggregate of the right length in the wrong order is accepted and each
+     * element is handed the wrong slice, so derive it from this same array by
+     * order-preserving steps — map() into join(), then an ordinary map() over
+     * the fanned-in vector — and do not route it through anything that sorts,
+     * filters, or holds a value from an earlier update.
+     *
+     * @throws std::runtime_error if the aggregate does not have one entry per
+     *         element. Thrown when a slice is read, so it surfaces from
+     *         whatever consumes the result rather than from scatter() itself.
+     */
+    template <typename T, typename TStorage, typename W, typename TFunc,
+             typename = std::enable_if_t<
+                 detail::isScatterCallable<TFunc, T, W>
+                 >>
+    auto scatter(ArraySignal<T> array,
+            Signal<TStorage, std::vector<W>> aggregate, TFunc func)
+    {
+        using Element = detail::ArrayElement<T>;
+        using Elements = detail::ArrayElements<T>;
+
+        using U = std::decay_t<std::invoke_result_t<
+            TFunc const&, T const&, AnySignal<W>>>;
+
+        auto slices = merge(array.elements(), std::move(aggregate))
+            .map([](Elements const& elements, std::vector<W> const& entries)
+                {
+                    return detail::keyByIdentity(elements, entries);
+                })
+            .share();
+
+        auto build = [slices, func=std::move(func)](detail::ArrayId const& id,
+                Element const& element)
+            {
+                return func(element.value, AnySignal<W>(detail::requirePresent(
+                                detail::pick(slices, id),
+                                "a slice of scatter")));
+            };
+
+        return ArraySignal<U>::fromElements(detail::makeArrayOnce(
+                    array.elements(),
+                    [](Element const& element)
+                    {
+                        return element.id;
+                    },
+                    std::move(build)));
     }
 
     /** @brief Fans the elements in, in membership order.

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -790,7 +790,7 @@ namespace bq::signal
      * all of them.
      *
      * The fan-out half of a container: fan the elements in with join(), compute
-     * over all of them at once, and give each one its share back. `func` is
+     * over all of them at once, and give each one its share back. 'func' is
      * invoked once per identity per context, as map()'s function is, and
      * receives the element's value together with a signal carrying that
      * element's entry of every later aggregate. Nothing is rebuilt when the
@@ -798,10 +798,10 @@ namespace bq::signal
      *
      * Every element's slice signal reports a change whenever **any** element's
      * slice does, because they all read one shared source. Suppress the repeats
-     * with `.check()` where they matter — anything that folds over a slice
+     * with '.check()' where they matter — anything that folds over a slice
      * accumulates its unchanged value again without it.
      *
-     * `aggregate` is **positional**: its entry `i` belongs to element `i` of
+     * 'aggregate' is **positional**: its entry 'i' belongs to element 'i' of
      * the current membership. The correspondence is a promise the caller makes
      * and only its arity is checked, on every update in which a slice is read.
      * An aggregate of the right length in the wrong order is accepted and each

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -3,12 +3,14 @@
 #include <bq/signal/constant.h>
 #include <bq/signal/frameinfo.h>
 #include <bq/signal/input.h>
+#include <bq/signal/merge.h>
 #include <bq/signal/signal.h>
 #include <bq/signal/signalcontext.h>
 #include <bq/signal/signaltraits.h>
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -66,6 +68,27 @@ namespace
                     return i.value;
                 })
             .check();
+    }
+
+    // The array a keyed source builds, whose elements carry the item's value.
+    auto keyedItems = [](AnySignal<std::vector<Item>> source)
+    {
+        return forEach(std::move(source), itemKey,
+                [](AnySignal<Item> item)
+                {
+                    return itemValue(std::move(item));
+                });
+    };
+
+    // Both halves of what a scattered element was handed, so that a wrong
+    // slice reads as a wrong number rather than as a missing one.
+    AnySignal<int> valueWithSlice(AnySignal<int> const& value,
+            AnySignal<int> slice)
+    {
+        return merge(value, std::move(slice)).map([](int v, int s)
+                {
+                    return 100 * v + s;
+                });
     }
 
     template <typename TFunc>
@@ -621,4 +644,394 @@ TEST(arraySignal, forEachTakesAPlainVector)
                     })));
 
     EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+}
+
+TEST(arraySignal, scatterGivesEachElementItsOwnSlice)
+{
+    ArraySignal<int> array = { 1, 2, 3 };
+
+    auto scattered = scatter(array,
+            constant(std::vector<int>{ 10, 20, 30 }),
+            [](int value, AnySignal<int> slice)
+            {
+                return AnySignal<int>(slice.map([value](int s)
+                            {
+                                return 100 * value + s;
+                            }));
+            });
+
+    auto c = makeSignalContext(join(scattered));
+
+    EXPECT_EQ((std::vector<int>{ 110, 220, 330 }),
+            c.evaluate<0>().get<0>());
+}
+
+// The construction scatter exists for: fan the elements in, compute over all
+// of them, and hand each one its share back. A positional aggregate makes an
+// element's own slice the slice of wherever it now is, so what this pins is
+// that a reorder recomputes it: were the map kept from the previous update,
+// a would still read the 1 it was given at position 0. The identity keying is
+// what the elementwise aggregate below tests.
+TEST(arraySignal, scatterFollowsMembershipThroughAReorder)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+
+    auto array = keyedItems(input.signal);
+
+    auto aggregate = join(array).map([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            for (std::size_t i = 0; i != values.size(); ++i)
+                result.push_back(10 * static_cast<int>(i) + values[i]);
+
+            return result;
+        });
+
+    auto c = makeSignalContext(join(scatter(array, aggregate,
+                    &valueWithSlice)));
+
+    EXPECT_EQ((std::vector<int>{ 101, 212 }), c.evaluate<0>().get<0>());
+
+    // Both identities survive, and each one's slice is the one computed for
+    // where it is now: a is at position 1 and reads 11, not the 1 it read at
+    // position 0.
+    input.handle.set(items({ { "b", 2 }, { "a", 1 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<int>{ 202, 111 }), c.evaluate<0>().get<0>());
+}
+
+// The property the design exists for, at the fan-out: a neighbour arriving and
+// leaving must not disturb what a survivor has accumulated from its slices.
+// The aggregate here is elementwise, so a survivor's slice is stable while its
+// position is not.
+TEST(arraySignal, aScatteredSurvivorKeepsItsSliceAndItsState)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 10 } }));
+
+    auto array = keyedItems(input.signal);
+
+    auto aggregate = join(array).map([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            for (int value : values)
+                result.push_back(10 * value);
+
+            return result;
+        });
+
+    auto sums = join(scatter(array, aggregate,
+                [](AnySignal<int> const&, AnySignal<int> slice)
+                {
+                    return AnySignal<int>(std::move(slice)
+                            .check()
+                            .withPrevious([](int sum, int value)
+                                {
+                                    return sum + value;
+                                },
+                                0));
+                }));
+
+    auto c = makeSignalContext(sums);
+
+    EXPECT_EQ((std::vector<int>{ 10, 100 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 5 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 10, 150 }), c.evaluate<0>().get<0>());
+
+    // An arrival ahead of both, which moves every position but no slice.
+    input.handle.set(items({ { "c", 100 }, { "a", 1 }, { "b", 5 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 1000, 10, 150 }), c.evaluate<0>().get<0>());
+
+    // And a departure.
+    input.handle.set(items({ { "c", 100 }, { "b", 5 } }));
+    c.update(FrameInfo(3, {}));
+    EXPECT_EQ((std::vector<int>{ 1000, 150 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "c", 100 }, { "b", 1 } }));
+    c.update(FrameInfo(4, {}));
+    EXPECT_EQ((std::vector<int>{ 1000, 160 }), c.evaluate<0>().get<0>());
+}
+
+// The delegate runs when an identity appears, as map's function does: neither a
+// changed item value nor a changed aggregate rebuilds anything.
+TEST(arraySignal, scatterRunsItsDelegateOncePerIdentity)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto offset = makeInput(std::vector<int>{ 1000 });
+    auto builds = std::make_shared<int>(0);
+
+    auto array = keyedItems(input.signal);
+
+    auto c = makeSignalContext(join(scatter(array, offset.signal,
+                    [builds](AnySignal<int> const& value,
+                        AnySignal<int> slice)
+                    {
+                        ++*builds;
+                        return valueWithSlice(value, std::move(slice));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 1100 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, *builds);
+
+    input.handle.set(items({ { "a", 2 } }));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 1200 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, *builds);
+
+    offset.handle.set(std::vector<int>{ 2000 });
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 2200 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, *builds);
+
+    input.handle.set(items({ { "a", 2 }, { "b", 3 } }));
+    offset.handle.set(std::vector<int>{ 2000, 3000 });
+    c.update(FrameInfo(3, {}));
+    EXPECT_EQ((std::vector<int>{ 2200, 3300 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+}
+
+// Emptying the array releases the last pick on the slice signal, whose
+// per-context data may then expire. A later arrival has to find or rebuild it
+// rather than fail, which is the same sequence forEach's shrink and grow
+// covers one level down.
+TEST(arraySignal, scatterShrinksToEmptyAndGrowsAgain)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+
+    auto array = keyedItems(input.signal);
+
+    auto aggregate = join(array).map([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            for (int value : values)
+                result.push_back(10 * value);
+
+            return result;
+        });
+
+    auto c = makeSignalContext(join(scatter(array, aggregate,
+                    &valueWithSlice)));
+
+    EXPECT_EQ((std::vector<int>{ 110 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({}));
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(std::vector<int>(), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "b", 2 } }));
+    c.update(FrameInfo(2, {}));
+    EXPECT_EQ((std::vector<int>{ 220 }), c.evaluate<0>().get<0>());
+}
+
+// scatter() itself only describes the graph, so the mismatch surfaces from
+// whatever reads a slice — here, realizing the description.
+TEST(arraySignal, scatterRejectsAnAggregateOfTheWrongSize)
+{
+    ArraySignal<int> array = { 1, 2 };
+
+    auto scattered = scatter(array, constant(std::vector<int>{ 10 }),
+            [](int, AnySignal<int> slice)
+            {
+                return slice;
+            });
+
+    expectThrowsContaining(
+            [&]
+            {
+                makeSignalContext(join(scattered));
+            },
+            "aggregate size 1 does not match membership size 2");
+}
+
+// A mismatch that appears only after the array has been running fails the same
+// way as one that was there from the start: the membership grew away from the
+// aggregate, and the update that observes it reports it.
+TEST(arraySignal, scatterRejectsAMembershipThatGrewPastItsAggregate)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+
+    auto c = makeSignalContext(join(scatter(keyedItems(input.signal),
+                    constant(std::vector<int>{ 10 }), &valueWithSlice)));
+
+    EXPECT_EQ((std::vector<int>{ 110 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 2 } }));
+
+    expectThrowsContaining(
+            [&]
+            {
+                c.update(FrameInfo(1, {}));
+            },
+            "aggregate size 1 does not match membership size 2");
+}
+
+// The other direction, which is the one a container reaches when a child is
+// removed: every surviving element is still there to read a slice, and the
+// aggregate now has one too many.
+TEST(arraySignal, scatterRejectsAMembershipThatShrankBelowItsAggregate)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+
+    auto c = makeSignalContext(join(scatter(keyedItems(input.signal),
+                    constant(std::vector<int>{ 10, 20 }), &valueWithSlice)));
+
+    EXPECT_EQ((std::vector<int>{ 110, 220 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 } }));
+
+    expectThrowsContaining(
+            [&]
+            {
+                c.update(FrameInfo(1, {}));
+            },
+            "aggregate size 2 does not match membership size 1");
+}
+
+// Two consumers of one scattered array in one context share its built values,
+// as two consumers of any array do.
+TEST(arraySignal, twoConsumersOfOneScatterShareItsBuiltValues)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto array = keyedItems(input.signal);
+
+    auto aggregate = join(array).map([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            for (int value : values)
+                result.push_back(10 * value);
+
+            return result;
+        });
+
+    auto scattered = scatter(array, aggregate,
+            [builds](AnySignal<int> const& value, AnySignal<int> slice)
+            {
+                ++*builds;
+                return valueWithSlice(value, std::move(slice));
+            });
+
+    auto c = makeSignalContext(join(scattered), join(scattered));
+
+    EXPECT_EQ(1, *builds);
+    EXPECT_EQ((std::vector<int>{ 110 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 110 }), c.evaluate<1>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 2 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(2, *builds);
+    EXPECT_EQ((std::vector<int>{ 110, 220 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 110, 220 }), c.evaluate<1>().get<0>());
+}
+
+// A self-concatenated array gives one identity two slices. The node keyed by
+// identity is what reports it, before any slice is read.
+TEST(arraySignal, scatterRejectsAnArrayConcatenatedWithItself)
+{
+    ArraySignal<int> array = { 1 };
+
+    expectThrowsContaining(
+            [&]
+            {
+                makeSignalContext(join(scatter(concat(array, array),
+                                constant(std::vector<int>{ 10, 20 }),
+                                [](int, AnySignal<int> slice)
+                                {
+                                    return slice;
+                                })));
+            },
+            "duplicate key");
+}
+
+TEST(arraySignal, twoContextsOverOneScatterAreIndependent)
+{
+    auto input = makeInput(items({ { "a", 1 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto array = keyedItems(input.signal);
+
+    auto aggregate = join(array).map([](std::vector<int> const& values)
+        {
+            std::vector<int> result;
+            for (int value : values)
+                result.push_back(10 * value);
+
+            return result;
+        });
+
+    auto description = join(scatter(array, aggregate,
+                [builds](AnySignal<int> const& value, AnySignal<int> slice)
+                {
+                    ++*builds;
+                    return valueWithSlice(value, std::move(slice));
+                }));
+
+    auto first = makeSignalContext(description);
+    auto second = makeSignalContext(description);
+
+    EXPECT_EQ(2, *builds);
+    EXPECT_EQ((std::vector<int>{ 110 }), first.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 110 }), second.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "b", 2 } }));
+    first.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(3, *builds);
+    EXPECT_EQ((std::vector<int>{ 110, 220 }), first.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 110 }), second.evaluate<0>().get<0>());
+}
+
+// The residual hazard, pinned rather than described: the aggregate is
+// positional, so one of the right length in the wrong order passes the only
+// check there is and every element is handed a neighbour's slice. Aligned, the
+// elements below would read 110, 220 and 330.
+TEST(arraySignal, scatterCannotDetectAMisorderedAggregate)
+{
+    ArraySignal<int> array = { 1, 2, 3 };
+
+    auto aggregate = values(array).map([](std::vector<int> const& v)
+        {
+            std::vector<int> result(v.rbegin(), v.rend());
+            for (int& value : result)
+                value *= 10;
+
+            return result;
+        });
+
+    auto c = makeSignalContext(join(scatter(array, aggregate,
+                    [](int value, AnySignal<int> slice)
+                    {
+                        return AnySignal<int>(slice.map([value](int s)
+                                    {
+                                        return 100 * value + s;
+                                    }));
+                    })));
+
+    EXPECT_EQ((std::vector<int>{ 130, 220, 310 }),
+            c.evaluate<0>().get<0>());
+}
+
+// The same hazard reached the way a caller is most likely to reach it: an
+// aggregate that is not derived from this array, and so still describes the
+// membership of an earlier update. The count matches, so nothing is reported
+// and c is handed the slice computed for b.
+TEST(arraySignal, scatterCannotDetectAnAggregateFromAnEarlierMembership)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto aggregate = makeInput(std::vector<int>{ 10, 20 });
+
+    auto c = makeSignalContext(join(scatter(keyedItems(input.signal),
+                    aggregate.signal, &valueWithSlice)));
+
+    EXPECT_EQ((std::vector<int>{ 110, 220 }), c.evaluate<0>().get<0>());
+
+    input.handle.set(items({ { "a", 1 }, { "c", 3 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<int>{ 110, 320 }), c.evaluate<0>().get<0>());
 }


### PR DESCRIPTION
Step 3 of `docs/design/arraysignal.md`, and the last `bq` piece before the layout
rework. Stacked on #112 (`arraysignal-node`); review that first.

`scatter(array, aggregate, f)` hands every element its own slice of an aggregate
computed over all of them, invoking `f` once per identity with the element's
value and a signal carrying that element's entry of every later aggregate.

It needed no new machinery, exactly as the design record predicted. The built
array is `detail::ArrayOnce` keyed by the element's identity — the same node
`ArraySignal::map` uses — and the slice signal is the `pick` construction from
`detail/pick.h` over a `merge` of the array's own elements with the aggregate,
keyed by identity and shared. So a slice follows its element rather than its
position, and nothing is rebuilt when the aggregate changes.

## The alignment question

The aggregate is positional and only its arity is checked, and a size check
cannot catch a permutation. What that leaves is now stated in the design record
under *Alignment is a promise, and only its arity is checked*, and pinned by
tests rather than left as prose:

- **Through the intended construction, misalignment is unreachable.** When the
  aggregate is derived from the same array — `map` into `join`, then a plain
  `map` over the fanned-in vector — the aggregate and the element sequence it is
  zipped against both read the array's one shared element signal in one pass,
  and every step between preserves order. The orders are the same order by
  construction.
- It becomes reachable when the aggregate comes from a **different array**, is
  routed through something that **reorders**, or describes an **earlier
  update's membership**. The last two have a test each, asserting the
  wrong-but-defined result.
- **A stronger cheap check was considered and rejected.** Requiring the
  aggregate to report a change whenever the membership changed catches all
  three, and also fires on a correct program: an aggregate that repeats one
  entry per child — `stack` — does not change when one child is swapped for
  another. A hard error the caller cannot suppress is worse than the hazard.
- **Folding the fan-in into `scatter` is the structural fix and is not
  recommended yet.** It would remove the wrong-generation class but not the
  permutation one, and a container needs the joined contributions for its own
  upward size hint too, so an internally-joining `scatter` forces a second
  `join` — a per-frame cost and a duplicated per-element instantiation. The
  trade-off is recorded; the escape hatch is an operator that also returns the
  joined vector.

## Tests

Twelve, in `arraysignaltest.cpp`: a survivor keeping its slice and its fold
across a neighbour's arrival and departure, membership through a reorder,
shrink-to-empty and grow, both directions of a size mismatch, self-concatenation,
two contexts, two consumers in one context, the delegate running once per
identity, and the two hazards above.

Verified with clang-cl and MSVC (debug): 84/84 `bq` tests, and the full
clang-cl build and test suite green.