### PR TITLE
Make App's window list an ArraySignal

### DIFF
--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -16,7 +16,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `916c25b` (2026-07-21).*
+*Last verified against `90c50f2` (2026-07-21).*
 
 ## The problem
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,9 +1,10 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, implementation started.** Steps 0 to 3 of
-> *Implementation order* have landed; everything in `bqui` is
-> outstanding, and this document has been amended to describe what was built
-> rather than what was first proposed. The earlier implementation on PR #100 is
+> **Status: revised design, implementation started.** Steps 0 to 4 of
+> *Implementation order* have landed — all of `bq`, plus `App`'s window list;
+> the layout rework is outstanding. This document has been amended to describe
+> what was built rather than what was first proposed. The earlier
+> implementation on PR #100 is
 > a **superseded spike**:
 > it put the per-identity table in the description rather than in the
 > `SignalContext`, which is a correctness defect, not a limitation. This revision
@@ -15,7 +16,7 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `86ddac5` (2026-07-21).*
+*Last verified against `916c25b` (2026-07-21).*
 
 ## The problem
 
@@ -277,9 +278,97 @@ first draft:
   occurrence-index disambiguation (`(key, n)` entries) existed only to satisfy
   global uniqueness and is deleted.
 
-The open question the first draft raised here — whether any identity surfaces at
-the exit, for PR #99's window list and `dataBind` — is unchanged and still
-belongs to PR #99. See *Open questions*.
+### No identity surfaces at the exit
+
+**Settled by PR #99's rework, and it is the answer *Identity is internal*
+predicted.** Nothing outside an array needs an id, so there is **no id-pair
+exit**: a consumer of a changing list takes an `ArraySignal<T>` and builds what
+it needs per identity with `map`, rather than being handed
+`AnySignal<vector<pair<size_t, T>>>` and reconciling by hand.
+
+`App` is the worked case. It now takes an `ArraySignal<Window>` and builds one
+`WindowGlue` per identity; the by-id reconcile loop, the producer-assigned
+`size_t`, and the `WindowList` alias are all deleted. What replaced them is not
+a translation of the loop — the loop *is* `ArrayOnce`, and `App` no longer
+contains one. The other consumer the open question named, `dataBind`, is
+retired wholesale at step 6 rather than re-typed, so nothing there reopens it.
+
+Four findings from doing it, because each one generalises past `App`:
+
+- **The consumer's `map` is the reconcile.** `map` runs once per identity and
+  its result is destroyed when the identity leaves, which is exactly
+  create-on-arrive / destroy-on-depart. A consumer whose per-item object is
+  expensive or owns an OS resource needs no more than that.
+- **A non-signal value leaves as a constant.** `App`'s per-item value is a glue,
+  not a signal, and `join` is the only exit. `map`ping it to
+  `constant(glue)` and joining reads oddly the first time and is what the exit
+  is for: *One layout engine* fans in `AnySignal<SizeHint>`s that were already
+  signals and so never met this, which is why `join`'s Doxygen now says so.
+- **The exit gives the consumer a plain vector, and that is enough.** Everything
+  `App` did with ids — iterating live glues, tearing down departed ones — is a
+  fold over that vector. The id was never carrying information the consumer
+  could not read off the list.
+- **The consumer owes no change notification either.** The first attempt kept
+  the window-list observer PR #99 had and only re-typed what it reported. That
+  was backwards: the list is the source of truth, so what an item offers is
+  wired *back into what the list is built from* — a window's close callback
+  removes its own key — and there is nothing left for a notification to be
+  for. A consumer that thinks it needs one is usually holding a second copy of
+  the membership. Nothing of the kind shipped.
+
+### An element's signal may not be read on a clock of its own
+
+**A constraint this design did not state, and the first `bqui` consumer broke
+it.** *The pick construction* requires that a pick be dropped "no later than the
+update that observes the key leaving". A consumer that reads the element's
+signal only inside the array's own update pass gets that for free: the source
+changes, the node retires the key, and nothing evaluates the departed pick
+again. The unified layout engine will be such a consumer, which is why the
+obligation looked like a formality.
+
+`App` was not. Each `WindowGlue` holds the window's title and widget signals in
+its **own** `SignalContext`, updated from OS input handlers. An `Input` is
+global to every context, so a handler that removed a window's key — a window
+with its own close button — made that window's next update read a pick whose key
+had just left, and `requirePresent` threw out of the event loop and took the
+process down. Reproduced in `testapp1`, whose second window is now exactly that
+button.
+
+The fix is not to soften `requirePresent`; a latch here would hand back a stale
+value, which *The pick construction* already rejects. It is to give the element's
+signals one clock: `WindowGlue`'s input handlers now request a frame instead of
+transacting inline, so every per-window update happens after the array has been
+reconciled and a departed window's glue is gone before anything can update it.
+
+State it as a rule for the next consumer:
+
+> **Read an element's signal only where the array is updated.** A consumer that
+> drives per-element signals on a schedule of its own must reconcile the array
+> first, and must destroy what it built for a departed identity before that
+> schedule comes round again.
+
+Note what the fix does *not* rest on. The close path — the idiom for removing a
+window — never transacts at all: the glue's close callback only invokes the
+window's own callbacks and returns, so removal from `onClose` is safe by
+construction. The deferral above is what makes removal safe from a *widget* in
+the window, which is the other half of the idiom.
+
+`App` still does not fully satisfy the rule, and the remainder is recorded in
+`src/bqui/AGENTS.md` rather than hidden: `AnimationGuard` brackets a
+`withAnimation` scope with two synchronous transactions of every window, and a
+list changed from inside the frame phase is reconciled only on the next pass.
+Reaching the first takes an explicit `withAnimation` around a removal, which no
+close path opens by itself. Both need the app loop's update model changed rather
+than a local guard, which is why they are not in this change. The lesson for the
+design is the rule above: a consumer with its own clock is the hard case, and
+the layout engine's being free of it is a property of the layout engine, not of
+the array.
+
+The one thing the caller loses is the ability to have a single `forEach` build
+*differently shaped* items, since the delegate is handed the item's value and
+not its key. That is not a gap: the caller writes one array per shape and
+concatenates them, which is what the braced-list constructor is for.
+`src/testapp1/main.cpp` does exactly this for its second window.
 
 ### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
