### PR TITLE
Reimplement layout() over the array operators

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
 # Conventions & gotchas
 
-*Last verified against `8677be3` (2026-07-21).*
+*Last verified against `30c2979` (2026-07-21).*
 
 Idioms and traps that are not obvious from reading a single file. Know these
 before editing the corresponding area.
@@ -103,6 +103,21 @@ methods (`&&`). Inside such a method, `*this` is an **lvalue**, so calling
 another `&&`-qualified overload on it requires `std::move(*this)`. Forgetting
 this is a latent bug (see above): `return foo(...)` may need to be
 `return std::move(*this).foo(...)`.
+
+## A signal consumed twice duplicates everything behind it
+
+Consuming a signal from two places without a `.share()` between them
+instantiates and evaluates the whole chain behind it **once per consumer, per
+pass**. Treat that as a defect rather than a style preference: the values still
+agree, so nothing fails — the work is simply done twice, and anything stateful
+in the chain exists twice.
+
+Nothing catches it but reading the code. Signals were once **move-only**, with
+an explicit `.clone()` to opt into copying, precisely so a second consumer could
+not appear by accident; copying was enabled later because move-only was too
+painful to write against. The surviving `.clone()` methods, and the habit of
+passing signals into widget-building functions as parameters rather than
+capturing them, are residue of that era.
 
 ## `merge()` has no zero-argument form
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -112,12 +112,10 @@ pass**. Treat that as a defect rather than a style preference: the values still
 agree, so nothing fails — the work is simply done twice, and anything stateful
 in the chain exists twice.
 
-Nothing catches it but reading the code. Signals were once **move-only**, with
-an explicit `.clone()` to opt into copying, precisely so a second consumer could
-not appear by accident; copying was enabled later because move-only was too
-painful to write against. The surviving `.clone()` methods, and the habit of
-passing signals into widget-building functions as parameters rather than
-capturing them, are residue of that era.
+Nothing catches it but reading the code — signals are freely copyable, so the
+compiler is no help. The surviving `.clone()` methods, and the habit of passing
+signals into widget-building functions as parameters rather than capturing them,
+are residue of an earlier move-only design (see `docs/decisions.md`).
 
 ## `merge()` has no zero-argument form
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -117,6 +117,17 @@ lets the unit tests cover drawing at all. The alternative — compiling ase's
 whole headless *platform*, which is worth having on its own terms and is a
 separate concern; drawing does not need it.
 
+## Signals are copyable, not move-only
+
+`bq::signal` is freely copyable. It was once **move-only**, with an explicit
+`.clone()` to opt into copying, so a second consumer of a signal could not
+appear by accident.
+
+**Why the change:** move-only was too painful to write against. The cost is that
+accidental duplication of a signal chain (see `docs/conventions.md`) no longer
+fails to compile — only review catches it. The surviving `.clone()` methods and
+the parameter-passing habit are residue of the move-only era.
+
 ## bqui's type-erased classes use no `extern template`
 
 `Widget`, `Element`, `WidgetModifier`, `ElementModifier` and `BuilderModifier`

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1013,8 +1013,8 @@ without a message.
 `scatter`'s aggregate is positional, and the node checks that it has one entry
 per element. This is the same strength as the spike's
 `assert(obbs.size() == builders.size())` (`dynamicbox.h:70`) and the static
-engine's unchecked `obbs.at(index)` contract (`layout.cpp:37-47`), except that it
-is stated once and enforced in one place. A size check cannot catch a
+engine's unchecked `obbs.at(index)` contract, which step 5 replaced, except
+that it is stated once and enforced in one place. A size check cannot catch a
 permutation, so it is worth being exact about what is left.
 
 **Through the intended construction, misalignment is unreachable.** When the
@@ -1142,64 +1142,78 @@ its own; needing one was an artefact of the round trip this revision removed. Th
 abstraction was not invented for this design either: it was already sitting in
 the static engine's signature, un-named and un-reused.
 
