### PR TITLE
Verify the render tree by drawing it

### DIFF
--- a/src/avg/include/avg/drawcontext.h
+++ b/src/avg/include/avg/drawcontext.h
@@ -12,9 +12,6 @@ namespace avg
 
     /**
      * @brief The memory a draw allocates its result out of.
-     *
-     * Drawing a render tree produces paths, shapes and drawings and nothing
-     * else, so memory is all a node ever asks of its context.
      */
     class AVG_EXPORT DrawContext
     {
@@ -28,8 +25,7 @@ namespace avg
          * @brief Allocates out of @p memory alone, with no rendering back end.
          *
          * A tree drawn this way yields the same avg::Drawing it would on
-         * screen, so drawing can be exercised where no graphics context
-         * exists.
+         * screen.
          */
         explicit DrawContext(pmr::memory_resource* memory);
 

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -174,6 +174,12 @@ owning `Window`.
   means having the builder hand out one shared hint signal rather than a fresh
   one per call — builder plumbing, not layout — which is why it is recorded here
   instead of patched at the call site.
+- Geometry recovered from input areas (`test/layouttest.cpp`) says nothing about
+  the render tree: a node placed wrongly, one that cannot be drawn at all, or
+  one paired with the wrong sibling across an update all leave the input areas
+  intact. Anything that only manifests when drawing belongs in
+  `test/rendertreetest.cpp`, which splices realised instances the way the window
+  loop does and asserts on the `avg::Drawing` that comes out.
 
 For cross-cutting rules (the `Any` convention, include-dir firewall, symbol
 visibility) see `docs/conventions.md`; do not restate them here.

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -118,6 +118,7 @@ bquitestsrc = [
   'test/introspectionjsontest.cpp',
   'test/introspectiontest.cpp',
   'test/layouttest.cpp',
+  'test/rendertreetest.cpp',
   'test/sessiontest.cpp',
   'test/shapetest.cpp',
   'test/transporttest.cpp',

--- a/src/bqui/test/rendertreetest.cpp
+++ b/src/bqui/test/rendertreetest.cpp
@@ -1,0 +1,416 @@
+#include <bqui/modifier/ondraw.h>
+#include <bqui/modifier/setsizehint.h>
+
+#include <bqui/widget/hbox.h>
+#include <bqui/widget/widget.h>
+
+#include <bqui/buildparams.h>
+#include <bqui/simplesizehint.h>
+#include <bqui/sizehint.h>
+
+#include <bq/signal/arraysignal.h>
+#include <bq/signal/constant.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+
+#include <avg/animationoptions.h>
+#include <avg/brush.h>
+#include <avg/color.h>
+#include <avg/curve/curves.h>
+#include <avg/drawcontext.h>
+#include <avg/drawing.h>
+#include <avg/obb.h>
+#include <avg/rect.h>
+#include <avg/rendertree.h>
+#include <avg/vector.h>
+
+#include <pmr/new_delete_resource.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace bqui;
+using namespace bqui::widget;
+
+namespace
+{
+
+using Milliseconds = std::chrono::milliseconds;
+using Children = std::vector<bq::signal::ArraySignal<AnyWidget>>;
+
+/**
+ * @brief Where one probe was drawn, and which probe it was.
+ *
+ * The color is the identity: it is carried by the draw function a render
+ * tree node holds, so it says which probe's drawing this is however the tree
+ * was spliced. The bounds are in window coordinates, with the origin at the
+ * bottom-left corner.
+ */
+struct DrawnRect
+{
+    avg::Color color;
+    avg::Rect bounds;
+};
+
+avg::Color const red(1.0f, 0.0f, 0.0f, 1.0f);
+avg::Color const green(0.0f, 1.0f, 0.0f, 1.0f);
+avg::Color const blue(0.0f, 0.0f, 1.0f, 1.0f);
+
+SizeHintResult const fixed50 = {{ 50.0f, 50.0f, 50.0f }};
+SizeHintResult const fixed100 = {{ 100.0f, 100.0f, 100.0f }};
+SizeHintResult const fixed150 = {{ 150.0f, 150.0f, 150.0f }};
+
+avg::Color colorOf(size_t index)
+{
+    switch (index)
+    {
+    case 0:
+        return red;
+    case 1:
+        return green;
+    default:
+        return blue;
+    }
+}
+
+SizeHint hintOf(size_t index)
+{
+    switch (index)
+    {
+    case 0:
+        return simpleSizeHint(fixed100, fixed50);
+    case 1:
+        return simpleSizeHint(fixed50, fixed50);
+    default:
+        return simpleSizeHint(fixed150, fixed50);
+    }
+}
+
+avg::Drawing fillSlot(avg::DrawContext const& context, avg::Vector2f size,
+        avg::Color const& color)
+{
+    return context.pathBuilder()
+        .start(0.0f, 0.0f)
+        .lineTo(size[0], 0.0f)
+        .lineTo(size[0], size[1])
+        .lineTo(0.0f, size[1])
+        .close()
+        .fill(avg::Brush(color));
+}
+
+/**
+ * @brief A widget that fills whatever it is given, in the color @p index
+ *        names.
+ *
+ * Unlike an input area, what this leaves behind is reachable only by drawing:
+ * it is a node in the render tree and nowhere else. The color rides on that
+ * node, so it says which probe a drawn shape came from however the tree was
+ * spliced.
+ */
+AnyWidget drawProbe(bq::signal::AnySignal<size_t> index)
+{
+    auto shared = index.share();
+
+    return makeWidget()
+        | modifier::setSizeHint(shared.map(&hintOf))
+        | modifier::onDraw(&fillSlot, shared.map(&colorOf))
+        ;
+}
+
+/** @overload */
+AnyWidget drawProbe(size_t index)
+{
+    return drawProbe(bq::signal::constant(index));
+}
+
+/**
+ * @brief A widget that takes up the same room but draws nothing at all.
+ */
+AnyWidget blankProbe(size_t index)
+{
+    return makeWidget()
+        | modifier::setSizeHint(hintOf(index))
+        ;
+}
+
+/**
+ * @brief Splices and draws a render tree the way the window loop does.
+ *
+ * Every realised Instance is spliced onto the tree the previous one produced,
+ * which is what turns a change in the widget tree into an animation and what
+ * makes the tree pair its nodes up. Drawing is a pure function of the
+ * timestamp, so a draw part-way through an animation shows which node is
+ * moving where.
+ */
+class TreeDriver
+{
+public:
+    TreeDriver(avg::Vector2f size, Milliseconds animationDuration) :
+        size_(size),
+        animationOptions_(avg::AnimationOptions{
+                animationDuration, avg::curve::linear })
+    {
+    }
+
+    void splice(Instance const& instance, Milliseconds time)
+    {
+        avg::RenderTree next = instance.getRenderTree();
+
+        tree_ = std::move(std::move(tree_).update(
+                std::move(next),
+                animationOptions_,
+                time
+                ).first);
+    }
+
+    std::vector<DrawnRect> draw(Milliseconds time)
+    {
+        avg::DrawContext context(pmr::new_delete_resource());
+
+        auto [drawing, animating] = tree_.draw(context, avg::Obb(size_), time);
+
+        animating_ = animating;
+
+        std::vector<DrawnRect> result;
+
+        for (auto const& element : drawing.getElements())
+        {
+            auto const* shape = std::get_if<avg::Drawing::ShapeElement>(
+                    &element);
+
+            if (!shape || !shape->brush)
+                continue;
+
+            result.push_back(DrawnRect{
+                    shape->brush->getColor(),
+                    shape->shape.getControlBb()
+                    });
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Whether the last draw left anything still moving.
+     */
+    bool animating() const
+    {
+        return animating_;
+    }
+
+private:
+    avg::RenderTree tree_;
+    avg::Vector2f size_;
+    std::optional<avg::AnimationOptions> animationOptions_;
+    bool animating_ = false;
+};
+
+std::optional<avg::Rect> boundsOf(std::vector<DrawnRect> const& rects,
+        avg::Color const& color)
+{
+    for (auto const& rect : rects)
+        if (rect.color == color)
+            return rect.bounds;
+
+    return std::nullopt;
+}
+
+void expectDrawnAt(std::string const& label,
+        std::vector<DrawnRect> const& rects, avg::Color const& color,
+        float x, float y, float width, float height)
+{
+    SCOPED_TRACE(label);
+
+    auto bounds = boundsOf(rects, color);
+
+    ASSERT_TRUE(bounds.has_value()) << "probe was not drawn";
+
+    EXPECT_FLOAT_EQ(x, bounds->getLeft());
+    EXPECT_FLOAT_EQ(y, bounds->getBottom());
+    EXPECT_FLOAT_EQ(width, bounds->getWidth());
+    EXPECT_FLOAT_EQ(height, bounds->getHeight());
+}
+
+void expectNotDrawn(std::string const& label,
+        std::vector<DrawnRect> const& rects, avg::Color const& color)
+{
+    SCOPED_TRACE(label);
+
+    EXPECT_FALSE(boundsOf(rects, color).has_value());
+}
+
+avg::Vector2f const row(300.0f, 50.0f);
+
+Milliseconds const duration(100);
+Milliseconds const start(0);
+Milliseconds const halfway(50);
+
+/**
+ * @brief A row of probes whose membership the test drives.
+ *
+ * Each probe is keyed by the index that names it, so a probe keeps its
+ * identity across removals and reorderings.
+ */
+AnyWidget dynamicRow(bq::signal::AnySignal<std::vector<size_t>> indices)
+{
+    return hbox(bq::signal::forEach(std::move(indices),
+            [](size_t index)
+            {
+                return index;
+            },
+            [](bq::signal::AnySignal<size_t> index)
+            {
+                return drawProbe(std::move(index));
+            }));
+}
+
+bq::signal::FrameInfo nextFrame(uint64_t frameId)
+{
+    return bq::signal::FrameInfo(frameId, std::chrono::microseconds(0));
+}
+
+} // anonymous namespace
+
+TEST(RenderTree, everyChildDrawsInTheSlotTheLayoutGaveIt)
+{
+    // Where a child ends up on screen is decided entirely inside the render
+    // tree: the layout hands each child a transform, every enclosing node
+    // contributes its own on the way down, and only the drawing says what the
+    // sum of them was. A node that repeats a transform its child already
+    // carries draws that child at twice the offset it was laid out at.
+    Children children;
+    children.push_back(drawProbe(0));
+    children.push_back(drawProbe(1));
+    children.push_back(drawProbe(2));
+
+    auto context = bq::signal::makeSignalContext(
+            hbox(std::move(children))(BuildParams())(
+                bq::signal::constant(row)).getInstance());
+
+    TreeDriver driver(row, duration);
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    auto rects = driver.draw(start);
+
+    ASSERT_EQ(3u, rects.size());
+
+    expectDrawnAt("first", rects, red, 0.0f, 0.0f, 100.0f, 50.0f);
+    expectDrawnAt("second", rects, green, 100.0f, 0.0f, 50.0f, 50.0f);
+    expectDrawnAt("third", rects, blue, 150.0f, 0.0f, 150.0f, 50.0f);
+}
+
+TEST(RenderTree, aChildThatDrawsNothingContributesNothing)
+{
+    // A layout names each of its children so that the tree can pair them up,
+    // and a child that draws nothing has no node to name. Naming one anyway
+    // leaves a node that cannot be drawn, which nothing notices until the
+    // first frame.
+    Children children;
+    children.push_back(drawProbe(0));
+    children.push_back(blankProbe(1));
+    children.push_back(drawProbe(2));
+
+    auto context = bq::signal::makeSignalContext(
+            hbox(std::move(children))(BuildParams())(
+                bq::signal::constant(row)).getInstance());
+
+    TreeDriver driver(row, duration);
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    auto rects = driver.draw(start);
+
+    ASSERT_EQ(2u, rects.size());
+
+    expectDrawnAt("first", rects, red, 0.0f, 0.0f, 100.0f, 50.0f);
+    expectDrawnAt("third", rects, blue, 150.0f, 0.0f, 150.0f, 50.0f);
+}
+
+TEST(RenderTree, removingAMiddleChildLeavesItsNeighboursNodes)
+{
+    // The tree pairs a child up with the child of the same name, so a removal
+    // takes out the node that was removed. Pairing by position instead pairs
+    // the departing child with whichever one now sits in its slot, and the
+    // last child — which nothing now pairs with — is the one that leaves.
+    auto input = bq::signal::makeInput(std::vector<size_t>{ 0, 1, 2 });
+
+    auto context = bq::signal::makeSignalContext(
+            dynamicRow(input.signal)(BuildParams())(
+                bq::signal::constant(row)).getInstance());
+
+    TreeDriver driver(row, duration);
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    input.handle.set(std::vector<size_t>{ 0, 2 });
+    context.update(nextFrame(1));
+
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    auto rects = driver.draw(halfway);
+
+    ASSERT_EQ(2u, rects.size());
+
+    expectDrawnAt("stayed put", rects, red, 0.0f, 0.0f, 100.0f, 50.0f);
+    expectNotDrawn("removed", rects, green);
+
+    // Half of the way from the slot it had to the one the removal frees up,
+    // at the size it has always had.
+    expectDrawnAt("moved up", rects, blue, 125.0f, 0.0f, 150.0f, 50.0f);
+    EXPECT_TRUE(driver.animating());
+
+    rects = driver.draw(duration);
+
+    ASSERT_EQ(2u, rects.size());
+
+    expectDrawnAt("settled left", rects, red, 0.0f, 0.0f, 100.0f, 50.0f);
+    expectDrawnAt("settled right", rects, blue, 100.0f, 0.0f, 150.0f, 50.0f);
+    EXPECT_FALSE(driver.animating());
+}
+
+TEST(RenderTree, reorderingMovesNodesRatherThanRebuildingThem)
+{
+    // A node paired with its own name animates from where it was to where it
+    // now belongs. One that was rebuilt instead has nothing to animate from
+    // and appears at its destination immediately, so a draw part-way through
+    // tells the two apart.
+    auto input = bq::signal::makeInput(std::vector<size_t>{ 0, 1, 2 });
+
+    auto context = bq::signal::makeSignalContext(
+            dynamicRow(input.signal)(BuildParams())(
+                bq::signal::constant(row)).getInstance());
+
+    TreeDriver driver(row, duration);
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    input.handle.set(std::vector<size_t>{ 2, 0, 1 });
+    context.update(nextFrame(1));
+
+    driver.splice(context.evaluate<0>().get<0>(), start);
+
+    auto rects = driver.draw(halfway);
+
+    ASSERT_EQ(3u, rects.size());
+
+    // Each probe keeps its size and is half of the way from its old slot to
+    // its new one: 0 -> 150, 100 -> 250, and 150 -> 0.
+    expectDrawnAt("first", rects, red, 75.0f, 0.0f, 100.0f, 50.0f);
+    expectDrawnAt("second", rects, green, 175.0f, 0.0f, 50.0f, 50.0f);
+    expectDrawnAt("third", rects, blue, 75.0f, 0.0f, 150.0f, 50.0f);
+    EXPECT_TRUE(driver.animating());
+
+    rects = driver.draw(duration);
+
+    expectDrawnAt("first settled", rects, red, 150.0f, 0.0f, 100.0f, 50.0f);
+    expectDrawnAt("second settled", rects, green, 250.0f, 0.0f, 50.0f, 50.0f);
+    expectDrawnAt("third settled", rects, blue, 0.0f, 0.0f, 150.0f, 50.0f);
+    EXPECT_FALSE(driver.animating());
+}

--- a/src/bqui/test/rendertreetest.cpp
+++ b/src/bqui/test/rendertreetest.cpp
@@ -51,10 +51,8 @@ using Children = std::vector<bq::signal::ArraySignal<AnyWidget>>;
 /**
  * @brief Where one probe was drawn, and which probe it was.
  *
- * The color is the identity: it is carried by the draw function a render
- * tree node holds, so it says which probe's drawing this is however the tree
- * was spliced. The bounds are in window coordinates, with the origin at the
- * bottom-left corner.
+ * The bounds are in window coordinates, with the origin at the bottom-left
+ * corner.
  */
 struct DrawnRect
 {
@@ -146,11 +144,7 @@ AnyWidget blankProbe(size_t index)
 /**
  * @brief Splices and draws a render tree the way the window loop does.
  *
- * Every realised Instance is spliced onto the tree the previous one produced,
- * which is what turns a change in the widget tree into an animation and what
- * makes the tree pair its nodes up. Drawing is a pure function of the
- * timestamp, so a draw part-way through an animation shows which node is
- * moving where.
+ * Drawing is a pure function of the passed time.
  */
 class TreeDriver
 {
@@ -166,11 +160,11 @@ public:
     {
         avg::RenderTree next = instance.getRenderTree();
 
-        tree_ = std::move(std::move(tree_).update(
+        tree_ = std::move(tree_).update(
                 std::move(next),
                 animationOptions_,
                 time
-                ).first);
+                ).first;
     }
 
     std::vector<DrawnRect> draw(Milliseconds time)
@@ -283,11 +277,7 @@ bq::signal::FrameInfo nextFrame(uint64_t frameId)
 
 TEST(RenderTree, everyChildDrawsInTheSlotTheLayoutGaveIt)
 {
-    // Where a child ends up on screen is decided entirely inside the render
-    // tree: the layout hands each child a transform, every enclosing node
-    // contributes its own on the way down, and only the drawing says what the
-    // sum of them was. A node that repeats a transform its child already
-    // carries draws that child at twice the offset it was laid out at.
+    // A repeated transform would draw a child at twice its slot offset.
     Children children;
     children.push_back(drawProbe(0));
     children.push_back(drawProbe(1));
@@ -311,10 +301,7 @@ TEST(RenderTree, everyChildDrawsInTheSlotTheLayoutGaveIt)
 
 TEST(RenderTree, aChildThatDrawsNothingContributesNothing)
 {
-    // A layout names each of its children so that the tree can pair them up,
-    // and a child that draws nothing has no node to name. Naming one anyway
-    // leaves a node that cannot be drawn, which nothing notices until the
-    // first frame.
+    // A named child that draws nothing would leave a node that cannot be drawn.
     Children children;
     children.push_back(drawProbe(0));
     children.push_back(blankProbe(1));
@@ -337,10 +324,8 @@ TEST(RenderTree, aChildThatDrawsNothingContributesNothing)
 
 TEST(RenderTree, removingAMiddleChildLeavesItsNeighboursNodes)
 {
-    // The tree pairs a child up with the child of the same name, so a removal
-    // takes out the node that was removed. Pairing by position instead pairs
-    // the departing child with whichever one now sits in its slot, and the
-    // last child — which nothing now pairs with — is the one that leaves.
+    // Pairing children by position rather than by name would remove the wrong
+    // child when a middle one leaves.
     auto input = bq::signal::makeInput(std::vector<size_t>{ 0, 1, 2 });
 
     auto context = bq::signal::makeSignalContext(
@@ -378,10 +363,8 @@ TEST(RenderTree, removingAMiddleChildLeavesItsNeighboursNodes)
 
 TEST(RenderTree, reorderingMovesNodesRatherThanRebuildingThem)
 {
-    // A node paired with its own name animates from where it was to where it
-    // now belongs. One that was rebuilt instead has nothing to animate from
-    // and appears at its destination immediately, so a draw part-way through
-    // tells the two apart.
+    // A reordered node should animate from its old slot; a rebuilt one would
+    // appear at its destination immediately.
     auto input = bq::signal::makeInput(std::vector<size_t>{ 0, 1, 2 });
 
     auto context = bq::signal::makeSignalContext(


### PR DESCRIPTION
## What

Adds `src/bqui/test/rendertreetest.cpp`: tests that actually **draw** the
render tree and assert on the `avg::Drawing` that comes out.

Stacked on `hbox-unified-layout` (#116) at `7732de0`. `foreach-keyed-delegate`
(#117) has **not** been rebased onto that commit yet, so this branches from
#116's tip.

**Depends on #119** (`headless-drawcontext`), which is branched from `master`
and independently mergeable. Its single commit is cherry-picked here so this
branch builds; it drops out cleanly when #119 merges.

## The gap

`bqui`'s layout tests recover geometry from **input areas**. An input area
travels from a leaf to the root Instance untouched by anything the render tree
does, so it stays intact when a node is placed at the wrong transform, cannot
be drawn at all, or is paired with the wrong sibling across an update. Three
defects went through that hole in as many days, and the `Layout.*` tests
constructed a render tree that faulted on its first frame *and passed*.

## The tests

A probe fills whatever room it is given in a colour. The colour rides on the
render-tree node, so it identifies which probe a drawn shape belongs to however
the tree was spliced; the shape's control bounds say where the tree put it. A
`TreeDriver` splices each realised Instance onto the tree the previous one
produced - what the window loop does - so a membership change becomes an
animation, and a draw part-way through one shows which node moved where.

- `everyChildDrawsInTheSlotTheLayoutGaveIt` - three probes in a 300x50 row draw
  at 0/100/150 at the widths the layout gave them.
- `aChildThatDrawsNothingContributesNothing` - a blank middle child leaves
  exactly two shapes, and the neighbours stay where they were.
- `removingAMiddleChildLeavesItsNeighboursNodes` - the middle child goes, its
  left neighbour does not move, and its right neighbour is **half way** from
  the slot it had to the one the removal frees up, at its own size.
- `reorderingMovesNodesRatherThanRebuildingThem` - after a reorder each probe
  is half way from its old slot to its new one. A rebuilt node would have
  nothing to animate from and would appear at its destination immediately.

## Each defect verified red

Reintroduced one at a time, rebuilt, and re-run:

| Defect | Reintroduced by | Result |
| --- | --- | --- |
| `IdNode` given the instance's full obb (double offset) | `setid.cpp`: `avg::Obb(instance.getSize())` -> `instance.getObb()` | all 4 tests fail; offsets come out at exactly double (100->200, 150->300, 125->250, 75->150) |
| `IdNode` wrapping an empty tree (null child) | `setid.cpp`: drop the empty-tree guard | `aChildThatDrawsNothingContributesNothing` aborts on `assert(childNode_)` in `avg::IdNode` - the very assert that made the fix's own unit test possible, now reached through a draw |
| children unnamed, so `ContainerNode` pairs by position | `layout.cpp`: drop `setElementId` from `buildChild` | `removingAMiddleChild...` and `reordering...` fail; **the other 52 tests all pass**, so this defect escapes the entire existing suite |

For the removal case the failure is exactly the reported symptom: the departing
child's node is drawn wearing its right neighbour's colour, at width 100
instead of 150 and at x=100 instead of 125 - the last child is the one that
left.

## Found along the way (not fixed here)

Two pre-existing bugs the correctness review turned up while checking these
assertions. Neither affects the tests as written; both bound what a future
render-tree assertion can rely on:

- `avg::Shape::getControlBb` (`src/avg/src/shape.cpp:164,173,182`) applies a
  composed element's transform **twice** in the `Operation` branch - it passes
  `transform * e.transform` to an overload that multiplies by `e.transform`
  again. The `StrokeToShape` branch alongside it is correct. Only single-`Path`
  shapes are used here, so nothing in this PR trips it.
- `avg::RenderTree::update` (`src/avg/src/rendertree/rendertree.cpp:52`) builds
  a `newRoot` fallback for an empty incoming tree and then ignores it, calling
  `tree.root_->update(...)` - a null dereference one empty-widget-tree test
  away. `TreeDriver::splice` is a new caller of that path but never an empty
  one.

## Docs

`src/bqui/AGENTS.md` records what input-area geometry cannot see and where a
drawing-visible property belongs.

## Verification

Built and run with `CC=clang-cl CXX=clang-cl`, debug. All four suites green
(btl, bq, avg, bqui - 54 bqui tests).