@@ -1407,25 +1496,10 @@ per item and is not something this design can avoid, so a long-lived window whos
 list churns still accumulates dead entries. Pre-existing, but this is the first
 design that reaches it at churn rate.
 
-**PR #99 (dynamic windows)** is open, and makes `App`'s window list
-`AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
-stable id. It is expected to be reworked onto `ArraySignal<Window>`. Note that
-`App` no longer owns an id allocator under this design — the `ArraySignal` does —
-so the rework is `forEach` over the window list rather than a
-consumer-side reconcile. See *Open questions*.
-
 ## Open questions
 
 Points the design does not settle. Flagged rather than guessed.
 
-- **Does any identity surface at the exit?** Unchanged from the first draft, and
-  still the one open question that changes code outside this design. *Identity is
-  internal* argues that nothing outside needs an id, which taken to its conclusion
-  means there is **no id-pair exit at all**: `App` would take an
-  `ArraySignal<Window>` and use `forEach` rather than being handed
-  `AnySignal<vector<pair<size_t, Window>>>` and reconciling by hand. The two live
-  consumers are PR #99's window list and `dataBind`
-  (`src/bqui/include/bqui/databind.h:22`). Decide it when PR #99 is reworked.
 - **The reactive subtree `AnySignal<ArraySignal<T>>`.** Still unimplemented and
   still unreconciled: the identity algebra says only construction and `forEach`
   mint identity, but this constructor hands out fresh ids on every swap. Either
@@ -1447,7 +1521,7 @@ Written for a from-scratch implementation. The spike on PR #100 is superseded an
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
 
-Steps 0 to 3 are done; the rest is outstanding.
+Steps 0 to 4 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
    not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
@@ -1479,18 +1553,40 @@ Steps 0 to 3 are done; the rest is outstanding.
    the aggregate. The size-alignment check is that zip; what it reaches is
    *Alignment is a promise, and only its arity is checked*.
 
-4. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
+4. **`App`'s window list.** *Done.* The first `bqui` consumer, and the one that
+   settled *No identity surfaces at the exit*. `App::windows` takes an
+   `ArraySignal<Window>` and `App::run` builds a `WindowGlue` per identity with
+   `map`, joins the glues through a constant, and reads the live set off the
+   fanned-in vector. Independent of steps 5 and 6 and landed before them.
+
+5. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
    `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are
    unaffected. Delete the dead heterogeneous tuple path
    (`accumulateSizeHintsTuple`, `MapObbs`) at the same time.
 
-5. **Delete `dynamicBox`.** `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
+6. **Delete `dynamicBox`.** `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
    route to the unified `layout()`. This is where the missing `handleGravity()`
    and the element-cache bug disappear. Retire `dataBind` /
    `dataSourceFromCollection` here, porting `src/bqui/test/databindtest.cpp:18`
    and `src/testapp1/adder.cpp:84`.
 
 Steps 0-3 are `bq` only and land before anything in `bqui` changes.
+
+Step 4 also fixed an `ase` defect it was the first thing to reach: the WGL
+backend never destroyed a window's `HWND`, so closing a window at runtime left a
+dead one on screen that painted nothing and answered no input. Nothing could
+close a window while the app ran before this step, which is why it had gone
+unnoticed. The GLX backend has always destroyed its window.
+
+### `App::run` can only be tested where the backend is headless
+
+`App::run` opens windows, so on the GLX and WGL backends a test of it needs a
+display and a GPU context that a CI runner does not have.
+`src/bqui/test/apptest.cpp` is therefore compiled only where `ase` builds its
+headless backend, which `ase_is_headless` in `src/ase/meson.build` reports.
+Anything else that wants end-to-end coverage of the app loop inherits the
+constraint, and the way out is to inject the platform into `App` rather than to
+weaken the test — nothing has needed that yet.
 
 ### Tests the departed-key invariant requires
 

--- a/src/ase/AGENTS.md
+++ b/src/ase/AGENTS.md
@@ -1,6 +1,6 @@
 # ase — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `916c25b` (2026-07-21).*
 
 The GPU + platform layer. Concepts are in `readme.md`; project-wide conventions
 are in the top-level `docs/`.
@@ -18,6 +18,21 @@ are in the top-level `docs/`.
 - The Windows GPU/rendering path lives under `src/windows/` and `src/gl/` — this
   is where to look for Windows rendering performance or context-selection issues
   (integrated-vs-discrete GPU, vsync).