-`layout()`'s implementation completes the picture: it fans in with
-`bq::signal::combine` over the children's hints (`layout.cpp:21-26`), computes
-once (`layout.cpp:31`), and fans out per child (`layout.cpp:34-55`). That is
-`join`, a plain map, and `scatter` — hand-written for the static case.
+`layout()`'s implementation completed the picture: it fanned in with
+`bq::signal::combine` over the children's hints, computed once, and fanned out
+per child on a captured index. That is `join`, a plain map, and `scatter` —
+hand-written for the static case, and step 5 replaced it with the operators
+themselves.
 
-### The static engine expresses nothing the dynamic one cannot — the tuple path is dead
+### The static engine expresses nothing the dynamic one cannot — the tuple path was dead
 
-There is one thing the static engine could in principle do that a homogeneous
+There was one thing the static engine could in principle do that a homogeneous
 `ArraySignal<T>` cannot: hold children of **heterogeneous types** in a
 `std::tuple`, keeping each child's concrete type through the layout. `box.h`
-contains the machinery for it:
+carried the machinery for it — `accumulateSizeHintsTuple`, returning
+`AccumulateSizeHint<dir, std::tuple<Ts...>>`, and `MapObbs<dir>`, a struct whose
+`operator()` was templated on the hint container and flattened it with
+`btl::forEach`.
 
-- `accumulateSizeHintsTuple` (`box.h:116-121`), returning
-  `AccumulateSizeHint<dir, std::tuple<Ts...>>`.
-- `MapObbs<dir>` (`box.h:163-202`), a struct whose `operator()` is templated on
-  the hint container and flattens it with `btl::forEach`.
+**Both were dead code**, and step 5 deleted them. A repo-wide search for either
+name over all `.h`, `.hpp` and `.cpp` files returned only their own definitions
+and nothing else in the tree. `box()` uses the vector forms
+(`accumulateSizeHints<dir>` and `&mapObbs<dir>`); so do `stack` and
+`uniformGrid`.
 
-**Both are dead code.** A repo-wide search for either name over all `.h`, `.hpp`
-and `.cpp` files returns only their own definitions — `box.h:117` and `box.h:164`
-— and nothing else in the tree. `box()` uses the vector forms
-(`accumulateSizeHints<dir>` and `&mapObbs<dir>`, `box.h:238`); so do `stack`
-(`stack.cpp:25`) and `uniformGrid` (`uniformgrid.cpp:82-86`).
+So the only capability the static path had over a unified engine was one **no
+caller used**. That removed the last reason to keep two implementations.
 
-So the only capability the static path has over a unified engine is one **no
-caller uses**. That removes the last reason to keep two implementations.
-
-### Cost: the static path is lighter at construction, not at steady state
+### Cost: the static path is lighter per changed frame, not per idle frame
 
 The fair objection is that a static list should not pay for identity it does not
-need. The honest accounting:
+need. The honest accounting, corrected by step 5 against what was built:
 
 - **Construction.** The unified engine costs one extra node in the graph and N
   key allocations. Once.
-- **Steady state.** For a never-changing membership the fan-in initialises each
+- **An idle frame.** For a never-changing membership the fan-in initialises each
   element once and thereafter does what a plain `combine` does: the reconcile
   branch is only taken when the membership changes, and for a fixed list it never
-  does. `scatter` matches identity once at construction, not per emission. **Per
-  frame, both paths do the same work.**
+  does. Nothing re-evaluates, so **both paths do the same work.**
+- **A frame in which the aggregate changes** — a resize, for a layout. Here the
+  first draft was wrong to say `scatter` matches identity only at construction.
+  The *build* happens once per identity, but the keyed zip that feeds the slices
+  runs on **every emission**: it allocates a `map<ArrayId, W>` of N entries, and
+  each element then reads its slice through two map lookups where the static
+  engine did a `vector::at`. That is O(n log n) with N allocations against the
+  old O(n).
 
