### PR TITLE
Give forEach's delegate its key

### DIFF
--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -549,7 +549,9 @@ element's value never changes once built.
 ```
 forEach(AnySignal<std::vector<T>> source,
         keyFn   : T const& -> TKey,
-        delegate: AnySignal<T> -> U)          -> ArraySignal<U>
+        delegate: (AnySignal<T>) -> U
+               or (TKey, AnySignal<T>) -> U)
+                                              -> ArraySignal<U>
 ```
 
 The delegate runs **once per identity, per context**. `U` need not be a signal;
@@ -905,9 +907,12 @@ ordered and comparable — `std::map` is the internal store, chosen for simplici
 over a hash map (no hash requirement on user keys, no `std::hash`
 specialisations to write).
 
-**delegate** is `(AnySignal<T>) -> U`, and that is the **only** form.
-A `(T) -> U` shorthand was considered and deliberately rejected; the *Rationale*
-section is that argument, and it is the most important part of this document.
+**delegate** is `(AnySignal<T>) -> U` or `(TKey, AnySignal<T>) -> U`, and those
+are the **only** forms. A `(T) -> U` shorthand was considered and deliberately
+rejected; the *Rationale* section is that argument, and it is the most important
+part of this document. Which of the two a delegate takes, and why the key is a
+value rather than a signal, is argued under *No index is passed to the delegate
+— but the key is*.
 
 ### Behaviour
 
@@ -939,7 +944,7 @@ section is that argument, and it is the most important part of this document.
   than kept, because it added a concept to the model in exchange for defining
   behaviour after a programming error.
 
-### No index is passed to the delegate
+### No index is passed to the delegate — but the key is
 
 Deliberately. An index is *positional*, and position is exactly what keyed
 identity abandons. A delegate that closes over an index would have to re-run for