+- A backend owns its window's lifetime in the `WindowImpl` destructor —
+  `GlxWindow` destroys its X window there and `WglWindow` its `HWND`. Leaving
+  that out does not fail a test: nothing closes a window while the app runs
+  unless the window list says to, so the symptom is a dead window left on
+  screen. The WGL backend was missing it until a window list became reactive.
+- **Unfixed:** destroying a WGL window mid-run leaves two loose ends that were
+  unreachable while windows lived for the whole process, and became reachable
+  when the window list did. `WglDispatchedContext` caches the last DC it made
+  current and nothing invalidates that entry, so a recycled `HDC` can make it
+  skip a `wglMakeCurrent` it needed; and with no window left the run loop keeps
+  submitting fences against a context current on a destroyed DC. Releasing the
+  context from the window's destructor would close both, and has to be
+  dispatched to the render thread.
+- `src/ase/meson.build` sets `ase_is_headless`, which is how a dependent decides
+  whether a test may open a window (`src/bqui/meson.build` uses it).
 - The root `meson.build` adds MSVC-style flags (`/wd4251`, `/bigobj`, `/UNICODE`)
   for any Windows build; those assume an MSVC-compatible driver, which is why
   clang must be `clang-cl`, not `clang++` (the build notes in the repo-root

--- a/src/ase/AGENTS.md
+++ b/src/ase/AGENTS.md
@@ -1,6 +1,6 @@
 # ase — agent notes
 
-*Last verified against `916c25b` (2026-07-21).*
+*Last verified against `90c50f2` (2026-07-21).*
 
 The GPU + platform layer. Concepts are in `readme.md`; project-wide conventions
 are in the top-level `docs/`.

--- a/src/ase/include/ase/wglwindow.h
+++ b/src/ase/include/ase/wglwindow.h
@@ -15,6 +15,11 @@ namespace ase
     public:
         WglWindow(WglPlatform& platform, Vector2i size, float scalingFactor);
 
+        WglWindow(WglWindow const&) = delete;
+        WglWindow& operator=(WglWindow const&) = delete;
+
+        ~WglWindow();
+
         HWND getHwnd() const;
         HDC getDc() const;
 

--- a/src/ase/include/ase/windowimpl.h
+++ b/src/ase/include/ase/windowimpl.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <functional>
 #include <chrono>
+#include <optional>
 
 namespace ase
 {

--- a/src/ase/meson.build
+++ b/src/ase/meson.build
@@ -24,6 +24,11 @@ glsrcs = [
   'src/gl/glrenderqueue.cpp'
   ]
 
+# Whether the backend built here is the headless "dummy" one. A test that
+# drives a real window can only run where it is: the GLX and WGL backends need
+# a display and a GPU context that CI does not have.
+ase_is_headless = false
+
 if target_machine.system() == 'linux'
   gldep = dependency('gl')
   x11dep = dependency('x11')
@@ -57,6 +62,7 @@ elif target_machine.system() == 'windows'
     glsrcs
     ]
 else
+  ase_is_headless = true
   system_deps = []
   system_link_args = []
   system_incs = []

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -234,7 +234,11 @@ Window WglPlatform::makeWindow(Vector2i size)
     try
     {
         auto wglWindow = std::make_shared<WglWindow>(*this, size, 1.0f);
-        windows.insert(std::make_pair(wglWindow->getHwnd(), wglWindow));
+        // Assign rather than insert: Windows reuses an HWND once its window is
+        // gone, and an expired entry under that handle lingers here until the
+        // next pass of handleEvents(), where insert() would keep it and leave
+        // the new window without a receiver for its events.
+        windows[wglWindow->getHwnd()] = wglWindow;
         return Window(std::move(wglWindow));
     }
     catch(std::exception& e)

--- a/src/ase/src/windows/wglwindow.cpp
+++ b/src/ase/src/windows/wglwindow.cpp
@@ -426,6 +426,13 @@ WglWindow::WglWindow(WglPlatform& platform, Vector2i size,
     genericWindow_.setScalingFactor(scalingFactor);
 }
 
+WglWindow::~WglWindow()
+{
+    // The window class is CS_OWNDC, so the DC belongs to the window and goes
+    // with it; releasing it separately would be a no-op.
+    DestroyWindow(hwnd_);
+}
+
 HWND WglWindow::getHwnd() const
 {
     return hwnd_;

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -855,7 +855,10 @@ namespace bq::signal
      *
      * The only exit from the array domain, and the reason the element type has
      * to be a signal: an array of anything else has nothing to fan in. Map it
-     * to something joinable first.
+     * to something joinable first. A value that carries no variation of its own
+     * leaves as `constant(value)`: the exit hands back a vector of the
+     * elements' current values, and a constant's current value is the thing
+     * itself.
      *
      * A membership change initializes what arrived and releases what left. A
      * surviving element is carried across untouched, so whatever its signal has

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -1,6 +1,6 @@
 # bqui — agent notes
 
-*Last verified against `916c25b` (2026-07-21).*
+*Last verified against `90c50f2` (2026-07-21).*
 
 Internals, entry points, and traps for the UI toolkit. Concepts and usage are in
 `readme.md`; project-wide conventions are in the top-level `docs/`. This file is

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -1,6 +1,6 @@
 # bqui — agent notes
 
-*Last verified against `9cbe4cb` (2026-07-20).*
+*Last verified against `916c25b` (2026-07-21).*
 
 Internals, entry points, and traps for the UI toolkit. Concepts and usage are in
 `readme.md`; project-wide conventions are in the top-level `docs/`. This file is
@@ -38,6 +38,61 @@ terminate to `AnyWidget`. Transforms are **paint-time and never affect layout**
 - Environment: a typed, scoped store threaded through the tree (`provider/`,
   `modifier/setparams.h`); `Theme` is the common parameter.
 - Animation: `withanimation.h` (guard or lambda form) marks changes to animate.
+
+## The app loop (`app.cpp`)
+
+**The window list is the only thing that says which windows exist.** `App` holds
+it as a `bq::signal::ArraySignal<Window>` and `App::run` maps it to one
+`WindowGlue` per identity and joins the glues, so the array itself creates a
+glue when an identity appears and destroys it — closing the window — when the
+identity leaves; a surviving window is never rebuilt. A `WindowGlue` owns
+everything for one window: its `ase::Window`, painter, per-window signal
+contexts, and input state. The glues are re-read from the joined signal only on
+the frames in which membership changed, and `AnimationGuard` walks that cached
+vector.
+
+`App` therefore reports nothing about the open windows and has no hook for
+observing them. A window closes by leaving the list, so what a window offers —
+`Window::onClose`, a button in its own UI — is wired to whatever the list is
+built from, and the removal flows back through the array. `src/testapp1` is the
+worked example: its second window's title bar and its own button both take the
+same key out of the same input.
+
+Two ordering rules hold that together, and both are load-bearing rather than
+tidiness:
+
+- **A window's signals are updated in the frame phase, never from an input
+  handler.** The handler marks the window for redraw and returns; the platform
+  runs the frame after `App::run`'s callback has reconciled the list, so a
+  window whose key has just left is destroyed before anything updates it. A
+  handler that transacted inline updated a signal naming a key it had itself
+  removed, and that signal throws once the key is gone — a window with its own
+  close button took the process down that way.
+- **A glue is released only after the main render queue has caught up.** An
+  in-flight frame holds the window's framebuffer, which holds the window by
+  reference.
+
+The close path itself never transacts: `WindowGlue`'s close callback only
+invokes the window's own callbacks, so removing a window from its `onClose` is
+safe by construction rather than by the rule above. That is worth knowing
+because it is what makes the idiom safe.
+
+Two paths still break the first rule and are **known gaps**, not oversights to
+re-derive:
+
+- `AnimationGuard` transacts every glue from its constructor and destructor, and
+  `withAnimation` is called from input handlers. A handler that both animates
+  and removes a window still throws, for the window that left. Reaching it takes
+  an explicit `withAnimation` scope around the removal; the close path does not
+  open one. Fixing it means the animation bracket no longer being a pair of
+  synchronous transactions.
+- A window list changed from *within* the frame phase — one window's update
+  removing another's key — is reconciled only on the next pass, so the other
+  window can update once with its key already gone.
+
+Neither is reachable from `test/apptest.cpp`: the dummy backend never runs a
+window's frame callback at all, so that binary covers the array plumbing and
+nothing about this ordering. Run `testapp1` to exercise it.
 
 ## Traps
 

--- a/src/bqui/include/bqui/app.h
+++ b/src/bqui/include/bqui/app.h
@@ -3,12 +3,15 @@
 #include "window.h"
 #include "bquivisibility.h"
 
+#include <bq/signal/arraysignal.h>
 #include <bq/signal/signal.h>
 
 #include <avg/curve/curves.h>
 
 #include <btl/shared.h>
 #include <btl/visibility.h>
+
+#include <optional>
 
 namespace bqui
 {
@@ -20,9 +23,31 @@ namespace bqui
     public:
         explicit App();
 
-        App windows(std::initializer_list<Window> windows) &&;
+        /** @brief Sets the windows the app opens.
+         *
+         * The list is the only thing that says which windows exist. A braced
+         * list is a constant array, so `windows({ a, b })` opens two windows
+         * and never changes; a list built with bq::signal::forEach() opens and
+         * closes windows as its keys come and go, and every window that stays
+         * keeps everything it had — its widgets, their state, and its own OS
+         * window.
+         *
+         * A window closes by leaving the list, so wire what a window offers to
+         * whatever the list is built from: `Window::onClose` on a window whose
+         * key comes from an input removes that key.
+         */
+        App windows(bq::signal::ArraySignal<Window> windows) &&;
 
+        /** @brief Runs until `running` is false. */
         int run(bq::signal::AnySignal<bool> running) &&;
+
+        /** @overload
+         *
+         * Runs until a window closes — **any** window, including one that
+         * opened later. That is what a single-window app wants; a list whose
+         * windows come and go wants the overload above, so that closing one
+         * window can mean removing it rather than stopping.
+         */
         int run() &&;
 
         [[nodiscard]]

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -80,13 +80,23 @@ libbquidep = declare_dependency(
   include_directories: include_directories('include')
   )
 
-bquitest =  executable('bquitest',
+bquitestsrc = [
   'test/collectiontest.cpp',
   'test/databindtest.cpp',
   'test/layouttest.cpp',
   'test/shapetest.cpp',
   'test/widgetinstancemodifiertest.cpp',
   'test/widgettest.cpp',
+  ]
+
+# App::run opens real windows, so it can only be exercised where ase builds its
+# headless backend.
+if ase_is_headless
+  bquitestsrc += 'test/apptest.cpp'
+endif
+
+bquitest =  executable('bquitest',
+  bquitestsrc,
   dependencies: [gtestdep, libbquidep],
   )
 

--- a/src/bqui/readme.md
+++ b/src/bqui/readme.md
@@ -51,6 +51,37 @@ return app()
     .run();
 ```
 
+The window list is a `bq::signal::ArraySignal<Window>`, so a braced list is
+simply the constant case. Build one with `bq::signal::forEach` instead and
+windows open and close as its keys come and go; the ones that stay keep
+everything they had. Concatenate arrays — `.windows({ mainWindow, others })` —
+when the windows are not all built the same way.
+
+The list is the only thing that says which windows exist, so a window closes by
+leaving it: wire `onClose` back to whatever the list is built from. Here the
+list holds one window while `showDetails` is true, so closing that window means
+setting it false.
+
+```cpp
+auto showDetails = bq::signal::makeInput(false);
+
+auto details = bq::signal::forEach(
+        showDetails.signal.map([](bool b) {
+            return b ? std::vector<std::string>{ "Details" }
+                     : std::vector<std::string>{};
+        }),
+        [](std::string const& name) { return name; },
+        [handle = showDetails.handle](bq::signal::AnySignal<std::string> name)
+        {
+            return window(std::move(name), detailsUi())
+                .onClose(send(false, handle));
+        });
+```
+
+`run()` with no arguments means "run until any window closes", which is what a
+single-window app wants. Pass `run(running)` when closing one window should
+remove it rather than stop the app.
+
 Signal changes made inside a `withAnimation` scope are animated.
 
 ## Layout (of the source)

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -5,6 +5,8 @@
 
 #include "debug.h"
 
+#include <bq/signal/arraysignal.h>
+#include <bq/signal/constant.h>
 #include <bq/signal/input.h>
 #include <bq/signal/updateresult.h>
 #include <bq/signal/signalcontext.h>
@@ -34,9 +36,12 @@
 #include <tracy/Tracy.hpp>
 
 #include <chrono>
+#include <functional>
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include <string>
+#include <vector>
 #include <cstdint>
 
 namespace bqui
@@ -54,6 +59,8 @@ namespace
 
 class WindowGlue;
 
+using GlueSignal = bq::signal::AnySignal<btl::shared<WindowGlue>>;
+
 class BQUI_EXPORT AppDeferred
 {
 public:
@@ -62,7 +69,7 @@ public:
         TracyAppInfo("Reactive application", 20);
     }
 
-    std::vector<Window> windows_;
+    bq::signal::ArraySignal<Window> windows_;
     std::vector<btl::shared<WindowGlue>> windowGlues_;
 };
 
@@ -112,7 +119,7 @@ public:
                         a.emitButtonEvent(e);
                         areas_[e.button].push_back(a);
 
-                        makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                        aseWindow.requestFrame();
                     }
                 }
             }
@@ -125,7 +132,7 @@ public:
 
                 areas_[e.button].clear();
 
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                aseWindow.requestFrame();
             }
 
         });
@@ -205,7 +212,7 @@ public:
                 (*currentKeyHandler_)(e);
                 keys_[e.getKey()] = *currentKeyHandler_;
 
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                aseWindow.requestFrame();
             }
             else
             {
@@ -217,7 +224,7 @@ public:
 
                 f(e);
 
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                aseWindow.requestFrame();
             }
         });
 
@@ -227,7 +234,7 @@ public:
             {
                 (*currentTextHandler_)(e);
 
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                aseWindow.requestFrame();
             }
         });
 
@@ -240,7 +247,7 @@ public:
                     currentHoverArea_->emitHoverEvent(e);
                     currentHoverArea_ = std::nullopt;
 
-                    makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
+                    aseWindow.requestFrame();
                 }
             }
         });
@@ -465,10 +472,9 @@ App::App() :
 {
 }
 
-App App::windows(std::initializer_list<Window> windows) &&
+App App::windows(bq::signal::ArraySignal<Window> windows) &&
 {
-    for (auto const& w : windows)
-        d()->windows_.push_back(btl::clone(w));
+    d()->windows_ = std::move(windows);
 
     return std::move(*this);
 }
@@ -477,15 +483,44 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
 {
     ase::Platform platform = ase::makeDefaultPlatform();
 
-    d()->windowGlues_.reserve(d()->windows_.size());
-
     ase::RenderContext context = platform.makeRenderContext();
 
-    for (auto&& w : d()->windows_)
+    // One glue per window identity: the array builds it when the identity
+    // appears and destroys it when the identity leaves, so a window that
+    // survives an edit keeps the glue it already had. A glue is not a signal,
+    // and join() is the only way out of the array, so each one leaves as a
+    // constant.
+    auto makeGlue = [&platform, &context](Window const& window)
     {
-        d()->windowGlues_.push_back(std::make_shared<WindowGlue>(
-            platform, context, std::move(w)));
-    }
+        btl::shared<WindowGlue> glue = std::make_shared<WindowGlue>(platform,
+                context, btl::clone(window));
+
+        return GlueSignal(bq::signal::constant(std::move(glue)));
+    };
+
+    auto glues = bq::signal::makeSignalContext(
+            bq::signal::join(d()->windows_.map(makeGlue)));
+
+    auto mainQueue = context.getMainRenderQueue();
+
+    auto collect = [&]()
+    {
+        std::vector<btl::shared<WindowGlue>> departing =
+            glues.evaluate<0>().get<0>();
+
+        // A frame that drew a departing window can still be in flight, and it
+        // holds that window's framebuffer, so nothing may release a glue until
+        // the queue has caught up.
+        mainQueue.finish();
+
+        // Swap and then clear, rather than assign: destroying a window runs
+        // event handlers that reach back into the live set, which must be the
+        // new one by then.
+        d()->windowGlues_.swap(departing);
+        departing.clear();
+    };
+
+    collect();
 
     std::chrono::steady_clock clock;
     auto startTime = clock.now();
@@ -496,7 +531,11 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
     platform.run(context, [&](ase::Frame const& aseFrame) -> bool
         {
             bq::signal::FrameInfo frame{ getNextFrameId(), aseFrame.dt };
-            auto [timeToNext, didChange] = running.update(frame);
+
+            if (glues.update(frame).didChange)
+                collect();
+
+            running.update(frame);
 
             return running.evaluate<0>().get<0>();
         });
@@ -512,6 +551,7 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
                 (double)glue->getFrames() / time.count());
     }
 
+    mainQueue.finish();
     d()->windowGlues_.clear();
 
     return 0;
@@ -520,8 +560,14 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
 int App::run() &&
 {
     auto running = bq::signal::makeInput(true);
-    for (auto&& w : d()->windows_)
-        w = std::move(w).onClose(send(false, running.handle));
+
+    // Wiring the handler through the array reaches a window that opens later
+    // just as it reaches one that was there from the start.
+    d()->windows_ = d()->windows_.map(
+            [handle = running.handle](Window const& window)
+            {
+                return btl::clone(window).onClose(send(false, handle));
+            });
 
     return std::move(*this).run(running.signal);
 }

--- a/src/bqui/test/apptest.cpp
+++ b/src/bqui/test/apptest.cpp
@@ -1,0 +1,189 @@
+#include <bqui/app.h>
+#include <bqui/window.h>
+
+#include <bqui/widget/widget.h>
+
+#include <bq/signal/arraysignal.h>
+#include <bq/signal/constant.h>
+#include <bq/signal/input.h>
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace bqui;
+
+// Each test builds its own App rather than calling app(), whose App shares one
+// AppDeferred with every other caller — two tests would then run the same
+// window list.
+//
+// App reports nothing about the open windows, so these tests watch the windows
+// themselves. Two things are observable from outside without any hook:
+//
+//   - A window's title is read once per window that opens, when the glue builds
+//     its SignalContext; every later read is cached, and the dummy platform
+//     runs no window frames that could invalidate it. Counting reads of a title
+//     therefore counts openings, and a window rebuilt behind our backs counts
+//     twice.
+//   - A probe held by a window's close callback lives exactly as long as that
+//     window does.
+
+namespace
+{
+    using Probe = std::shared_ptr<int>;
+    using Opens = std::map<std::string, int>;
+
+    auto countReads(Opens& opens)
+    {
+        return [&opens](std::string const& title)
+        {
+            ++opens[title];
+            return title;
+        };
+    }
+
+    Window makeWindow(std::string title, Opens& opens, Probe probe)
+    {
+        return window(
+                bq::signal::constant(std::move(title)).map(countReads(opens)),
+                widget::makeWidget())
+            .onClose([probe]() {});
+    }
+
+    // The dummy platform's loop has no bound of its own, so a regression that
+    // stopped a script advancing would hang rather than fail.
+    constexpr int maxFrames = 100;
+} // namespace
+
+// A window whose key stays is not rebuilt when its neighbours come and go —
+// neither its delegate nor its glue runs twice — and a window whose key leaves
+// is destroyed there and then.
+TEST(App, windowsOpenAndCloseWithTheirKeys)
+{
+    auto titles = bq::signal::makeInput(std::vector<std::string>{ "first" });
+
+    int builds = 0;
+    Opens opens;
+    std::vector<std::weak_ptr<int>> probes;
+
+    auto windows = bq::signal::forEach(titles.signal,
+            [](std::string const& title) { return title; },
+            [&](bq::signal::AnySignal<std::string> title)
+            {
+                ++builds;
+
+                Probe probe = std::make_shared<int>(0);
+                probes.push_back(probe);
+
+                return window(title.map(countReads(opens)),
+                        widget::makeWidget())
+                    .onClose([probe]() {});
+            });
+
+    int frames = 0;
+    bool survivorOutlivedTheDeparted = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    // The script drives itself. A SignalContext caches each signal's value and
+    // re-evaluates only on a frame the signal reports changed, so a step earns
+    // the next one by advancing the input it is derived from. Step 0 runs when
+    // the context is built, before the first frame.
+    //
+    // Editing the window list from here is the one case of doing so during the
+    // frame phase that is sound: App reconciles the list before it evaluates
+    // this, so a step sees what the step before it asked for and no window is
+    // updated after its key left.
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    titles.handle.set(
+                            std::vector<std::string>{ "first", "second" });
+                    break;
+
+                case 1:
+                    titles.handle.set(std::vector<std::string>{ "second" });
+                    break;
+
+                case 2:
+                    survivorOutlivedTheDeparted = probes.size() == 2u
+                        && probes[0].expired()
+                        && !probes[1].expired();
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    App().windows(std::move(windows)).run(running);
+
+    EXPECT_LT(frames, maxFrames);
+
+    EXPECT_EQ(builds, 2);
+    EXPECT_TRUE(survivorOutlivedTheDeparted);
+
+    // The survivor opened when it arrived and not again when its neighbour
+    // left.
+    EXPECT_EQ(opens, (Opens{ { "first", 1 }, { "second", 1 } }));
+
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_TRUE(probes[0].expired());
+    EXPECT_TRUE(probes[1].expired());
+}
+
+// A braced list is a constant array: every window in it opens once and every
+// one is gone when the app is.
+TEST(App, staticWindowsAllOpenOnce)
+{
+    Opens opens;
+    std::vector<Probe> owned { std::make_shared<int>(0),
+        std::make_shared<int>(0), std::make_shared<int>(0) };
+
+    std::vector<std::weak_ptr<int>> probes { owned[0], owned[1], owned[2] };
+
+    bq::signal::ArraySignal<Window> windows = {
+        makeWindow("a", opens, owned[0]),
+        makeWindow("b", opens, owned[1]),
+        makeWindow("c", opens, owned[2])
+    };
+
+    owned.clear();
+
+    int frames = 0;
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames || i != 0)
+                    return false;
+
+                step.handle.set(1);
+
+                return true;
+            });
+
+    App().windows(std::move(windows)).run(running);
+
+    EXPECT_LT(frames, maxFrames);
+
+    EXPECT_EQ(opens, (Opens{ { "a", 1 }, { "b", 1 }, { "c", 1 } }));
+
+    for (auto const& probe : probes)
+        EXPECT_TRUE(probe.expired());
+}

--- a/src/testapp1/main.cpp
+++ b/src/testapp1/main.cpp
@@ -47,6 +47,8 @@
 #include <btl/future.h>
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 using namespace bqui;
 
@@ -120,8 +122,22 @@ int main()
                 avg::RepeatMode::reverse
                 ));
 
+    auto showSecond = bq::signal::makeInput(false);
+
     auto widgets = widget::hbox({
         widget::vbox({
+            widget::button(
+                    showSecond.signal.map([](bool b) -> std::string
+                        {
+                            return b ? "Close second window"
+                                : "Open second window";
+                        }),
+                    showSecond.signal.bindToFunction(
+                        [handle = showSecond.handle](bool b) mutable
+                        {
+                            handle.set(!b);
+                        }))
+                | modifier::setSizeHint({ 250, 50 }),
             shape::rectangle()
                 //.size(bq::signal::constant(avg::Vector2f(100, 100)))
                 //.transform(bq::signal::constant(avg::translate(10, 20)))
@@ -179,6 +195,42 @@ int main()
                 bq::signal::constant(0.5f))
     });
 
+    // The second window is a separate array concatenated with the first, which
+    // is what lets the two be built differently: forEach() hands its delegate
+    // the item's value and not its key, so one call builds one kind of window.
+    auto secondWindows = bq::signal::forEach(
+            showSecond.signal.map([](bool b)
+                {
+                    std::vector<std::string> names;
+                    if (b)
+                        names.push_back("Second window");
+                    return names;
+                }),
+            [](std::string const& name) { return name; },
+            [show = showSecond.signal, handle = showSecond.handle]
+            (bq::signal::AnySignal<std::string> name)
+            {
+                // The window closes by leaving the list, so both ways of
+                // closing it — its own title bar and its own button — do the
+                // one thing: take its key out of what the list is built from.
+                return window(std::move(name),
+                        widget::button("Close me",
+                                    show.bindToFunction(
+                                        [handle](bool) mutable
+                                        {
+                                            handle.set(false);
+                                        }))
+                        | modifier::frame()
+                        | modifier::focusGroup()
+                        )
+                    .onClose(send(false, handle));
+            });
+
+    // Closing the main window ends the app; closing the second one only
+    // removes it. run() without a signal cannot tell the two apart, since it
+    // means "run until any window closes".
+    auto running = bq::signal::makeInput(true);
+
     return app()
         .windows({
                 window(
@@ -187,7 +239,8 @@ int main()
                     //| debug::drawKeyboardInputs()
                     | modifier::focusGroup()
                     )
+                    .onClose(send(false, running.handle)),
+                secondWindows
                 })
-        .run();
+        .run(running.signal);
 }
-


### PR DESCRIPTION
Reworks PR #99 onto `ArraySignal`. Based on `arraysignal-scatter` (PR #114), not
`master`; the old branch predates the design it should be built on, and its
hand-written by-id reconcile is what `forEach` replaces.

## The design question this settles

`docs/design/arraysignal.md` asked, as an open question, whether any identity
surfaces at the exit, and named this PR as the consumer that would decide it.

**It does not.** `App` takes a `bq::signal::ArraySignal<Window>` and builds one
`WindowGlue` per identity with `map()`. The array *is* the reconciliation:
create on arrive, destroy on depart, survivors untouched. The `WindowList`
alias, the producer-assigned `size_t`, and the reconcile loop in `App::run` are
all deleted, and no id reaches user code.

What the doing of it taught, now recorded in the design:

- The consumer's `map` is the reconcile. Nothing else was needed.
- A value that is not a signal leaves the array as `constant(value)`. That is
  what the exit is for — `join`'s Doxygen now says so.
- The exit hands back a plain vector, and everything `App` did with ids is a
  fold over it.

The one thing a caller gives up is having a single `forEach` build differently
shaped items, since the delegate gets the item's value and not its key. The
answer is one array per shape, concatenated — `testapp1` does exactly that for
its second window, so **the keyed delegate on `foreach-keyed-delegate` was not
needed and is not cherry-picked.**

`onWindowsReconciled` is **gone, with nothing in its place.** The list is the
source of truth for which windows exist, so a change notification on `App` is
the wrong shape: what a window offers is wired back into whatever the list is
built from, and the removal flows through the array. A window's `onClose`
removes its own key; so does a button in its own UI. `testapp1` shows both
halves on its second window.

That also removes the reason to argue about the payload — reporting titles was
doubly wrong, since a title is presentation, not identity. The finding
generalises: a consumer that thinks it needs a change notification from the
array is usually holding a second copy of the membership.

## A constraint the design did not state, found by breaking it

**An element's signal may not be read on a clock of its own.** *The pick
construction* requires a pick to be dropped no later than the update that
observes its key leaving. A consumer that only reads elements inside the array's
own update pass gets that for free — the unified layout engine will be one,
which is why the obligation looked like a formality.

`App` was not one. Each `WindowGlue` holds its window's title and widget signals
in its own `SignalContext`, updated from OS input handlers, and an `Input` is
global to every context. So a window with its own close button removed its key
and then updated a signal naming that key, `requirePresent` threw out of the
event loop, and the process died. Reproduced in `testapp1` by clicking, not
reasoned about.

The fix is not to soften `requirePresent` — a latch there hands back a stale
value, which the design already rejects. It is to give the element's signals one
clock: input handlers now request a frame instead of transacting inline, so
per-window updates happen after the array has been reconciled and a departed
window's glue is gone before anything can touch it. The rule is now in the
design doc and in `src/bqui/AGENTS.md`.

A second ordering rule came out of review: a glue is released only after the
main render queue has caught up, because an in-flight frame holds the window's
framebuffer, which holds the window by reference.

## The multi-window defect: half real, and fixed

Rendering and input in an already-open window are **fine** when a second window
opens at runtime — verified by running `testapp1`. The first window keeps
animating and keeps accepting clicks with a second window open.

What was broken is the other direction. `WglWindow` had **no destructor**, so
releasing an `ase::Window` left its `HWND` alive: a closed window stayed on
screen, painted nothing, and answered no input. Two open/close cycles left three
"Second window" windows on screen. `GlxWindow` has always destroyed its X
window; this is the WGL half, and nothing could close a window mid-run before
this PR, which is why it had gone unnoticed.

## The old CI failures were not staleness

PR #99's Linux and Windows legs failed with `Unable to open X display` and
`Unable to get wglCreateContextAttribsARB.` — `App::run` opens real windows, and
CI has no display and no GPU context. macOS passed because it builds the dummy
backend. That is structural, not stale.

So `ase` now exports `ase_is_headless` and `bqui` compiles `test/apptest.cpp`
only where the headless backend is built. The app loop is otherwise verified by
running the app.

## Verified

- All twelve CI legs green, plus `ci-success`.
- `clang-cl` Debug + Release and `msvc-17` Release locally: build and tests
  green.
- The headless backend forced on locally so `apptest.cpp` compiles and runs;
  both tests pass. They also run for real on the macOS legs. Their assertions
  were rewritten after review to be able to fail: a window's title is read once
  per glue built, so counting reads observes an opening and catches a rebuild,
  and both tests cap their frames so a stalled script fails instead of hanging.
- `testapp1` driven with synthetic input through: open the second window, close
  it from its **own title bar**, reopen, close it from its **own button**, then
  close the main window and confirm that ends the app. Screenshots of the main
  window at each step show it still animating and still interactive.

## Known gaps, and why the animation one does not block this

Making self-removal the idiom raises the obvious question of whether the
`AnimationGuard` gap is now on the main path. **It is not, and here is the
reason rather than the assertion:** the close path never transacts at all.
`WindowGlue`'s close callback only invokes the window's own callbacks and
returns — no `makeTransaction`, no signal evaluation — so removing a window from
its `onClose` is safe *by construction*, not by the frame-phase rule. The other
half of the idiom, a button inside the window, is safe by that rule. Neither
opens an animation scope.

Reaching the `AnimationGuard` gap therefore takes an author explicitly wrapping
a *removal* in `withAnimation`, and there is no window-level exit animation in
the toolkit that would make that routine — `withAnimation` marks widget signal
changes, and a window being destroyed has no render tree left to animate.
Verified by running: title-bar close, widget-button close, reopen, and quit, all
clean.

What the fix would need, so it can be scoped as its own PR: `AnimationGuard`
must stop being a pair of synchronous transactions of every glue. Two shapes
work — carry the options into the frame phase and let the next per-window
transaction apply them (loses the commit-before boundary for changes made
earlier in the same event drain), or give `App` a reconcile-and-defer-destruction
step the guard runs first, so departed glues leave the live set without being
destroyed under their own handler (keeps the semantics). Both need state that
today lives as locals in `App::run` moved into `AppDeferred`, and both change
observable animation behaviour, so they want their own run-the-app verification.

The second gap is unchanged: a list changed from *within* the frame phase — one
window's update removing another's key — is reconciled only on the next pass.

Both are recorded in `src/bqui/AGENTS.md` and the design doc.

Destroying a WGL window mid-run also leaves two loose ends in the render
context that were unreachable while windows lived for the whole process: the
dispatched context caches the last DC it made current and nothing invalidates
it, and with no window left the loop keeps submitting fences against a context
current on a destroyed DC. Noted in `src/ase/AGENTS.md`.

## Known open points for the reviewer

- Gating `apptest.cpp` on `ase_is_headless` means it compiles only on macOS. A
  build option that forces the dummy backend for the test binary would decouple
  the two.
- `App::run()`'s close wiring now reaches windows opened later, so closing any
  window ends the app. That is the pre-existing meaning of the no-argument
  `run()`, applied to a list that can grow, and it is now said in its Doxygen —
  a list whose windows come and go wants `run(running)`. `testapp1` switched to
  that so its two windows can close to different effect.

Both clean-context reviews were run again after the observer removal and their
findings applied.

Draft: the whole stack is gated pending review.