-A per-frame cost would be a real argument against unifying. A one-off
-construction cost is not.
+So the cost is real but it is paid on resize rather than per frame, and it is
+bounded by the same N the layout is already walking. A per-idle-frame cost
+would be a real argument against unifying; this one is not, and if a resize-heavy
+profile ever says otherwise the fix is in `keyByIdentity`, not in the framing.
 
 ### Safety: keyed fan-out removes two unchecked arity contracts
 
-The static path fans out with `obbs.at(index)` on a captured index
-(`layout.cpp:37-47`). `at()` throws rather than corrupting, but the contract —
-"the obb vector has one entry per builder, in builder order" — is unchecked at
-the type level and is asserted nowhere. It is the same unchecked contract as
-`dynamicBox`'s `assert(obbs.size() == builders.size())` (`dynamicbox.h:70`),
-written a different way.
+The static path fanned out with `obbs.at(index)` on a captured index. `at()`
+throws rather than corrupting, but the contract — "the obb vector has one entry
+per builder, in builder order" — was unchecked at the type level and asserted
+nowhere. It is the same unchecked contract as `dynamicBox`'s
+`assert(obbs.size() == builders.size())` (`dynamicbox.h:70`), written a
+different way.
 
 Keyed fan-out removes both: `scatter` matches by identity, and checks the
-aggregate's size against the current membership in one place.
+aggregate's size against the current membership in one place. Step 5 took the
+static half; `dynamicBox`'s assert goes with step 6.
+
+The check is stronger than the one it replaced, in a way a caller outside the
+tree can feel: `at()` threw only when the `ObbMap` returned **fewer** obbs than
+children, and silently ignored extra ones, where `scatter` rejects a mismatch in
+either direction. Every `ObbMap` in the tree returns exactly one obb per hint, so
+nothing here changes.
 
 ### The maintenance argument is the strongest one
 
 `dynamicBox` is missing `handleGravity()`. `layout()` applies it to every child
-(`layout.cpp:84-87`); `dynamicBox` does not apply it anywhere. `dynamicBox` also
+before building it; `dynamicBox` does not apply it anywhere. `dynamicBox` also
 has the element-cache correctness bug described under *Rationale*.
 
 Neither is a hard problem. Both exist **because `dynamicBox` is a second
@@ -1259,7 +1273,7 @@ fan-out, hand-rolled — `scatter`.
 ### The missing `handleGravity()` is fixed structurally
 
 `layout()` pipes every child through `modifier::handleGravity()` before building
-it (`layout.cpp:84-87`). `dynamicBox` does not, so a gravity set on a child of an
+it. `dynamicBox` does not, so a gravity set on a child of an
 `hbox`/`vbox` with a dynamic child list is silently ignored.
 
 Unifying fixes this by construction rather than by remembering to add a line.
@@ -1287,10 +1301,10 @@ primitive beyond `join` and `scatter` is needed.
 
 | Apparent difficulty | Where it actually lives |
 | --- | --- |