@@ -953,6 +958,51 @@ T>>>` before `forEach` sees it. With that comes a warning worth stating loudly:
 > **Key on the item's identity, not the injected index.** Keying on the index
 > makes every key change when the list reorders, which discards every id and
 > rebuilds everything — precisely the failure mode indices were avoiding.
+
+**The key is categorically different, and `forEach` does hand it over.** Read
+the argument above closely: every word of it is about *position*. A key is the
+one thing in this design that a neighbour's arrival cannot change — an element's
+key is what says which element it is, and it is fixed for the identity's whole
+life by construction. So the objection that rules out an index does not reach
+it, and nothing else does either: a delegate closing over its key closes over a
+constant.
+
+The delegate therefore takes either shape, and `forEach` picks by asking which
+one the callable accepts:
+
+```
+(AnySignal<T>) -> U
+(TKey, AnySignal<T>) -> U
+```
+
+Three decisions inside that, none of them free:
+
+- **Key first.** It reads as key-then-value, which is the conventional order for
+  a keyed callback. The retired `dataBind` put it last
+  (`(AnySignal<T> value, size_t id)`), so this is a deliberate break with the
+  one local precedent rather than an oversight — that precedent is a single
+  call site and the order it chose is the unusual one.
+- **By value, not as a signal.** This is the whole point. Handing the key over
+  as an `AnySignal<TKey>` would model a constant as time-varying, and the cost
+  is not theoretical: it is exactly what forced `adder`'s buttons to build their
+  callables through a `map` over the item signal when only the unkeyed form
+  existed.
+- **A generic delegate gets the keyed form.** `[](auto&&...)` satisfies both,
+  and there is no way to ask which one the author meant. The key is strictly
+  more to work with and a delegate that names no parameter for it cannot tell
+  the difference, so preferring the keyed form is the choice that loses nothing.
+
+A delegate matching neither shape is a `static_assert` naming both, not a
+deduction failure inside the node: the rest of `forEach`'s body is discarded by
+an `if constexpr` on the same condition, so nothing downstream of the assert
+fails as well. The call site still sees a function returning `void`, so it is
+one further error rather than none — the node's own instantiation trace, which
+is the unreadable part, is what goes away.
+
+`map` is **not** given the same treatment. Its function is value-level and runs
+inside a node that already knows the identity, but an `ArraySignal`'s identities
+are internal and no key survives `map` — there is nothing to hand over. The
+asymmetry is a consequence of *Identity is internal*, not an inconsistency.
 
 ### Skipping repeats is a property of the data, not a requirement on `T`
 
@@ -1881,14 +1931,14 @@ Three things fell out of doing it:
   is a few lines against `dataBind`'s branch per event kind. Nothing is lost by
   the coarseness: `forEach` keys by the collection's own id, so an item that
   stays put is not rebuilt whatever the event was.
-- **`forEach`'s delegate is not given its key**, and a delegate that needs the
-  item's identity — `adder`'s buttons act on a collection id — must re-derive it
-  from the item signal and produce its callables through a `map`. `dataBind`'s
-  delegate took the id directly, so this is a real ergonomic regression at the
-  one call site that exists. It is *not* the rejected index of *No index is
-  passed to the delegate*: a key is stable identity, which is the thing an index
-  is not. Handing the key to the delegate is a small change to `forEach` and
-  should be decided on its own; it was not made here.
+- **`forEach`'s delegate was not given its key**, so a delegate that needs the
+  item's identity — `adder`'s buttons act on a collection id — had to re-derive
+  it from the item signal and produce its callables through a `map`.
+  `dataBind`'s delegate took the id directly, so this was a real ergonomic
+  regression at the one call site that existed. It was *not* the rejected index
+  of *No index is passed to the delegate*: a key is stable identity, which is
+  the thing an index is not. **Fixed since**, by the keyed delegate form — that
+  section carries the argument, and `adder` is back to capturing its id.
 - **A value change now reaches every item, not one.** `dataBind` pushed a
   changed value through that item's own `InputHandle`. A `pick` is a plain `map`
   over one shared keyed source, so every item's signal reports a change whenever

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -141,13 +141,7 @@ namespace bq::signal
         constexpr bool isForEachKeyFunc =
             std::is_invocable_v<TKeyFunc const&, T const&>;
 
-        /** @brief Whether `TDelegate` is forEach()'s keyed delegate form.
-         *
-         * The key is a prvalue here because that is how it is handed over: a
-         * delegate that keeps it keeps a copy of its own, and one that binds a
-         * reference to it is doing what binding a reference to any parameter
-         * does.
-         */
+        /** @brief Whether `TDelegate` is forEach()'s keyed delegate form. */
         template <typename TDelegate, typename TKey, typename T>
         constexpr bool isKeyedForEachDelegate =
             std::is_invocable_v<TDelegate const&, TKey, AnySignal<T>>;
@@ -157,12 +151,7 @@ namespace bq::signal
         constexpr bool isPlainForEachDelegate =
             std::is_invocable_v<TDelegate const&, AnySignal<T>>;
 
-        /** @brief Invokes a forEach() delegate in whichever form it takes.
-         *
-         * A delegate that accepts both — a generic lambda does — is given
-         * the key. It is strictly more to work with, and one that names no
-         * parameter for it is unaffected.
-         */
+        /** @brief Invokes a forEach() delegate in whichever form it takes. */
         template <typename TDelegate, typename TKey, typename T>
         auto invokeForEachDelegate(TDelegate const& delegate, TKey key,
                 AnySignal<T> value)
@@ -715,10 +704,8 @@ namespace bq::signal
      * (TKey, AnySignal<T>) -> U
      * @endcode
      *
-     * The key comes first, and by value rather than as a signal, because it
-     * cannot change: it is the identity, and a delegate handed it as a signal
-     * would have to map over a constant to reach it. A delegate that accepts
-     * both forms — a generic lambda does — is given the key.
+     * The key comes first, and by value rather than as a signal. A delegate
+     * that accepts both forms — a generic lambda does — is given the key.
      *
      * Eviction is strict. When a key leaves, its identity is dropped and what
      * the delegate built for it is destroyed in that same update; a key that
@@ -757,9 +744,8 @@ namespace bq::signal
         static_assert(isDelegate, "forEach's delegate must be const callable "
                 "as (TKey, AnySignal<T>) or as (AnySignal<T>)");
 
-        // Everything below is discarded when the delegate is neither form, so
-        // that the assert above is not followed by a page of failures from
-        // inside the node. The call still sees a function returning void.
+        // Guarded so a non-delegate stops at the assert, not a page of
+        // node-internal errors.
         if constexpr (isDelegate)
         {
             using U = detail::ForEachResult<TDelegate, Key, T>;

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -129,18 +129,61 @@ namespace bq::signal
             std::is_convertible_v<U, T>
             && !IsArraySignal<std::decay_t<U>>::value;
 
-        /** @brief Whether forEach() accepts this key function and delegate.
+        /** @brief Whether forEach() accepts this key function.
          *
          * Constrained at the call so that a callable of the wrong shape is
          * reported where it was written rather than as a failure deep inside
-         * the node. Only invocability can be constrained, not the results:
-         * those are what the key and the built value are deduced *from*, so
-         * there is nothing to give is_invocable_r to compare against.
+         * the node. Only invocability can be constrained, not the result: that
+         * is what the key is deduced *from*, so there is nothing to give
+         * is_invocable_r to compare against.
          */
-        template <typename TKeyFunc, typename TDelegate, typename T>
-        constexpr bool isForEachCallable =
-            std::is_invocable_v<TKeyFunc const&, T const&>
-            && std::is_invocable_v<TDelegate const&, AnySignal<T>>;
+        template <typename TKeyFunc, typename T>
+        constexpr bool isForEachKeyFunc =
+            std::is_invocable_v<TKeyFunc const&, T const&>;
+
+        /** @brief Whether `TDelegate` is forEach()'s keyed delegate form.
+         *
+         * The key is a prvalue here because that is how it is handed over: a
+         * delegate that keeps it keeps a copy of its own, and one that binds a
+         * reference to it is doing what binding a reference to any parameter
+         * does.
+         */
+        template <typename TDelegate, typename TKey, typename T>
+        constexpr bool isKeyedForEachDelegate =
+            std::is_invocable_v<TDelegate const&, TKey, AnySignal<T>>;
+
+        /** @brief Whether `TDelegate` is forEach()'s plain delegate form. */
+        template <typename TDelegate, typename T>
+        constexpr bool isPlainForEachDelegate =
+            std::is_invocable_v<TDelegate const&, AnySignal<T>>;
+
+        /** @brief Invokes a forEach() delegate in whichever form it takes.
+         *
+         * A delegate that accepts both — a generic lambda does — is given
+         * the key. It is strictly more to work with, and one that names no
+         * parameter for it is unaffected.
+         */
+        template <typename TDelegate, typename TKey, typename T>
+        auto invokeForEachDelegate(TDelegate const& delegate, TKey key,
+                AnySignal<T> value)
+        {
+            if constexpr (isKeyedForEachDelegate<TDelegate, TKey, T>)
+                return delegate(std::move(key), std::move(value));
+            else
+                return delegate(std::move(value));
+        }
+
+        /** @brief What a forEach() delegate builds, in whichever form it
+         * takes.
+         *
+         * Only well formed for a delegate that is one of the two, which is
+         * what forEach() checks before naming it.
+         */
+        template <typename TDelegate, typename TKey, typename T>
+        using ForEachResult = std::decay_t<decltype(invokeForEachDelegate(
+                    std::declval<TDelegate const&>(),
+                    std::declval<TKey>(),
+                    std::declval<AnySignal<T>>()))>;
 
         /** @brief Whether scatter() accepts this delegate. */
         template <typename TFunc, typename T, typename W>
@@ -665,6 +708,18 @@ namespace bq::signal
      * already holds — so nothing the delegate built is destroyed by a value
      * change. That is what preserves the state of what was built.
      *
+     * The delegate takes either form:
+     *
+     * @code
+     * (AnySignal<T>) -> U
+     * (TKey, AnySignal<T>) -> U
+     * @endcode
+     *
+     * The key comes first, and by value rather than as a signal, because it
+     * cannot change: it is the identity, and a delegate handed it as a signal
+     * would have to map over a constant to reach it. A delegate that accepts
+     * both forms — a generic lambda does — is given the key.
+     *
      * Eviction is strict. When a key leaves, its identity is dropped and what
      * the delegate built for it is destroyed in that same update; a key that
      * leaves and returns is a new item, exactly as a changed key is. The
@@ -687,7 +742,7 @@ namespace bq::signal
      */
     template <typename TStorage, typename T, typename TKeyFunc,
              typename TDelegate, typename = std::enable_if_t<
-                 detail::isForEachCallable<TKeyFunc, TDelegate, T>
+                 detail::isForEachKeyFunc<TKeyFunc, T>
                  >>
     auto forEach(Signal<TStorage, std::vector<T>> source, TKeyFunc keyFn,
             TDelegate delegate)
@@ -695,30 +750,43 @@ namespace bq::signal
         using Key = std::decay_t<std::invoke_result_t<
             TKeyFunc const&, T const&>>;
 
-        using U = std::decay_t<std::invoke_result_t<
-            TDelegate const&, AnySignal<T>>>;
+        constexpr bool isDelegate =
+            detail::isKeyedForEachDelegate<TDelegate, Key, T>
+            || detail::isPlainForEachDelegate<TDelegate, T>;
 
-        auto shared = AnySignal<std::vector<T>>(source.share());
-        auto keyed = detail::shareKeyed(shared, keyFn);
+        static_assert(isDelegate, "forEach's delegate must be const callable "
+                "as (TKey, AnySignal<T>) or as (AnySignal<T>)");
 
-        auto build = [keyed, delegate=std::move(delegate)](Key const& key,
-                T const&)
-            {
-                return delegate(AnySignal<T>(detail::requirePresent(
-                                detail::pick(keyed, key),
-                                "an element of forEach")));
-            };
+        // Everything below is discarded when the delegate is neither form, so
+        // that the assert above is not followed by a page of failures from
+        // inside the node. The call still sees a function returning void.
+        if constexpr (isDelegate)
+        {
+            using U = detail::ForEachResult<TDelegate, Key, T>;
 
-        return ArraySignal<U>::fromElements(detail::makeArrayOnce(
-                    std::move(shared),
-                    std::move(keyFn),
-                    std::move(build)));
+            auto shared = AnySignal<std::vector<T>>(source.share());
+            auto keyed = detail::shareKeyed(shared, keyFn);
+
+            auto build = [keyed, delegate=std::move(delegate)](Key const& key,
+                    T const&)
+                {
+                    return detail::invokeForEachDelegate(delegate, key,
+                            AnySignal<T>(detail::requirePresent(
+                                    detail::pick(keyed, key),
+                                    "an element of forEach")));
+                };
+
+            return ArraySignal<U>::fromElements(detail::makeArrayOnce(
+                        std::move(shared),
+                        std::move(keyFn),
+                        std::move(build)));
+        }
     }
 
     /** @overload */
     template <typename T, typename TKeyFunc, typename TDelegate,
              typename = std::enable_if_t<
-                 detail::isForEachCallable<TKeyFunc, TDelegate, T>
+                 detail::isForEachKeyFunc<TKeyFunc, T>
                  >>
     auto forEach(std::vector<T> source, TKeyFunc keyFn, TDelegate delegate)
     {

--- a/src/bq/test/arraysignaltest.cpp
+++ b/src/bq/test/arraysignaltest.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using namespace bq::signal;
@@ -107,7 +108,36 @@ namespace
 
         ADD_FAILURE() << "expected a std::runtime_error containing " << text;
     }
+
+    using KeyedDelegate = std::function<AnySignal<int>(std::string,
+            AnySignal<Item>)>;
+    using KeyedByRefDelegate = std::function<AnySignal<int>(
+            std::string const&, AnySignal<Item>)>;
+    using KeyedByMutableRefDelegate = std::function<AnySignal<int>(
+            std::string&, AnySignal<Item>)>;
+    using PlainDelegate = std::function<AnySignal<int>(AnySignal<Item>)>;
+    using WrongDelegate = std::function<AnySignal<int>(int, int)>;
 } // namespace
+
+// The two delegate shapes forEach accepts, and the condition its static_assert
+// reports on. A delegate matching neither cannot be given a test that compiles,
+// so what is pinned here is what that assert is written against.
+static_assert(detail::isKeyedForEachDelegate<KeyedDelegate, std::string, Item>);
+static_assert(!detail::isPlainForEachDelegate<KeyedDelegate, Item>);
+static_assert(detail::isPlainForEachDelegate<PlainDelegate, Item>);
+static_assert(!detail::isKeyedForEachDelegate<PlainDelegate, std::string,
+        Item>);
+static_assert(!detail::isKeyedForEachDelegate<WrongDelegate, std::string,
+        Item>);
+static_assert(!detail::isPlainForEachDelegate<WrongDelegate, Item>);
+
+// The key is handed over as a value, so a delegate may read it however a
+// parameter can be read — except by non-const reference, which is what asking
+// to write back to the node's table would look like.
+static_assert(detail::isKeyedForEachDelegate<KeyedByRefDelegate, std::string,
+        Item>);
+static_assert(!detail::isKeyedForEachDelegate<KeyedByMutableRefDelegate,
+        std::string, Item>);
 
 TEST(arraySignal, bracedConstructionNestsAndFlattens)
 {
@@ -348,6 +378,109 @@ TEST(arraySignal, forEachBuildsOncePerKeyAndFollowsMembership)
     c.update(FrameInfo(4, {}));
     EXPECT_EQ(std::vector<int>{ 3 }, c.evaluate<0>().get<0>());
     EXPECT_EQ(3, *builds);
+}
+
+// The delegate is given the key its own element was minted under, and the key
+// is a value rather than a signal because it cannot change. The built value
+// below carries both halves, so a mispairing reads as a wrong string.
+TEST(arraySignal, aKeyedDelegateIsGivenItsOwnKey)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+    auto builds = std::make_shared<int>(0);
+
+    auto c = makeSignalContext(join(forEach(
+                    input.signal,
+                    itemKey,
+                    [builds](std::string key, AnySignal<Item> item)
+                    {
+                        ++*builds;
+
+                        return AnySignal<std::string>(std::move(item).map(
+                                [key](Item const& i)
+                                {
+                                    return key + std::to_string(i.value);
+                                }));
+                    })));
+
+    EXPECT_EQ((std::vector<std::string>{ "a1", "b2" }),
+            c.evaluate<0>().get<0>());
+    EXPECT_EQ(2, *builds);
+
+    // The key is invariant for the identity, so it still names its element
+    // after the value changed and after the membership moved around it.
+    input.handle.set(items({ { "b", 20 }, { "c", 3 }, { "a", 10 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<std::string>{ "b20", "c3", "a10" }),
+            c.evaluate<0>().get<0>());
+    EXPECT_EQ(3, *builds);
+}
+
+// The key is a value and not a reference into the node's own table, so a
+// delegate that keeps it keeps a copy and cannot outlive what it names.
+TEST(arraySignal, theKeyIsGivenAsAValue)
+{
+    auto c = makeSignalContext(join(forEach(
+                    items({ { "a", 1 } }),
+                    itemKey,
+                    [](auto&& key, AnySignal<Item> item)
+                    {
+                        static_assert(std::is_same_v<decltype(key),
+                                std::string&&>);
+
+                        return itemValue(std::move(item));
+                    })));
+
+    EXPECT_EQ(std::vector<int>{ 1 }, c.evaluate<0>().get<0>());
+}
+
+// A delegate that accepts both forms is given the key. It is strictly more to
+// work with, and one that names no parameter for it cannot tell the difference.
+TEST(arraySignal, aGenericDelegateIsGivenTheKeyedForm)
+{
+    auto arity = std::make_shared<std::size_t>(0);
+
+    auto c = makeSignalContext(join(forEach(
+                    items({ { "a", 1 } }),
+                    itemKey,
+                    [arity](auto&&... ts)
+                    {
+                        *arity = sizeof...(ts);
+
+                        return AnySignal<int>(constant(0));
+                    })));
+
+    EXPECT_EQ(std::vector<int>{ 0 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(2u, *arity);
+}
+
+// The unkeyed form is unchanged, and the two build the same array.
+TEST(arraySignal, bothDelegateFormsBuildTheSameArray)
+{
+    auto input = makeInput(items({ { "a", 1 }, { "b", 2 } }));
+
+    auto plain = join(forEach(input.signal, itemKey,
+                [](AnySignal<Item> item)
+                {
+                    return itemValue(std::move(item));
+                }));
+
+    auto keyed = join(forEach(input.signal, itemKey,
+                [](std::string, AnySignal<Item> item)
+                {
+                    return itemValue(std::move(item));
+                }));
+
+    auto c = makeSignalContext(std::move(plain), std::move(keyed));
+
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<0>().get<0>());
+    EXPECT_EQ((std::vector<int>{ 1, 2 }), c.evaluate<1>().get<0>());
+
+    input.handle.set(items({ { "b", 20 } }));
+    c.update(FrameInfo(1, {}));
+
+    EXPECT_EQ(std::vector<int>{ 20 }, c.evaluate<0>().get<0>());
+    EXPECT_EQ(std::vector<int>{ 20 }, c.evaluate<1>().get<0>());
 }
 
 // A key that leaves is retired, so the same key coming back is a new item

--- a/src/testapp1/adder.cpp
+++ b/src/testapp1/adder.cpp
@@ -116,14 +116,10 @@ bqui::widget::AnyWidget adder()
                 return item.first;
             },
             [items, textInputSignal=std::move(textInput.signal), swapState]
-            (bq::signal::AnySignal<std::pair<size_t, std::string>> item)
+            (size_t id,
+                bq::signal::AnySignal<std::pair<size_t, std::string>> item)
             -> widget::AnyWidget
             {
-                auto id = item.map([](std::pair<size_t, std::string> const& i)
-                        {
-                            return i.first;
-                        });
-
                 auto value = item.map(
                         [](std::pair<size_t, std::string> const& i)
                         {
@@ -132,8 +128,8 @@ bqui::widget::AnyWidget adder()
 
                 return widget::hbox({
                 widget::button("U",
-                    textInputSignal.merge(id).bindToFunction(
-                    [items] (std::string str, size_t id) mutable
+                    textInputSignal.bindToFunction(
+                    [items, id] (std::string str) mutable
                     {
                         auto range = items.rangeLock();
                         auto i = range.findId(id);
@@ -142,51 +138,42 @@ bqui::widget::AnyWidget adder()
                             range.update(i, std::move(str));
                         }
                     })),
-                widget::button("T", id.map([items](size_t id)
+                widget::button("T", bq::signal::constant([items, id]() mutable
                     {
-                        return std::function<void()>([items, id]() mutable
-                        {
-                            auto a = withAnimation(0.3f, avg::curve::linear);
-                            auto range = items.rangeLock();
-                            auto i = range.findId(id);
+                        auto a = withAnimation(0.3f, avg::curve::linear);
+                        auto range = items.rangeLock();
+                        auto i = range.findId(id);
 
-                            range.move(i, range.begin());
-                        });
+                        range.move(i, range.begin());
                     }))
                 ,
-                widget::button("S", id.map([items, swapState](size_t id)
+                widget::button("S", bq::signal::constant(
+                    [items, id, swapState]() mutable
                     {
-                        return std::function<void()>(
-                            [items, id, swapState]() mutable
+                        auto a = withAnimation(0.3f, avg::curve::linear);
+                        if (*swapState == 0)
                         {
-                            auto a = withAnimation(0.3f, avg::curve::linear);
-                            if (*swapState == 0)
-                            {
-                                *swapState = id;
-                            }
-                            else
-                            {
-                                auto range = items.rangeLock();
-                                auto i = range.findId(id);
-                                auto j = range.findId(*swapState);
+                            *swapState = id;
+                        }
+                        else
+                        {
+                            auto range = items.rangeLock();
+                            auto i = range.findId(id);
+                            auto j = range.findId(*swapState);
 
-                                range.swap(i, j);
-                                *swapState = 0;
-                            }
-                        });
+                            range.swap(i, j);
+                            *swapState = 0;
+                        }
                     }))
                 ,
                 widget::label(std::move(value))
                 ,
                 widget::hfiller()
                 ,
-                widget::button("x", id.map([items](size_t id)
+                widget::button("x", bq::signal::constant([id, items]() mutable
                     {
-                        return std::function<void()>([id, items]() mutable
-                        {
-                            auto a = withAnimation(0.3f, avg::curve::linear);
-                            items.rangeLock().eraseWithId(id);
-                        });
+                        auto a = withAnimation(0.3f, avg::curve::linear);
+                        items.rangeLock().eraseWithId(id);
                     }))
                 })
                 | modifier::transition(modifier::transitionLeft())


### PR DESCRIPTION
A `forEach` delegate that needs the item's identity had no way to reach it,
which is what forced `adder`'s buttons to build their callables through a `map`
over the item signal in #116. The key *is* the identity, and `forEach` has
already computed it, so the delegate now takes either form:

```cpp
(AnySignal<T>) -> U             // as before
(TKey, AnySignal<T>) -> U       // new
```

## Stacking note

`forEach` lives in `bq`, so by dependency order this belongs below #116 rather
than above it. Inserting it there would mean rebasing four open PRs for tidiness
alone, so it sits on top instead. Nothing in `bq` depends on `bqui`, so the
ordering is a property of the review stack and not of the code.

## The three decisions

- **Key first.** Key-then-value is the conventional order for a keyed callback.
  The retired `dataBind` put it last - `(AnySignal<T> value, size_t id)` - and
  that precedent loses on the merits: one call site, and the unusual order.
  Flagging it rather than following it silently, as asked.
- **By value, not as a signal.** This is the whole point. A key cannot change -
  it is what says which element this is - so handing it over as a signal models
  a constant as time-varying. The cost of that is not theoretical: it is exactly
  what `adder` was paying. It is by value in the literal sense as well, so a
  delegate that keeps its key keeps a copy rather than a reference into the
  node's own table; a test pins that a generic delegate's key parameter deduces
  to `TKey&&` and not to `TKey const&`.
- **A generic delegate gets the keyed form.** `[](auto&&...)` satisfies both and
  there is no way to ask which the author meant. The key is strictly more to
  work with, and a delegate that names no parameter for it cannot tell the
  difference, so preferring the keyed form loses nothing.

A delegate matching neither form is a `static_assert` naming both. The rest of
`forEach`'s body is discarded by an `if constexpr` on the same condition, so
nothing downstream of the assert fails as well - the node's own instantiation
trace, which is the unreadable part, does not appear. The call site still sees a
function returning `void`, so it is one further error rather than none. The
message says "const callable", because a capturing `mutable` delegate is
rejected for that reason rather than for its shape.

## Did the call site actually get simpler?

Yes, measurably. `src/testapp1/adder.cpp` is 28 insertions against 41 deletions,
and the shape of the reduction is the point rather than the count:

- The `item.map(...)` that existed only to extract the id is gone.
- All four buttons go back to `bq::signal::constant([items, id]{ ... })` from
  `id.map([items](size_t id){ return std::function<void()>([items, id]{ ... }); })`
  - one lambda each instead of two nested ones, and no `std::function` written
  out by hand to pin the mapped signal's value type.
- The "U" button drops the `textInputSignal.merge(id)` that existed only to
  carry the id alongside the text, and is back to
  `textInputSignal.bindToFunction(...)`.
- The item signal is now used for exactly one thing - the label - which is what
  a value signal is for.
- A side benefit: the onClick signals no longer re-emit when the item's text
  changes.

The result is close to what `dataBind`'s delegate looked like before #116 ported
it, which is the honest test: the operator now expresses what the thing it
replaced expressed.

## Tests

- `aKeyedDelegateIsGivenItsOwnKey` - the built value carries both the key and
  the item's value, so a mispairing reads as a wrong string. Also pins that the
  key still names its element after the value changes and after the membership
  moves around it, and that only an arriving key is handed over.
- `theKeyIsGivenAsAValue` - a generic delegate's key parameter deduces to
  `std::string&&`.
- `aGenericDelegateIsGivenTheKeyedForm` - a `[](auto&&...)` delegate records its
  arity; it is 2.
- `bothDelegateFormsBuildTheSameArray` - the two forms over one input signal
  agree, initially and after a membership change.
- Eight `static_assert`s pin the trait conditions the `static_assert` inside
  `forEach` is written against, including the rejections and the fact that a
  key parameter may be `TKey` or `TKey const&` but not `TKey&`. A delegate
  matching neither form cannot be given a runtime test that compiles, so the
  condition is what gets pinned.

## Doc

`docs/design/arraysignal.md`'s "No index is passed to the delegate" is amended
rather than deleted, and retitled "- but the key is". Every word of the original
argument is about *position*; a key is the one thing a neighbour's arrival
cannot change, so the objection that rules out an index does not reach it. The
section now says so explicitly, records the three decisions above, and notes
that `map` deliberately does not get the same treatment - an `ArraySignal`'s
identities are internal and no key survives `map`, so there is nothing to hand
over.

## Verified

`lw build` + `lw test` green on `Debug:clang-cl-18.1.7`,
`Debug:msvc-17-2022-enterprise` and `Release:clang-cl-18.1.7`; no new warnings.
Both clean-context reviews ran; every finding is addressed.