-| The prefix scan with a running accumulator in `mapObbs`, with the y-axis running backwards (`box.h:213-230`) | A local `float acc` in a loop. No `scan` primitive needed. |
-| `getSizes` computes a container-level aggregate — the three-element `multiplier` — and then redistributes it per child (`box.h:24-52`) | One function that already receives every child's hint at once. That is exactly the shape of a plain map over the joined hints. |
-| A second fan-in round *inside* the hint computation: `AccumulateSizeHint::getHeightForWidth` re-queries every child at its resolved width, zipping via a mutable counter (`box.h:70-90`) | Inside the `SizeHint` value, not in the signal graph. |
-| The lazy, re-entrant `SizeHint` (`AccumulateSizeHint`, `box.h:54-107`; `StackSizeHint`, `stacksizehint.h:8-15`) that the parent may re-query at arbitrary widths | The laziness is **inside the value**. The child hints are captured synchronously when the aggregate is built; re-querying never touches the signal graph. |
+| The prefix scan with a running accumulator in `mapObbs`, with the y-axis running backwards (`box.h`'s `mapObbs`) | A local `float acc` in a loop. No `scan` primitive needed. |
+| `getSizes` computes a container-level aggregate — the three-element `multiplier` — and then redistributes it per child (`box.h`'s `getSizes`) | One function that already receives every child's hint at once. That is exactly the shape of a plain map over the joined hints. |
+| A second fan-in round *inside* the hint computation: `AccumulateSizeHint::getHeightForWidth` re-queries every child at its resolved width, zipping via a mutable counter (`box.h`'s `AccumulateSizeHint`) | Inside the `SizeHint` value, not in the signal graph. |
+| The lazy, re-entrant `SizeHint` (`AccumulateSizeHint` in `box.h`; `StackSizeHint`, `stacksizehint.h:8-15`) that the parent may re-query at arbitrary widths | The laziness is **inside the value**. The child hints are captured synchronously when the aggregate is built; re-querying never touches the signal graph. |
 | `stack` needs zero per-child data downward but all of it upward (`stack.cpp:12-25`) | `join` for the upward direction; an aggregate that repeats the same obb for every child for the downward one. |
 
 Two layouts actively shaped the design:
@@ -1744,7 +1758,7 @@ Written for a from-scratch implementation. The spike on PR #100 is superseded an
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
 
-Steps 0 to 4 are done; the rest is outstanding.
+Steps 0 to 5 are done; step 6 is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
    not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
@@ -1786,10 +1800,21 @@ Steps 0 to 4 are done; the rest is outstanding.
    signal-derived data. The rules it settled stand; `App` no longer exercises
    them. The **layout engine** (steps 5-6) is the consumer that does.
 
-5. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
-   `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are
-   unaffected. Delete the dead heterogeneous tuple path
-   (`accumulateSizeHintsTuple`, `MapObbs`) at the same time.
+5. **Unify `layout()`** over `map`/`scatter`/`join`. *Done.* One behavioural
+   consequence to know, since the step was otherwise behaviour-preserving: a
+   child's build function now runs from `scatter`'s delegate, which is **once
+   per `DataContext`** rather than once per description. Two contexts over one
+   layout therefore build two sets of children, where before they shared one
+   set of built descriptions. That follows from where the array keeps its state
+   and is the more correct of the two, but it is a change. The builders
+   become a constant `ArraySignal<AnyBuilder>`; `map` into `join` is the hint
+   fan-in, the existing `ObbMap` is an ordinary map over the joined hints, and
+   `scatter` hands each child its obb. The `SizeHintMap`/`ObbMap` signatures
+   are unchanged, so `box`, `stack` and `uniformGrid` are untouched, and the
+   dead heterogeneous tuple path went with it. Nothing about the fan-out needed
+   a primitive the operator set did not have, and the aggregate is aligned by
+   construction as *Alignment is a promise* predicted: the hint fan-in and
+   `scatter` read the array's one shared element signal.
 
 6. **Delete `dynamicBox`.** `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
    route to the unified `layout()`. This is where the missing `handleGravity()`
@@ -1797,7 +1822,7 @@ Steps 0 to 4 are done; the rest is outstanding.
    `dataSourceFromCollection` here, porting `src/bqui/test/databindtest.cpp:18`
    and `src/testapp1/adder.cpp:84`.
 
-Steps 0-3 are `bq` only and land before anything in `bqui` changes.
+Steps 0-3 are `bq` only and landed before anything in `bqui` changed.
 
 Step 4 also fixed an `ase` defect it was the first thing to reach: the WGL
 backend never destroyed a window's `HWND`, so closing a window at runtime left a

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -167,6 +167,13 @@ owning `Window`.
   constant (the `if constexpr (sizeof...(Ts) == 0)` branch in `shape/shape.h`).
 - Builder-style template APIs are guarded by an instantiation smoke test
   (`test/shapetest.cpp`) — extend it when adding builder methods.
+- **Known and unfixed: a child's size hint is instantiated twice under every
+  `layout()` container.** The hint fan-in reads each child's `getSizeHint()`,
+  and `handleGravity` reads it again when that child's element is built, so the
+  hint chain is evaluated once per child per pass instead of once. Fixing it
+  means having the builder hand out one shared hint signal rather than a fresh
+  one per call — builder plumbing, not layout — which is why it is recorded here
+  instead of patched at the call site.
 
 For cross-cutting rules (the `Any` convention, include-dir firewall, symbol
 visibility) see `docs/conventions.md`; do not restate them here.

--- a/src/bqui/include/bqui/widget/box.h
+++ b/src/bqui/include/bqui/widget/box.h
@@ -113,13 +113,6 @@ namespace bqui::widget
         return AccumulateSizeHint<dir, std::vector<SizeHint>>{std::move(hints)};
     }
 
-    template <Axis dir, typename... Ts>
-    auto accumulateSizeHintsTuple(std::tuple<Ts...> hints)
-        -> AccumulateSizeHint<dir, std::tuple<Ts...>>
-    {
-        return AccumulateSizeHint<dir, std::tuple<Ts...>>{std::move(hints)};
-    }
-
     template <Axis dir>
     auto combineSizes(ase::Vector2f size,
             std::vector<SizeHint> const& hints)
@@ -159,47 +152,6 @@ namespace bqui::widget
 
         return result;
     }
-
-    template <Axis dir>
-    struct MapObbs
-    {
-        template <typename TSizeHints>
-        auto operator()(ase::Vector2f size, TSizeHints const& hints2) const
-            -> std::vector<avg::Obb>
-        {
-            std::vector<SizeHint> hints;
-            btl::forEach(hints2, [&hints](auto&& hint)
-            {
-                hints.push_back(hint);
-            });
-
-            std::vector<avg::Vector2f> sizes = combineSizes<dir>(size, hints);
-
-            std::vector<avg::Obb> obbs;
-            obbs.reserve(hints.size());
-            float acc = dir == Axis::x ? 0.0f : size[1];
-
-            btl::forEach(std::move(sizes), [&acc, &obbs](auto&& size)
-            {
-                ase::Vector2f offset;
-                if (dir == Axis::x)
-                {
-                    offset = ase::Vector2f(acc, 0.0f);
-                    acc += size[0];
-                }
-                else
-                {
-                    acc -= size[1];
-                    offset = ase::Vector2f(0.0f, acc);
-                }
-
-                obbs.push_back(avg::Transform().translate(offset) *
-                        avg::Obb(size));
-            });
-
-            return obbs;
-        }
-    };
 
     template <Axis dir>
     auto mapObbs(ase::Vector2f size,

--- a/src/bqui/include/bqui/widget/box.h
+++ b/src/bqui/include/bqui/widget/box.h
@@ -33,7 +33,16 @@ namespace bqui::widget
         for (size_t i = 0; i < multiplier.size(); ++i)
         {
             float prev = (i ? combined[i-1] : 0.0f);
-            float m = (size - prev) / (combined[i] - prev);
+            float span = combined[i] - prev;
+
+            // An interval is empty whenever the children ask for no room
+            // across it, which a list of fixed-size children does for two of
+            // the three. How far into an empty interval the size reaches is
+            // then only whether it reaches it at all.
+            float m = span != 0.0f
+                ? (size - prev) / span
+                : (size < prev ? 0.0f : 1.0f);
+
             multiplier[i] = std::max(0.0f, std::min(1.0f, m));
         }
 
@@ -102,7 +111,6 @@ namespace bqui::widget
                 : getLargestHint(xHints);
         }
 
-        //std::vector<SizeHint> const hints_;
         THints const hints_;
     };
 

--- a/src/bqui/include/bqui/widget/box.h
+++ b/src/bqui/include/bqui/widget/box.h
@@ -35,10 +35,8 @@ namespace bqui::widget
             float prev = (i ? combined[i-1] : 0.0f);
             float span = combined[i] - prev;
 
-            // An interval is empty whenever the children ask for no room
-            // across it, which a list of fixed-size children does for two of
-            // the three. How far into an empty interval the size reaches is
-            // then only whether it reaches it at all.
+            // Empty interval (span 0): avoid the divide; the size either
+            // reaches it (1) or it does not (0).
             float m = span != 0.0f
                 ? (size - prev) / span
                 : (size < prev ? 0.0f : 1.0f);

--- a/src/bqui/src/widget/layout.cpp
+++ b/src/bqui/src/widget/layout.cpp
@@ -37,8 +37,9 @@ bq::signal::AnySignal<widget::Instance> buildChild(
         widget::AnyBuilder const& builder,
         bq::signal::AnySignal<avg::Obb> obb)
 {
-    auto transform = obb.map(&avg::Obb::getTransform);
-    auto size = obb.map(&avg::Obb::getSize);
+    auto shared = obb.share();
+    auto transform = shared.map(&avg::Obb::getTransform);
+    auto size = shared.map(&avg::Obb::getSize);
 
     auto placed = builder.clone()
         | modifier::transformBuilder(std::move(transform));

--- a/src/bqui/src/widget/layout.cpp
+++ b/src/bqui/src/widget/layout.cpp
@@ -10,7 +10,7 @@
 
 #include "bqui/provider/providebuildparams.h"
 
-#include <bq/signal/combine.h>
+#include <bq/signal/arraysignal.h>
 
 namespace bqui::widget
 {
@@ -18,58 +18,67 @@ namespace bqui::widget
 namespace
 {
 
+bq::signal::ArraySignal<widget::AnyBuilder> toArray(
+        std::vector<widget::AnyBuilder> builders)
+{
+    std::vector<bq::signal::ArraySignal<widget::AnyBuilder>> children;
+    children.reserve(builders.size());
+
+    for (auto&& builder : builders)
+    {
+        children.push_back(bq::signal::ArraySignal<widget::AnyBuilder>(
+                    std::move(builder)));
+    }
+
+    return bq::signal::ArraySignal<widget::AnyBuilder>(std::move(children));
+}
+
+bq::signal::AnySignal<widget::Instance> buildChild(
+        widget::AnyBuilder const& builder,
+        bq::signal::AnySignal<avg::Obb> obb)
+{
+    auto transform = obb.map(&avg::Obb::getTransform);
+    auto size = obb.map(&avg::Obb::getSize);
+
+    auto placed = builder.clone()
+        | modifier::transformBuilder(std::move(transform));
+
+    return std::move(placed)(std::move(size)).getInstance();
+}
+
 auto layout(SizeHintMap sizeHintMap, ObbMap obbMap,
         std::vector<widget::AnyBuilder> builders)
 {
-    auto hints = btl::fmap(builders, [](auto const& builder)
-            {
-                return builder.getSizeHint();
-            });
+    auto array = toArray(std::move(builders));
 
-    auto hintsSignal = bq::signal::combine(std::move(hints)).share();
+    auto hints = bq::signal::join(array.map(
+                [](widget::AnyBuilder const& builder)
+                {
+                    return builder.getSizeHint();
+                })).share();
 
     auto widget = makeWidgetWithSize(
-            [](auto size, auto obbMap, auto hintsSignal, auto builders)
+            [](auto size, auto obbMap, auto hints, auto array)
             {
-                auto obbs = merge(std::move(size), hintsSignal).map(obbMap).share();
+                auto obbs = merge(std::move(size), std::move(hints))
+                    .map(std::move(obbMap));
 
-                size_t index = 0;
-                auto widgets = btl::fmap(builders, [&index, &obbs](auto&& f)
-                        -> bq::signal::AnySignal<widget::Instance>
-                    {
-                        auto t = obbs.map([index](
-                                    std::vector<avg::Obb> const& obbs)
-                                {
-                                    return obbs.at(index).getTransform();
-                                });
-
-                        auto size = obbs.map([index](
-                                    std::vector<avg::Obb> const& obbs)
-                                {
-                                    return obbs.at(index).getSize();
-                                });
-
-                        auto builder = f.clone()
-                            | modifier::transformBuilder(std::move(t));
-
-                        ++index;
-
-                        return std::move(builder)(std::move(size)).getInstance();
-                    });
+                auto instances = bq::signal::join(bq::signal::scatter(
+                            std::move(array), std::move(obbs), &buildChild));
 
                 return widget::makeWidget()
-                    | modifier::addWidgets(std::move(widgets))
+                    | modifier::addWidgets(std::move(instances))
                     | modifier::setRole("Layout")
                     ;
             }
             ,
             std::move(obbMap),
-            hintsSignal,
-            std::move(builders)
+            hints,
+            std::move(array)
             );
 
     return std::move(widget)
-        | modifier::setSizeHint(hintsSignal.map(std::move(sizeHintMap)))
+        | modifier::setSizeHint(hints.map(std::move(sizeHintMap)))
         ;
 }
 


### PR DESCRIPTION
Step 4 of `docs/design/arraysignal.md`: `bqui`'s static layout engine is
reimplemented over `map`/`scatter`/`join`, keeping the `SizeHintMap` and
`ObbMap` signatures so `box`, `stack` and `uniformGrid` are untouched at
their call sites. Stacked on #114 (`arraysignal-scatter`).

The step was a verification, and the design held: the fan-in, the compute
and the fan-out map onto the operators with nothing added. `layout()`'s body
is now the builders as a constant `ArraySignal<AnyBuilder>`, `map` into
`join` for the hints, the caller's `ObbMap` as an ordinary map over the
joined vector, and `scatter` handing each child its obb. The dead
heterogeneous tuple path - `accumulateSizeHintsTuple` and `MapObbs` - goes
with it; a repo-wide search found no caller of either.

All 24 layout tests stay green, including the two that pin current-but-wrong
behaviour belonging to step 5 (`uniformGridSizeHintIgnoresCellSpans` and
`dynamicBoxDoesNotApplyGravity`). Verified with clang-cl and MSVC.

### Two things the design got slightly wrong, corrected in the record

- **"Per frame, both paths do the same work" was too strong.** The build
  happens once per identity, but the keyed zip feeding `scatter`'s slices
  runs on every emission, so a *resize* costs O(n log n) with n allocations
  where the old fan-out cost O(n). An idle frame is still free.
- **The step is not quite behaviour-neutral.** A child's build function now
  runs from `scatter`'s delegate, which is once per `DataContext` rather than
  once per description. Two contexts over one layout build two sets of
  children. That follows from where the array keeps its state and is the more
  correct of the two, but it is a change.

### Alignment and shared state

The two branches - the hint fan-in and, after the obbs, the element fan-in -
consume one array. Both read `array.elements()`, which is behind a `share()`,
so within a context they see one element sequence in one pass and the
aggregate is aligned with the membership by construction, exactly as
*Alignment is a promise* predicts. The per-branch instantiated-state hazard
is not reachable here: no element signal is joined twice, and with no
`forEach` in this step there is no delegate state to diverge.

`getSizes`' division by an empty interval is guarded rather than left to the
arithmetic. The infinities and the NaN it produced were clamped back to the
same answers, so the result is unchanged for every input a hint can produce.

