### PR TITLE
Let App own its windows via decoupled value handles

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,9 +1,92 @@
 # Decisions
 
-*Last verified against `9c47767` (2026-07-21).*
+*Last verified against `f52d7f2` (2026-07-23), for the window-handle rework.*
 
 Why non-obvious choices were made, so they are not re-litigated. Newest first.
 Each entry is intentionally short: the decision and its rationale.
+
+## A `Window` is a handle; its widget is supplied at `addWindow`
+
+A `Window` is a small value handle over shared, persistent data (identity,
+title, close callbacks) — `std::shared_ptr<WindowData>`. It holds none of the
+window's contents. The widget is supplied to `App::addWindow(window, widget)` at
+mount time and lives in the app-owned `WindowImpl` (which absorbed the old
+`WindowGlue`), not on the window. `removeWindow`/`Window::close` unmount and
+destroy the impl and its widget; the window's data persists as long as a
+`Window` naming it is held, so a re-add is a clean remount that re-supplies a
+fresh widget. `WindowData` links back to the app only weakly, so it is a
+strong-leaf.
+
+**Why:** it decouples the widget from the window so a widget can capture the
+very `Window` that owns it — a close button is `[w]{ w.close(); }` — with no
+retain cycle. The strong chain is `App → WindowImpl → widget → closure → Window
+→ WindowData`, and `WindowData`'s only link back (to the app) is weak, so
+closing the window tears the impl down and the captured handle with it. Before
+this, the widget lived on the `Window`, so a window captured in its own widget
+owned the widget that owned it; the workaround was a separate `WindowHandle`
+minted ahead of the window and captured in its place. Folding that weak
+back-reference into `WindowData` and moving the widget to the impl deletes
+`WindowHandle` outright — the `Window` is the handle now — and makes
+remove/re-add an ordinary unmount/remount rather than a special case.
+
+The cost is that the widget is no longer part of a window's identity: a re-add
+must re-supply one, and there is no way to persist a widget across a remove. That
+is the intended model — the widget is mount-time content — not a limitation to
+route around.
+
+## `App`'s window collection is imperative, not an `ArraySignal`
+
+`App` holds its windows in a plain, thread-safe collection
+(`bq::signal::SharedVector<Window>` behind `WindowList`) reached with
+`addWindow`/`addWindows`, `removeWindow` and `Window::close`. `getWindows`
+snapshots it and `getWindowsSignal` observes it, but that signal is a *report*,
+not the source: nothing derives the windows from a signal. The run loop reads
+the collection each frame and syncs one `WindowGlue` per window to it with a
+plain O(n) set-diff — build a glue for a window that has none, tear down a glue
+whose window has left.
+
+An earlier design (PR #121's first form) made the window set an
+`ArraySignal<Window>`: the loop mapped the array to one glue per identity, joined
+the glues, and reconciled a cached glue vector from that signal each frame, with
+a second caller-driven `addWindowArray` path for windows a caller's own model
+owned.
+
+**Why the change:** a window is an imperative OS resource — an `ase::Window`, a
+framebuffer, input state — created and destroyed by the app, not a value derived
+from data. Modelling the *set* of them as a signal solved a matching problem the
+signal itself created: `forEach` earns its keep when a delegate must not rebuild
+a surviving item as its neighbours change, but `App` never had that problem —
+the window *is* the stable identity, held by value, and a set-diff over ids is
+all "keep the survivor, drop the departed" needs. Removing the signal layer
+deleted `addWindowArray`, `takeAllWindows`, the `join`-of-glues, the fused
+two-signal loop context, and the signal-driven `collect()` reconcile, and left a
+shorter run loop whose glue lifecycle reads straight down the page. `ArraySignal`
+and `forEach` stay in `bq` — the layout engine is their real consumer; `App`
+simply was not one.
+
+## `App::run()` with no arguments stops at zero windows, not at the first close
+
+`run()` used to stop when *any* window closed; it now runs while a window
+remains in the collection. It is not a rule of the loop: `run()` with no
+argument builds a default `running` signal from that collection — true while it
+holds a window, false when the last one leaves — and passes it to the same loop
+`run(running)` drives, which is unchanged and stops when its signal says so. A
+caller who wants another policy, such as outliving an empty collection, passes a
+`running` signal of its own.
+
+**Why:** the app owns its windows now, so closing one is a removal and not an
+exit — that is what makes a close button, a title bar, and `removeWindow` one
+thing. "Stop at the first close" only ever described a single-window app, and it
+described it by accident: with one window the two rules agree. Making the default
+an ordinary signal rather than a special case in the loop is what lets a caller
+replace it: an app that wants the old behaviour passes `run(running)` an
+`onClose` that sets the signal false.
+
+**The cost is real and accepted.** A multi-window app that relied on the main
+window closing the whole app now has to say so. There is no deprecation path
+worth building for it: the call is the same and only the meaning changed, so a
+compiler cannot help, and the behaviour it changes to is the one a reader
+expects from the name.
 
 ## A draw context is memory, nothing more
 

--- a/docs/design/arraysignal.md
+++ b/docs/design/arraysignal.md
@@ -1,9 +1,10 @@
 # Design: `ArraySignal<T>`, `forEach`, and one layout engine
 
-> **Status: revised design, implementation started.** Steps 0 to 3 of
-> *Implementation order* have landed; everything in `bqui` is
-> outstanding, and this document has been amended to describe what was built
-> rather than what was first proposed. The earlier implementation on PR #100 is
+> **Status: revised design, implementation started.** All of `bq` —
+> `ArraySignal`, `forEach`, `scatter`/`join`, `SharedVector` — has landed; the
+> layout rework is outstanding. This document has been amended to describe what
+> was built rather than what was first proposed. The earlier implementation on
+> PR #100 is
 > a **superseded spike**:
 > it put the per-identity table in the description rather than in the
 > `SignalContext`, which is a correctness defect, not a limitation. This revision
@@ -15,7 +16,22 @@
 > `docs/conventions.md`, the settled *why* to `docs/decisions.md`, and the API
 > contract to Doxygen in the new headers — and this file goes away.
 
-*Last verified against `86ddac5` (2026-07-21).*
+> **`App` is no longer a consumer of this design.** An early step made `App`'s
+> window set an `ArraySignal<Window>`; that has since been reverted — the window
+> collection is imperative again (add/remove/close), because a window is an OS
+> resource the app creates and destroys, not a value derived from a signal (see
+> `docs/decisions.md`). The `bq` operators stay: the **layout engine** is their
+> real consumer, and it is the one this document is ultimately for. The sections
+> below still cite `App` as the worked case for the *exit* and the
+> *element-signal* rules because it was the case that settled them; treat those
+> as the reasoning that produced the rules, not as a description of `App` today.
+> `App` has since evolved further still — a `Window` is a handle and its widget
+> is supplied at `addWindow`, and the per-window `WindowGlue` those sections name
+> is now `WindowImpl` (see `docs/decisions.md`) — but none of that changes the
+> `ArraySignal` reasoning below, which describes the reverted experiment.
+
+*Last verified against `77e391f` (2026-07-22), amended for the `App` revert and
+the later window-handle rework.*
 
 ## The problem
 
@@ -277,9 +293,124 @@ first draft:
   occurrence-index disambiguation (`(key, n)` entries) existed only to satisfy
   global uniqueness and is deleted.
 
-The open question the first draft raised here — whether any identity surfaces at
-the exit, for PR #99's window list and `dataBind` — is unchanged and still
-belongs to PR #99. See *Open questions*.
+### No identity surfaces at the exit
+
+**Settled by PR #99's rework, and it is the answer *Identity is internal*
+predicted.** Nothing outside an array needs an id, so there is **no id-pair
+exit**: a consumer of a changing list takes an `ArraySignal<T>` and builds what
+it needs per identity with `map`, rather than being handed
+`AnySignal<vector<pair<size_t, T>>>` and reconciling by hand.
+
+`App` was the worked case (it has since reverted to an imperative collection —
+see the note at the top — but it is what settled this). It took an
+`ArraySignal<Window>` and built one `WindowGlue` per identity; the by-id
+reconcile loop and the producer-assigned `size_t` were deleted, and what
+replaced them was not a translation of the loop — the loop *is* `ArrayOnce`. The
+other consumer the open question named, `dataBind`, is retired wholesale at step
+6 rather than re-typed, so nothing there reopens it.
+
+Four findings from doing it, because each one generalises past `App`:
+
+- **The consumer's `map` is the reconcile.** `map` runs once per identity and
+  its result is destroyed when the identity leaves, which is exactly
+  create-on-arrive / destroy-on-depart. A consumer whose per-item object is
+  expensive or owns an OS resource needs no more than that.
+- **A non-signal value leaves as a constant.** `App`'s per-item value is a glue,
+  not a signal, and `join` is the only exit. `map`ping it to
+  `constant(glue)` and joining reads oddly the first time and is what the exit
+  is for: *One layout engine* fans in `AnySignal<SizeHint>`s that were already
+  signals and so never met this, which is why `join`'s Doxygen now says so.
+- **The exit gives the consumer a plain vector, and that is enough.** Everything
+  `App` did with ids — iterating live glues, tearing down departed ones — is a
+  fold over that vector. The id was never carrying information the consumer
+  could not read off the list.
+- **The consumer owes no change notification either.** The first attempt kept
+  the window-list observer PR #99 had and only re-typed what it reported. That
+  was backwards: the list is the source of truth, so what an item offers is
+  wired *back into what the list is built from* — a window's close callback
+  removes its own key — and there is nothing left for a notification to be
+  for. A consumer that thinks it needs one is usually holding a second copy of
+  the membership. Nothing of the kind shipped.
+
+### An element's signal may not be read on a clock of its own
+
+**A constraint this design did not state, and the first `bqui` consumer broke
+it.** *The pick construction* requires that a pick be dropped "no later than the
+update that observes the key leaving". A consumer that reads the element's
+signal only inside the array's own update pass gets that for free: the source
+changes, the node retires the key, and nothing evaluates the departed pick
+again. The unified layout engine will be such a consumer, which is why the
+obligation looked like a formality.
+
+`App` was not. Each `WindowGlue` holds the window's title and widget signals in
+its **own** `SignalContext`, updated from OS input handlers. An `Input` is
+global to every context, so a handler that removed a window's key — a window
+with its own close button — made that window's next update read a pick whose key
+had just left, and `requirePresent` threw out of the event loop and took the
+process down. Reproduced in `testapp1`, whose second window is now exactly that
+button.
+
+The fix is not to soften `requirePresent`; a latch here would hand back a stale
+value, which *The pick construction* already rejects. It is to give the element's
+signals one clock: `WindowGlue`'s input handlers now request a frame instead of
+transacting inline, so every per-window update happens after the array has been
+reconciled and a departed window's glue is gone before anything can update it.
+
+State it as a rule for the next consumer:
+
+> **Read an element's signal only where the array is updated.** A consumer that
+> drives per-element signals on a schedule of its own must reconcile the array
+> first, and must destroy what it built for a departed identity before that
+> schedule comes round again.
+
+Note what the fix does *not* rest on. The close path — the idiom for removing a
+window — never transacts at all: the glue's close callback only invokes the
+window's own callbacks and returns, so removal from `onClose` is safe by
+construction. The deferral above is what makes removal safe from a *widget* in
+the window, which is the other half of the idiom.
+
+`App` still does not fully satisfy the rule for a caller-supplied array, and the
+remainder is recorded in `src/bqui/AGENTS.md` rather than hidden:
+`AnimationGuard` brackets a `withAnimation` scope with two synchronous
+transactions of every window, and a list changed from inside the frame phase is
+reconciled only on the next pass. Both need the app loop's update model changed
+rather than a local guard, which is why they are not in this change. The lesson
+for the design is the rule above: a consumer with its own clock is the hard
+case, and the layout engine's being free of it is a property of the layout
+engine, not of the array.
+
+The one thing the caller loses is the ability to have a single `forEach` build
+*differently shaped* items, since the delegate is handed the item's value and
+not its key. That is not a gap: the caller writes one array per shape and
+concatenates them, which is what the braced-list constructor is for.
+
+### Reading an element's signal once, versus driving it on a clock
+
+**Settled when `App` grew its own window collection.** The rule above forbids
+*driving* an element's signal on a schedule of the consumer's own. It does not
+forbid **reading it once**, when the identity appears, which is what a consumer
+that builds something per element wants anyway.
+
+`App` is the worked case in both directions. `App::run` maps
+`ArraySignal<AnySignal<Window>>` to one `WindowGlue` per identity, and the glue
+holds the element signal in a `SignalContext` that it evaluates in its
+constructor and **never updates**. There is nothing later to read — an element
+cannot vary at a fixed identity — so the read that would encounter a departed
+key never happens. Everything the glue drives per frame is the *window's own*
+signals, its title and its widgets, which came out of that one read and are not
+the array's.
+
+That is what makes self-removal safe on this path, and it is worth being precise
+about why, because the tempting wrong answer is to freeze the value into the
+array. An operator that handed back the item's value rather than its signal
+would discard later values under the same key, silently, for every caller — a
+different operator wearing the identity delegate's name. The freeze belongs to
+the consumer that knows its elements do not vary, not to the vocabulary.
+
+So the rule stands unchanged, with its scope made explicit:
+
+> An element's signal may be **read once**, when its identity appears. What it
+> may not be is *driven* — updated on a clock the array does not control.
 
 ### The reactive subtree: `AnySignal<ArraySignal<T>>`
 
@@ -1586,27 +1717,12 @@ per item and is not something this design can avoid, so a long-lived window whos
 list churns still accumulates dead entries. Pre-existing, but this is the first
 design that reaches it at churn rate.
 
-**PR #99 (dynamic windows)** is open, and makes `App`'s window list
-`AnySignal<std::vector<std::pair<size_t, Window>>>` with a caller-assigned
-stable id. It is expected to be reworked onto `ArraySignal<Window>`. Note that
-`App` no longer owns an id allocator under this design — the `ArraySignal` does —
-so the rework is `forEach` over the window list rather than a
-consumer-side reconcile. See *Open questions*.
-
 ## Open questions
 
 Points the design does not settle. Flagged rather than guessed. Sharing within a
 single context is *not* one of them — it is a supported mechanism with an
 existing reference implementation; see *Sharing: `SharedArraySignal`*.
 
-- **Does any identity surface at the exit?** Unchanged from the first draft, and
-  still the one open question that changes code outside this design. *Identity is
-  internal* argues that nothing outside needs an id, which taken to its conclusion
-  means there is **no id-pair exit at all**: `App` would take an
-  `ArraySignal<Window>` and use `forEach` rather than being handed
-  `AnySignal<vector<pair<size_t, Window>>>` and reconciling by hand. The two live
-  consumers are PR #99's window list and `dataBind`
-  (`src/bqui/include/bqui/databind.h:22`). Decide it when PR #99 is reworked.
 - **The reactive subtree `AnySignal<ArraySignal<T>>`.** Still unimplemented and
   still unreconciled: the identity algebra says only construction and `forEach`
   mint identity, but this constructor hands out fresh ids on every swap. Either
@@ -1628,7 +1744,7 @@ Written for a from-scratch implementation. The spike on PR #100 is superseded an
 should not be extended; read it for the `join` fixes and the test cases, and
 otherwise start clean.
 
-Steps 0 to 3 are done; the rest is outstanding.
+Steps 0 to 4 are done; the rest is outstanding.
 
 0. **Fix `DataContext::initializeData`'s assert.** *Done.* A **prerequisite**,
    not a nicety. `data_` holds `weak_ptr`s and the assert required the id to be
@@ -1660,18 +1776,44 @@ Steps 0 to 3 are done; the rest is outstanding.
    the aggregate. The size-alignment check is that zip; what it reaches is
    *Alignment is a promise, and only its arity is checked*.
 
-4. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
+4. **`App`'s window list.** *Reverted.* This was the first `bqui` consumer and
+   the one that settled *No identity surfaces at the exit*: `App::run` built a
+   `WindowGlue` per identity with `map`, joined the glues through a constant, and
+   read the live set off the fanned-in vector, over a `SharedVector<Window>`
+   keyed by `forEach`, with an `addWindowArray` path for a caller's own model.
+   It has since been undone — `App`'s window collection is imperative again (see
+   `docs/decisions.md`), because a window is an OS resource rather than
+   signal-derived data. The rules it settled stand; `App` no longer exercises
+   them. The **layout engine** (steps 5-6) is the consumer that does.
+
+5. **Unify `layout()`** over `map`/`scatter`/`join`, keeping the existing
    `SizeHintMap`/`ObbMap` signature so `box`, `stack` and `uniformGrid` are
    unaffected. Delete the dead heterogeneous tuple path
    (`accumulateSizeHintsTuple`, `MapObbs`) at the same time.
 
-5. **Delete `dynamicBox`.** `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
+6. **Delete `dynamicBox`.** `hbox`/`vbox` take an `ArraySignal<AnyWidget>` and
    route to the unified `layout()`. This is where the missing `handleGravity()`
    and the element-cache bug disappear. Retire `dataBind` /
    `dataSourceFromCollection` here, porting `src/bqui/test/databindtest.cpp:18`
    and `src/testapp1/adder.cpp:84`.
 
 Steps 0-3 are `bq` only and land before anything in `bqui` changes.
+
+Step 4 also fixed an `ase` defect it was the first thing to reach: the WGL
+backend never destroyed a window's `HWND`, so closing a window at runtime left a
+dead one on screen that painted nothing and answered no input. Nothing could
+close a window while the app ran before this step, which is why it had gone
+unnoticed. The GLX backend has always destroyed its window.
+
+### `App::run` can only be tested where the backend is headless
+
+`App::run` opens windows, so on the GLX and WGL backends a test of it needs a
+display and a GPU context that a CI runner does not have.
+`src/bqui/test/apptest.cpp` is therefore compiled only where `ase` builds its
+headless backend, which `ase_is_headless` in `src/ase/meson.build` reports.
+Anything else that wants end-to-end coverage of the app loop inherits the
+constraint, and the way out is to inject the platform into `App` rather than to
+weaken the test — nothing has needed that yet.
 
 ### Tests the departed-key invariant requires
 

--- a/readme.md
+++ b/readme.md
@@ -34,19 +34,15 @@ using namespace bqui;
 int main()
 {
     return app()
-        .windows({
-            window(
-                bq::signal::constant<std::string>("Hello"),
-                widget::label("Hello, world!")
-            )
-        })
+        .addWindow(window(bq::signal::constant<std::string>("Hello")),
+            widget::label("Hello, world!"))
         .run();
 }
 ```
 
-`app()` creates an application, `.windows({ ... })` gives it one or more windows,
-and `.run()` opens them and runs until they close. Each `window` takes a title
-and a widget to show.
+`app()` creates an application, `.addWindow(...)` gives it a window, and
+`.run()` opens the windows and runs until none is left. Each `window` takes a
+title; the widget is supplied to `addWindow`.
 
 ---
 
@@ -307,9 +303,8 @@ widget::AnyWidget counter()
 int main()
 {
     return app()
-        .windows({
-            window(bq::signal::constant<std::string>("Counter"), counter())
-        })
+        .addWindow(window(bq::signal::constant<std::string>("Counter")),
+                    counter())
         .run();
 }
 ```

--- a/src/ase/AGENTS.md
+++ b/src/ase/AGENTS.md
@@ -1,6 +1,6 @@
 # ase — agent notes
 
-*Last verified against `d2e8954` (2026-07-13).*
+*Last verified against `77e391f` (2026-07-22).*
 
 The GPU + platform layer. Concepts are in `readme.md`; project-wide conventions
 are in the top-level `docs/`.
@@ -18,6 +18,21 @@ are in the top-level `docs/`.
 - The Windows GPU/rendering path lives under `src/windows/` and `src/gl/` — this
   is where to look for Windows rendering performance or context-selection issues
   (integrated-vs-discrete GPU, vsync).
+- A backend owns its window's lifetime in the `WindowImpl` destructor —
+  `GlxWindow` destroys its X window there and `WglWindow` its `HWND`. Leaving
+  that out does not fail a test: nothing closes a window while the app runs
+  unless the window list says to, so the symptom is a dead window left on
+  screen. The WGL backend was missing it until a window list became reactive.
+- **Unfixed:** destroying a WGL window mid-run leaves two loose ends that were
+  unreachable while windows lived for the whole process, and became reachable
+  when the window list did. `WglDispatchedContext` caches the last DC it made
+  current and nothing invalidates that entry, so a recycled `HDC` can make it
+  skip a `wglMakeCurrent` it needed; and with no window left the run loop keeps
+  submitting fences against a context current on a destroyed DC. Releasing the
+  context from the window's destructor would close both, and has to be
+  dispatched to the render thread.
+- `src/ase/meson.build` sets `ase_is_headless`, which is how a dependent decides
+  whether a test may open a window (`src/bqui/meson.build` uses it).
 - The root `meson.build` adds MSVC-style flags (`/wd4251`, `/bigobj`, `/UNICODE`)
   for any Windows build; those assume an MSVC-compatible driver, which is why
   clang must be `clang-cl`, not `clang++` (the build notes in the repo-root

--- a/src/ase/include/ase/wglwindow.h
+++ b/src/ase/include/ase/wglwindow.h
@@ -15,6 +15,11 @@ namespace ase
     public:
         WglWindow(WglPlatform& platform, Vector2i size, float scalingFactor);
 
+        WglWindow(WglWindow const&) = delete;
+        WglWindow& operator=(WglWindow const&) = delete;
+
+        ~WglWindow();
+
         HWND getHwnd() const;
         HDC getDc() const;
 

--- a/src/ase/include/ase/windowimpl.h
+++ b/src/ase/include/ase/windowimpl.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <functional>
 #include <chrono>
+#include <optional>
 
 namespace ase
 {

--- a/src/ase/meson.build
+++ b/src/ase/meson.build
@@ -24,6 +24,11 @@ glsrcs = [
   'src/gl/glrenderqueue.cpp'
   ]
 
+# Whether the backend built here is the headless "dummy" one. A test that
+# drives a real window can only run where it is: the GLX and WGL backends need
+# a display and a GPU context that CI does not have.
+ase_is_headless = false
+
 if target_machine.system() == 'linux'
   gldep = dependency('gl')
   x11dep = dependency('x11')
@@ -57,6 +62,7 @@ elif target_machine.system() == 'windows'
     glsrcs
     ]
 else
+  ase_is_headless = true
   system_deps = []
   system_link_args = []
   system_incs = []

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -234,7 +234,11 @@ Window WglPlatform::makeWindow(Vector2i size)
     try
     {
         auto wglWindow = std::make_shared<WglWindow>(*this, size, 1.0f);
-        windows.insert(std::make_pair(wglWindow->getHwnd(), wglWindow));
+        // Assign rather than insert: Windows reuses an HWND once its window is
+        // gone, and an expired entry under that handle lingers here until the
+        // next pass of handleEvents(), where insert() would keep it and leave
+        // the new window without a receiver for its events.
+        windows[wglWindow->getHwnd()] = wglWindow;
         return Window(std::move(wglWindow));
     }
     catch(std::exception& e)

--- a/src/ase/src/windows/wglwindow.cpp
+++ b/src/ase/src/windows/wglwindow.cpp
@@ -419,6 +419,13 @@ WglWindow::WglWindow(WglPlatform& platform, Vector2i size,
     genericWindow_.setScalingFactor(scalingFactor);
 }
 
+WglWindow::~WglWindow()
+{
+    // The window class is CS_OWNDC, so the DC belongs to the window and goes
+    // with it; releasing it separately would be a no-op.
+    DestroyWindow(hwnd_);
+}
+
 HWND WglWindow::getHwnd() const
 {
     return hwnd_;

--- a/src/bqui/AGENTS.md
+++ b/src/bqui/AGENTS.md
@@ -1,6 +1,6 @@
 # bqui — agent notes
 
-*Last verified against `9cbe4cb` (2026-07-20).*
+*Last verified against `f52d7f2` (2026-07-23), for the window-handle rework.*
 
 Internals, entry points, and traps for the UI toolkit. Concepts and usage are in
 `readme.md`; project-wide conventions are in the top-level `docs/`. This file is
@@ -38,6 +38,122 @@ terminate to `AnyWidget`. Transforms are **paint-time and never affect layout**
 - Environment: a typed, scoped store threaded through the tree (`provider/`,
   `modifier/setparams.h`); `Theme` is the common parameter.
 - Animation: `withanimation.h` (guard or lambda form) marks changes to animate.
+
+## The app loop (`app.cpp`)
+
+**A `Window` is a handle; the widget is supplied at `addWindow`.** A `Window` is
+a `std::shared_ptr<WindowData>` (`src/windowdata.h`): its copies are one window
+and share the data — identity, title, close callbacks — which lives as long as
+any copy does, across a remove and a later re-add. The window holds none of its
+own contents. `WindowData` links back to the app only weakly, so it is a
+strong-leaf; that is what lets a widget capture the very `Window` that owns it
+without a cycle (see `docs/decisions.md`).
+
+**One imperative collection says which windows exist.** `AppDeferred::windows_`
+is a `bq::signal::SharedVector<Window>`. `App::addWindow` appends to it,
+`App::removeWindow` and `Window::close` remove from it, and `App::getWindows` /
+`App::getWindowsSignal` read it — as a snapshot and as a signal respectively. The
+signal is an observation for a UI that wants to follow the set; it is not the
+source, and nothing derives the windows from it.
+
+`App::addWindow(window, widget)` does two things: it adds the window to the
+collection (rejecting a duplicate or a window already in another app), and it
+enqueues the `(window, widget)` pair on `pendingMounts_`, a mutex-guarded queue,
+because an OS window must be built on the app thread. So `addWindow` is safe from
+any thread; the widget waits there for the run loop.
+
+`App::run` keeps a live `WindowImpl` per window, `windowImpls_`, keyed by window
+id. A `WindowImpl` (which absorbed the old `WindowGlue`) owns everything for one
+window: its `ase::Window`, painter, per-window signal contexts, input state, and
+the **widget** it was mounted with. It holds the window's `WindowData` too, but
+not its identity — the data outlives the impl. Each frame the loop **syncs** the
+impls to the collection with a plain O(n) set-diff: it reads `getWindows()`,
+drains `pendingMounts_` and mounts a `WindowImpl` for any window in the
+collection that has none, and tears down any impl whose window has left. A window
+that survives an edit keeps the impl it already had — it is never rebuilt. A
+pending widget whose window has since left (or is already mounted) is dropped; a
+re-add re-supplies one. `AnimationGuard` walks `windowImpls_`. The no-signal
+`run()` overload derives its `running` signal from `getWindowsSignal` and stops
+when the collection is empty.
+
+The sync replaced an earlier signal-driven design (see `docs/decisions.md`): the
+window set used to be an `ArraySignal<Window>` mapped to one glue per identity
+and joined, with a `collect()` reconcile off the joined signal and a second
+`addWindowArray` path. There is no array, no join, and no `addWindowArray` now;
+the plain set-diff is all the matching a by-value identity needs.
+
+A window belongs to one app: `App::addWindow` rejects a window whose data already
+names a live app, and `removeWindow` clears that reference so a closed window can
+be opened again. Without that a window could be open in one app and closable only
+from another.
+
+The impls are released by a scope guard in `run`, not at the end of it. They
+outlive the call — they are the app's — but the `ase::Platform` and
+`ase::RenderContext` they are made of do not, so a run that ends by exception
+must not leave one behind.
+
+### How `Window::close()` reaches the collection
+
+`WindowData` carries the window's `btl::UniqueId` and a
+`std::weak_ptr<AppDeferred>`, stamped in by `App::addWindow`. `close()` locks the
+weak app and calls `AppDeferred::removeWindow(id)`, which leaves the collection;
+the impl is torn down by the next sync, not inline. Weak, because a window
+outlives its app whenever a widget or a callback still names one: `close()` on a
+window whose app is gone — or that was never added — finds nothing to lock and
+returns.
+
+The back-reference is to the app rather than to the impl on purpose: it makes
+`close()` work before a window is mounted (and off the app thread), which the
+non-headless `windowtest.cpp` exercises, and it keeps `WindowData` free of any
+reference to the impl — the strong-leaf property the cycle-safety depends on.
+There is no separate `WindowHandle`; the `Window` is the handle now, and folding
+its weak app reference into `WindowData` is what deleted it.
+
+### Ordering
+
+Two rules hold the frame phase together, and both are load-bearing rather than
+tidiness:
+
+- **A window's signals are updated in the frame phase, never from an input
+  handler.** The handler marks the window for redraw and returns; the platform
+  runs the frame after `App::run`'s callback has synced the impls to the
+  collection, so a window that has just been removed is torn down before
+  anything updates it.
+- **An impl is released only after the main render queue has caught up.** An
+  in-flight frame holds the window's framebuffer, which holds the window by
+  reference, so the sync calls `mainQueue.finish()` before it destroys a
+  departed impl.
+
+Removal itself never evaluates a signal. `WindowImpl`'s close callback invokes
+the window's own callbacks and then removes it, and a removal writes the
+`SharedVector`, whose publication only sets an input. `Window::close()` (a widget
+button, say) writes the same `SharedVector` and no more; the callbacks are the
+title bar's path alone.
+
+**An impl drives its window's own signals.** Everything it updates per frame is
+the window's *own* title signal and the widget it was mounted with — not a
+per-frame read of the collection. There is therefore no departed-key hazard on
+this path: the collection can change and a surviving impl keeps driving what it
+already holds.
+
+The teardown ordering is the one subtlety worth stating: the sync builds the new
+complete impl set, swaps it into `windowImpls_`, and *then* destroys the departed
+impls, because destroying a window runs event handlers that reach back into the
+live set, which must be the new one by then.
+
+`AnimationGuard` transacts every impl from its constructor and destructor, and
+`withAnimation` is called from input handlers. A handler that both animates and
+removes a window transacts the departing window synchronously, which is harmless:
+the value is stable and the close path only invokes the window's own callbacks
+and returns.
+
+`test/apptest.cpp` drives the collection through a scripted `running` signal on
+the headless dummy backend (macOS CI only), covering mount/remove/close, the
+impl lifecycle, and the cycle-safety of a close button that captures its owning
+`Window`. `test/windowtest.cpp` covers the collection and the handle's lifetime
+without a backend at all, so it runs everywhere. Run `testapp1` to exercise the
+rest — its extra windows are app-owned, and each close button captures the
+owning `Window`.
 
 ## Traps
 

--- a/src/bqui/include/bqui/app.h
+++ b/src/bqui/include/bqui/app.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "window.h"
+#include "widget/widget.h"
 #include "bquivisibility.h"
 
 #include <bq/signal/signal.h>
@@ -8,7 +9,11 @@
 #include <avg/curve/curves.h>
 
 #include <btl/shared.h>
+#include <btl/uniqueid.h>
 #include <btl/visibility.h>
+
+#include <optional>
+#include <vector>
 
 namespace bqui
 {
@@ -20,10 +25,56 @@ namespace bqui
     public:
         explicit App();
 
-        App windows(std::initializer_list<Window> windows) &&;
+        /** @brief Opens a window the app owns, mounting the given widget in it.
+         *
+         * The widget becomes the window's mounted content, not part of its
+         * identity: removing the window destroys the widget, and adding the same
+         * window again re-supplies a fresh one. The collection is imperative, so
+         * a window may be added and removed both before and while the app runs.
+         *
+         * @throws std::invalid_argument if the window is already open, here or
+         *         in another app. A window and its copies are one window, so
+         *         adding a copy of an open window is adding it twice. A removed
+         *         window belongs to no app again and may be opened anywhere.
+         */
+        App& addWindow(Window window, widget::AnyWidget widget);
 
-        int run(bq::signal::AnySignal<bool> running) &&;
-        int run() &&;
+        /** @brief Closes the app's window with this identity.
+         *
+         * Does nothing if no window in the collection has it. The window's own
+         * data outlives this whenever a Window naming it is still held; only its
+         * mounted widget is torn down.
+         */
+        void removeWindow(btl::UniqueId id);
+
+        /** @brief The app's windows as they are right now.
+         *
+         * The snapshot form, for code outside a signal graph — counting the
+         * open windows, or finding one to remove.
+         */
+        std::vector<Window> getWindows() const;
+
+        /** @brief The app's windows, as a signal.
+         *
+         * The reactive form of the same collection, for a UI that follows it.
+         */
+        bq::signal::AnySignal<std::vector<Window>> getWindowsSignal() const;
+
+        /** @brief Runs until 'running' is false, whatever the windows do.
+         *
+         * The calling thread is the app's thread: run() and withAnimation()
+         * belong to it, and every window is built, drawn and driven there. The
+         * window collection is the exception — addWindow(), removeWindow(),
+         * getWindows() and Window::close() are lock-guarded, so a worker thread
+         * can open or close a window itself.
+         */
+        int run(bq::signal::AnySignal<bool> running);
+
+        /** @overload
+         *
+         * Runs until the last window is closed.
+         */
+        int run();
 
         [[nodiscard]]
         AnimationGuard withAnimation(avg::AnimationOptions options);
@@ -31,6 +82,8 @@ namespace bqui
         friend class AnimationGuard;
 
     private:
+        int runUntil(bq::signal::AnySignal<bool> running);
+
         inline AppDeferred* d()
         {
             return deferred_.get();

--- a/src/bqui/include/bqui/window.h
+++ b/src/bqui/include/bqui/window.h
@@ -1,20 +1,32 @@
 #pragma once
 
-#include "widget/widget.h"
-
 #include "bquivisibility.h"
 
 #include <bq/signal/signal.h>
 
-#include <btl/cloneoncopy.h>
+#include <btl/uniqueid.h>
+
+#include <functional>
+#include <memory>
+#include <string>
 
 namespace bqui
 {
+    class WindowData;
+    class App;
+    class AppDeferred;
+    class WindowImpl;
+
+    /** @brief A window in the application.
+     *
+     * Create a Window, add it to the App with the widget to show in it, and
+     * close it when you are done.
+     */
     class BQUI_EXPORT Window
     {
     public:
-        Window(widget::AnyWidget widget,
-                bq::signal::AnySignal<std::string> const& title);
+        /** @brief Mints a window with a fresh identity, belonging to no app. */
+        explicit Window(bq::signal::AnySignal<std::string> const& title);
 
         Window(Window const&) = default;
         Window& operator=(Window const&) = default;
@@ -22,13 +34,22 @@ namespace bqui
         Window(Window&&) = default;
         Window& operator=(Window&&) = default;
 
+        /** @brief Adds a callback run when the window's title bar closes it. */
         Window onClose(std::function<void()> const& cb) &&;
-
-        widget::AnyWidget getWidget() const;
 
         bq::signal::AnySignal<std::string> const& getTitle() const;
 
         void invokeOnClose() const;
+
+        /** @brief This window's identity, which its copies share. */
+        btl::UniqueId getId() const;
+
+        /** @brief Removes this window from the app that owns it.
+         *
+         * A no-op if the window is in no app, or if that app is gone. Closing
+         * twice is a race a UI can lose without anything being wrong.
+         */
+        void close() const;
 
         Window clone() const
         {
@@ -36,12 +57,18 @@ namespace bqui
         }
 
     private:
-        widget::AnyWidget widget_;
-        bq::signal::AnySignal<std::string> title_;
-        std::vector<std::function<void()>> closeCallbacks_;
+        friend class App;
+        friend class AppDeferred;
+        friend class WindowImpl;
+
+        std::shared_ptr<WindowData> const& data() const
+        {
+            return data_;
+        }
+
+        std::shared_ptr<WindowData> data_;
     };
 
-    BQUI_EXPORT auto window(bq::signal::AnySignal<std::string> const& title,
-            widget::AnyWidget widget) -> Window;
+    /** @brief Mints a window with the given title. */
+    BQUI_EXPORT Window window(bq::signal::AnySignal<std::string> const& title);
 }
-

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -80,13 +80,27 @@ libbquidep = declare_dependency(
   include_directories: include_directories('include')
   )
 
-bquitest =  executable('bquitest',
+bquitestsrc = [
   'test/collectiontest.cpp',
   'test/databindtest.cpp',
   'test/layouttest.cpp',
   'test/shapetest.cpp',
   'test/widgetinstancemodifiertest.cpp',
   'test/widgettest.cpp',
+  'test/windowtest.cpp',
+  ]
+
+# App::run opens real windows, so it can only be exercised where ase builds its
+# headless backend. This gate is the minimal thing needed to run apptest.cpp
+# against ase's dummy backend; the proper headless platform (env-selected and
+# frame-stepped) arrives in a follow-up (PR #96), and this should be revisited
+# to use it once that lands.
+if ase_is_headless
+  bquitestsrc += 'test/apptest.cpp'
+endif
+
+bquitest =  executable('bquitest',
+  bquitestsrc,
   dependencies: [gtestdep, libbquidep],
   )
 

--- a/src/bqui/readme.md
+++ b/src/bqui/readme.md
@@ -47,9 +47,39 @@ shape::rectangle().rotate(0.2f).stroke(pen);   // rectangle, circle, ellipse
 
 ```cpp
 return app()
-    .windows({ window(bq::signal::constant<std::string>("Title"), ui) })
+    .addWindow(window(bq::signal::constant<std::string>("Title")), ui)
     .run();
 ```
+
+A `Window` is a small handle: `window(title)` mints one, and the widget is
+supplied to `addWindow` alongside it. The app owns the windows added this way,
+and `run()` with no arguments runs until none of them is left. Windows may be
+added while it runs, so opening a second window is a button handler away.
+
+A window closes by leaving the app's collection. Its title bar does that by
+itself, and so does `Window::close()`; `App::removeWindow` takes an identity
+instead. Closing one of several windows removes it; the app stops when the last
+one closes.
+
+A close button *inside* the window captures the very window that owns it. The
+window holds none of its contents — the widget lives in the app — so this closes
+no cycle:
+
+```cpp
+Window w = window(bq::signal::constant<std::string>("Details"));
+
+app().addWindow(w, widget::button("Close",
+        bq::signal::constant(std::function<void()>(
+                [w]() { w.close(); }))));
+```
+
+The collection is imperative: `App::addWindow` opens a window and
+`removeWindow`/`Window::close` close it, before and while the app runs. Removing
+a window unmounts its widget but keeps the window's own data, so a held `Window`
+still reads its props and can be added again with a fresh widget.
+`App::getWindowsSignal` observes the set for a UI that follows it — a window
+list, or a title that counts — but that signal reports the collection, it does
+not drive it.
 
 Signal changes made inside a `withAnimation` scope are animated.
 

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -1,13 +1,16 @@
 #include "bqui/app.h"
 
 #include "bqui/window.h"
-#include "bqui/send.h"
+#include "bqui/modifier/background.h"
 
 #include "debug.h"
+#include "windowdata.h"
+#include "windowimpl.h"
 
 #include <bq/signal/input.h>
 #include <bq/signal/updateresult.h>
 #include <bq/signal/signalcontext.h>
+#include <bq/signal/sharedvector.h>
 
 #include <avg/rendertree.h>
 #include <avg/painter.h>
@@ -33,28 +36,24 @@
 
 #include <tracy/Tracy.hpp>
 
+#include <algorithm>
 #include <chrono>
+#include <functional>
+#include <mutex>
+#include <stdexcept>
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 #include <cstdint>
 
 namespace bqui
 {
 
-namespace
-{
-    uint64_t s_frameId_ = 0;
-
-    uint64_t getNextFrameId()
-    {
-        return ++s_frameId_;
-    }
-} // anonymous namespace
-
-class WindowGlue;
-
-class BQUI_EXPORT AppDeferred
+class BQUI_EXPORT AppDeferred :
+    public std::enable_shared_from_this<AppDeferred>
 {
 public:
     AppDeferred()
@@ -62,443 +61,253 @@ public:
         TracyAppInfo("Reactive application", 20);
     }
 
-    std::vector<Window> windows_;
-    std::vector<btl::shared<WindowGlue>> windowGlues_;
+    /** @brief Removes the window with this id from the collection.
+     *
+     * Thread-safe, and a no-op if no window here has the id. The window's impl
+     * is torn down by the run loop's next sync, not here, because an OS window
+     * is released on the app thread.
+     */
+    void removeWindow(btl::UniqueId id);
+
+    std::vector<Window> getWindows() const
+    {
+        return *windows_.read();
+    }
+
+    bq::signal::SharedVector<Window> windows_;
+
+    std::mutex pendingMutex_;
+    std::vector<std::pair<Window, widget::AnyWidget>> pendingMounts_;
+
+    std::vector<btl::shared<WindowImpl>> windowImpls_;
 };
 
-class WindowGlue
+// Releases the app's impls, whatever ends the run. An impl holds an
+// ase::Window and a framebuffer belonging to the run's render context, so
+// leaving one behind would outlive what it is made of.
+struct ImplScope
 {
-public:
-    WindowGlue(ase::Platform &platform, ase::RenderContext& context,
-            Window window)
-        : memoryPool_(pmr::new_delete_resource()),
-        memoryStatistics_(&memoryPool_),
-        memory_(&memoryStatistics_),
-        aseWindow(platform.makeWindow(ase::Vector2i(800, 600))),
-        context_(context),
-        window_(std::move(window)),
-        painter_(memory_, context_),
-        size_(bq::signal::makeInput(ase::Vector2f(800, 600))),
-        widgetInstanceSignal_(window_.getWidget()(
-                    BuildParams{}
-                    )(std::move(size_.signal)).getInstance()),
-        widgetInstance_(widgetInstanceSignal_.evaluate<0>().get<0>()),
-        titleSignal_(window_.getTitle()),
-        drawing_(memory_)
+    ~ImplScope()
     {
-        aseWindow.setVisible(true);
-        aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
-
-        aseWindow.setFrameCallback([this](ase::Frame const& frame) {
-                return onFrame(frame);
-                });
-
-        aseWindow.setCloseCallback([this]() { window_.invokeOnClose(); });
-        aseWindow.setResizeCallback([this]()
-                {
-                    resized_ = true;
-                    animating_ = true;
-                });
-
-        aseWindow.setButtonCallback([this](ase::PointerButtonEvent const &e)
-        {
-            if (e.state == ase::ButtonState::down)
-            {
-                auto areas = widgetInstance_.getInputAreas();
-                for (auto const &a : areas)
-                {
-                    if (a.acceptsButtonEvent(e))
-                    {
-                        a.emitButtonEvent(e);
-                        areas_[e.button].push_back(a);
-
-                        makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-                    }
-                }
-            }
-            else if (e.state == ase::ButtonState::up)
-            {
-                for (auto const &a : areas_[e.button])
-                {
-                    a.emitButtonEvent(e);
-                }
-
-                areas_[e.button].clear();
-
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-            }
-
-        });
-
-        aseWindow.setPointerCallback([this](ase::PointerMoveEvent const &e)
-        {
-            if (currentHoverArea_.has_value() && !currentHoverArea_->contains(e.pos))
-            {
-                currentHoverArea_->emitHoverEvent(HoverEvent{false, false});
-                currentHoverArea_ = std::nullopt;
-            }
-
-            auto areas = widgetInstance_.getInputAreas();
-            for (auto const &a : areas)
-            {
-                if (a.contains(e.pos))
-                {
-
-                    if (!currentHoverArea_.has_value() ||
-                        currentHoverArea_->getId() != a.getId())
-                    {
-                        if (currentHoverArea_.has_value())
-                        {
-                            currentHoverArea_->emitHoverEvent(HoverEvent{false, false});
-                        }
-
-                        currentHoverArea_ = a;
-
-                        a.emitHoverEvent(HoverEvent{true, true});
-                    }
-
-                    break;
-                }
-            }
-
-            bool accepted = false;
-            for (auto &item : areas_)
-            {
-                if (!e.buttons.at(item.first - 1))
-                    continue;
-
-                std::vector<InputArea> newAreas;
-                for (auto &&area : item.second)
-                {
-                    EventResult r = area.emitMoveEvent(e);
-                    if (r == EventResult::accept)
-                    {
-                        newAreas.clear();
-                        newAreas.emplace_back(std::move(area));
-                        accepted = true;
-                        break;
-                    }
-                    else if (r == EventResult::possible)
-                    {
-                        newAreas.push_back(std::move(area));
-                    }
-                    else if (r == EventResult::reject)
-                    {
-                    }
-                }
-
-                item.second = std::move(newAreas);
-
-                if (accepted)
-                    break;
-            }
-        });
-
-        aseWindow.setDragCallback([](ase::PointerDragEvent const & /*e*/)
-                {
-                });
-
-        aseWindow.setKeyCallback([this](ase::KeyEvent const &e)
-        {
-            if (currentKeyHandler_.has_value() && e.isDown())
-            {
-                (*currentKeyHandler_)(e);
-                keys_[e.getKey()] = *currentKeyHandler_;
-
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-            }
-            else
-            {
-                auto i = keys_.find(e.getKey());
-                if (i == keys_.end())
-                    return;
-                auto f = i->second;
-                keys_.erase(i);
-
-                f(e);
-
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-            }
-        });
-
-        aseWindow.setTextCallback([this](ase::TextEvent const& e)
-        {
-            if (currentTextHandler_.has_value())
-            {
-                (*currentTextHandler_)(e);
-
-                makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-            }
-        });
-
-        aseWindow.setHoverCallback([this](ase::HoverEvent const &e)
-        {
-            if (!e.hover)
-            {
-                if (currentHoverArea_.has_value())
-                {
-                    currentHoverArea_->emitHoverEvent(e);
-                    currentHoverArea_ = std::nullopt;
-
-                    makeTransaction(bq::signal::signal_time_t(0), std::nullopt);
-                }
-            }
-        });
+        // A frame that drew a window can still be in flight, and it holds that
+        // window's framebuffer.
+        queue.finish();
+        app.windowImpls_.clear();
     }
 
-    WindowGlue(WindowGlue const &) = delete;
-    WindowGlue &operator=(WindowGlue const &) = delete;
-
-    virtual ~WindowGlue()
-    {
-        std::cout << "Maximum concurrent allocations: "
-            << memoryStatistics_.maximum_concurrent_bytes_allocated()
-            << std::endl;
-    }
-
-    std::optional<bq::signal::signal_time_t> makeTransaction(
-            std::chrono::microseconds dt,
-            std::optional<avg::AnimationOptions> const& animationOptions
-            )
-    {
-        ZoneScoped;
-
-        auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(timer_);
-
-        bq::signal::FrameInfo frameInfo(getNextFrameId(), dt);
-
-        auto updateResult = widgetInstanceSignal_.update(frameInfo);
-        updateResult = updateResult + titleSignal_.update(frameInfo);
-
-
-        if (titleSignal_.didChange<0>())
-            aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
-
-        if (widgetInstanceSignal_.didChange<0>())
-        {
-            ZoneScopedN("Widget instance signal evaluation");
-
-            widgetInstance_ = widgetInstanceSignal_.evaluate<0>().get<0>();
-
-            // If there's an area with the same id -> update
-            auto areas = widgetInstance_.getInputAreas();
-            for (auto&& area : areas_)
-            {
-                for (InputArea& area3 : area.second)
-                {
-                    for (InputArea& area2 : areas)
-                    {
-                        if (area3.getId() == area2.getId())
-                        {
-                            area3 = std::move(area2);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            auto inputs = widgetInstance_.getKeyboardInputs();
-            for (auto&& input : inputs)
-            {
-                auto handle = input.getFocusHandle();
-
-                bool focus = input.getRequestFocus() || input.hasFocus();
-                if (focus && handle.has_value())
-                {
-                    if (input.getRequestFocus())
-                    {
-                        if (currentHandle_.has_value())
-                            currentHandle_->set(false);
-                        handle->set(true);
-                    }
-
-                    currentHandle_ = handle;
-                    currentKeyHandler_ = input.getKeyHandler();
-                    currentTextHandler_ = input.getTextHandler();
-
-                    if (input.getRequestFocus())
-                        break;
-                }
-            }
-
-            if (!currentHandle_.has_value() && !inputs.empty())
-            {
-                auto handle = inputs[0];
-                currentHandle_ = handle.getFocusHandle();
-                if (currentHandle_.has_value())
-                    currentHandle_->set(true);
-                currentKeyHandler_ = handle.getKeyHandler();
-                currentTextHandler_ = handle.getTextHandler();
-            }
-        }
-
-        if (widgetInstanceSignal_.didChange<0>()
-                || (nextUpdate_ && *nextUpdate_ <= timer)
-                )
-        {
-            ZoneScopedN("RenderTree update");
-            auto [renderTree, nextUpdate] = std::move(renderTree_).update(
-                    btl::clone(widgetInstance_.getRenderTree()),
-                    animationOptions,
-                    timer
-                    );
-
-            if (nextUpdate_ && *nextUpdate_ < timer)
-                nextUpdate_ = std::nullopt;
-
-            if (nextUpdate && *nextUpdate < timer)
-                nextUpdate = std::nullopt;
-
-            nextUpdate_ = avg::earlier(nextUpdate_, nextUpdate);
-
-            renderTree_ = std::move(renderTree);
-
-            animating_ = true;
-
-            aseWindow.requestFrame();
-        }
-
-        return updateResult.nextUpdate;
-    }
-
-    std::optional<bq::signal::signal_time_t> frame(std::chrono::microseconds dt)
-    {
-        ZoneScoped;
-
-        return onFrame( { timer_, dt });
-    }
-
-    std::optional<std::chrono::microseconds> onFrame(ase::Frame const& frame)
-    {
-        ZoneScoped;
-
-        timer_ = frame.time;
-
-        if (resized_)
-        {
-            size_.handle.set(aseWindow.getSize().cast<float>());
-            painter_.setSize(aseWindow.getSize());
-            resized_ = false;
-        }
-
-        auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(
-                timer_);
-
-        auto timeToNext = makeTransaction(frame.dt, std::nullopt);
-
-        if (animating_)
-        {
-            auto [drawing, cont] = renderTree_.draw(
-                    avg::DrawContext(&painter_),
-                    avg::Obb(aseWindow.getSize().cast<float>()),
-                    timer
-                    );
-
-            drawing_ = std::move(drawing);
-            animating_ = cont;
-        }
-
-        painter_.clearWindow(aseWindow);
-        painter_.paintToWindow(aseWindow, drawing_);
-        painter_.presentWindow(aseWindow);
-        painter_.flush();
-
-        ++frames_;
-
-        if (animating_)
-            return std::chrono::microseconds(0);
-
-        return timeToNext;
-    }
-
-    uint64_t getFrames() const
-    {
-        return frames_;
-    }
-
-    std::string getTitle() const
-    {
-        return titleSignal_.evaluate<0>().get<0>();
-    }
-
-    widget::Instance const& getWidgetInstance() const
-    {
-        return widgetInstance_;
-    }
-
-private:
-    pmr::unsynchronized_pool_resource memoryPool_;
-    pmr::statistics_resource memoryStatistics_;
-    pmr::memory_resource* memory_;
-    ase::Window aseWindow;
-    ase::RenderContext& context_;
-    Window window_;
-    avg::Painter painter_;
-    bq::signal::Input<bq::signal::SignalResult<ase::Vector2f>,
-        bq::signal::SignalResult<ase::Vector2f>> size_;
-    bq::signal::SignalContext<bq::signal::AnySignal<widget::Instance>>
-        widgetInstanceSignal_;
-    widget::Instance widgetInstance_;
-    bq::signal::SignalContext<bq::signal::AnySignal<std::string>> titleSignal_;
-    //RenderCache cache_;
-    std::unordered_map<unsigned int, std::vector<InputArea>> areas_;
-    std::unordered_map<ase::KeyCode,
-        std::function<void(ase::KeyEvent const&)>> keys_;
-    std::optional<bq::signal::InputHandle<bool>> currentHandle_;
-    std::optional<KeyboardInput::KeyHandler> currentKeyHandler_;
-    std::optional<KeyboardInput::TextHandler> currentTextHandler_;
-    uint64_t frames_ = 0;
-    std::optional<InputArea> currentHoverArea_;
-
-    std::chrono::microseconds timer_ = std::chrono::microseconds(0);
-    avg::RenderTree renderTree_;
-    std::optional<avg::AnimationOptions> animationOptions_;
-    avg::Drawing drawing_;
-    std::optional<std::chrono::milliseconds> nextUpdate_;
-    bool animating_ = true;
-    bool resized_ = true;
+    AppDeferred& app;
+    ase::RenderQueue& queue;
 };
 
+void WindowData::close() const
+{
+    std::shared_ptr<AppDeferred> app;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        app = app_.lock();
+    }
+
+    if (app)
+        app->removeWindow(id_);
+}
+
+void AppDeferred::removeWindow(btl::UniqueId id)
+{
+    {
+        auto handle = windows_.read();
+
+        auto found = std::find_if(handle->begin(), handle->end(),
+                [id](Window const& window)
+                {
+                    return window.getId() == id;
+                });
+
+        if (found == handle->end())
+            return;
+    }
+
+    std::vector<Window> departing;
+
+    {
+        auto handle = windows_.write();
+
+        auto departed = std::stable_partition(handle->begin(), handle->end(),
+                [id](Window const& window)
+                {
+                    return window.getId() != id;
+                });
+
+        departing.insert(departing.end(),
+                std::make_move_iterator(departed),
+                std::make_move_iterator(handle->end()));
+
+        handle->erase(departed, handle->end());
+    }
+
+    for (auto const& window : departing)
+        window.data()->clearApp();
+}
 
 App::App() :
     deferred_(std::make_shared<AppDeferred>())
 {
 }
 
-App App::windows(std::initializer_list<Window> windows) &&
+App& App::addWindow(Window window, widget::AnyWidget widget)
 {
-    for (auto const& w : windows)
-        d()->windows_.push_back(btl::clone(w));
+    {
+        auto handle = d()->windows_.write();
 
-    return std::move(*this);
+        bool alreadyOpen = std::any_of(handle->begin(), handle->end(),
+                [&](Window const& w) { return w.getId() == window.getId(); });
+
+        if (alreadyOpen)
+        {
+            throw std::invalid_argument("App: this window is already open. A "
+                    "window and its copies are one window, and one window "
+                    "cannot be opened twice.");
+        }
+
+        if (window.data()->hasApp())
+        {
+            throw std::invalid_argument("App: this window is open in another "
+                    "app. A window belongs to one app, because close() has to "
+                    "know which app to leave.");
+        }
+
+        window.data()->setApp(d()->weak_from_this());
+
+        handle->push_back(window);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(d()->pendingMutex_);
+        d()->pendingMounts_.emplace_back(std::move(window), std::move(widget));
+    }
+
+    return *this;
 }
 
-int App::run(bq::signal::AnySignal<bool> runningSignal) &&
+void App::removeWindow(btl::UniqueId id)
+{
+    d()->removeWindow(id);
+}
+
+std::vector<Window> App::getWindows() const
+{
+    return d()->getWindows();
+}
+
+bq::signal::AnySignal<std::vector<Window>> App::getWindowsSignal() const
+{
+    return d()->windows_.signal();
+}
+
+int App::run(bq::signal::AnySignal<bool> running)
+{
+    return runUntil(std::move(running));
+}
+
+int App::run()
+{
+    return runUntil(getWindowsSignal().map(
+                [](std::vector<Window> const& windows)
+                {
+                    return !windows.empty();
+                }));
+}
+
+int App::runUntil(bq::signal::AnySignal<bool> running)
 {
     ase::Platform platform = ase::makeDefaultPlatform();
 
-    d()->windowGlues_.reserve(d()->windows_.size());
-
     ase::RenderContext context = platform.makeRenderContext();
 
-    for (auto&& w : d()->windows_)
+    auto mainQueue = context.getMainRenderQueue();
+
+    // The impls outlive this call — they are the app's, not the loop's — but
+    // the platform and render context they hold do not, so they must be
+    // released before this returns, however it returns.
+    ImplScope implScope { *d(), mainQueue };
+
+    auto runningContext = bq::signal::makeSignalContext(std::move(running));
+
+    // Syncs the live impls to the window collection: mounts an impl for any
+    // window not yet mounted, tears down any impl whose window has left. The
+    // collection (which close()/removeWindow update directly) is read straight,
+    // once per frame, and the widgets to mount are drained from the pending
+    // queue addWindow fills.
+    auto sync = [&]()
     {
-        d()->windowGlues_.push_back(std::make_shared<WindowGlue>(
-            platform, context, std::move(w)));
-    }
+        std::vector<Window> windows = d()->getWindows();
+
+        std::vector<btl::shared<WindowImpl>> next;
+        next.reserve(windows.size());
+
+        std::vector<btl::shared<WindowImpl>> departing;
+
+        for (auto& impl : d()->windowImpls_)
+        {
+            bool present = std::any_of(windows.begin(), windows.end(),
+                    [&](Window const& w) { return w.getId() == impl->getId(); });
+
+            if (present)
+                next.push_back(std::move(impl));
+            else
+                departing.push_back(std::move(impl));
+        }
+
+        std::vector<std::pair<Window, widget::AnyWidget>> pending;
+        {
+            std::lock_guard<std::mutex> lock(d()->pendingMutex_);
+            pending.swap(d()->pendingMounts_);
+        }
+
+        for (auto& mount : pending)
+        {
+            btl::UniqueId id = mount.first.getId();
+
+            bool present = std::any_of(windows.begin(), windows.end(),
+                    [&](Window const& w) { return w.getId() == id; });
+
+            bool mounted = std::any_of(next.begin(), next.end(),
+                    [&](btl::shared<WindowImpl> const& impl)
+                    {
+                        return impl->getId() == id;
+                    });
+
+            if (present && !mounted)
+                next.push_back(std::make_shared<WindowImpl>(platform, context,
+                            std::move(mount.first), std::move(mount.second)));
+        }
+
+        // A frame that drew a departing window can still be in flight, and it
+        // holds that window's framebuffer, so nothing may release an impl until
+        // the queue has caught up.
+        if (!departing.empty())
+            mainQueue.finish();
+
+        d()->windowImpls_.swap(next);
+        departing.clear();
+    };
+
+    sync();
 
     std::chrono::steady_clock clock;
     auto startTime = clock.now();
 
     DBG("Reactive running...");
 
-    auto running = bq::signal::makeSignalContext(runningSignal);
     platform.run(context, [&](ase::Frame const& aseFrame) -> bool
         {
             bq::signal::FrameInfo frame{ getNextFrameId(), aseFrame.dt };
-            running.update(frame);
 
-            return running.evaluate<0>().get<0>();
+            runningContext.update(frame);
+
+            sync();
+
+            return runningContext.evaluate<0>().get<0>();
         });
 
     DBG("Shutting down...");
@@ -506,24 +315,13 @@ int App::run(bq::signal::AnySignal<bool> runningSignal) &&
     auto endTime = clock.now();
     std::chrono::duration<double> time = endTime - startTime;
 
-    for (auto const& glue : d()->windowGlues_)
+    for (auto const& impl : d()->windowImpls_)
     {
-        DBG("Window \"%1\" had FPS of %2.", glue->getTitle(),
-                (double)glue->getFrames() / time.count());
+        DBG("Window \"%1\" had FPS of %2.", impl->getTitle(),
+                (double)impl->getFrames() / time.count());
     }
 
-    d()->windowGlues_.clear();
-
     return 0;
-}
-
-int App::run() &&
-{
-    auto running = bq::signal::makeInput(true);
-    for (auto&& w : d()->windows_)
-        w = std::move(w).onClose(send(false, running.handle));
-
-    return std::move(*this).run(running.signal);
 }
 
 AnimationGuard App::withAnimation(avg::AnimationOptions options)
@@ -536,9 +334,9 @@ AnimationGuard::AnimationGuard(AppDeferred& app,
     app_(&app),
     options_(options)
 {
-    for (auto& glue : app_->windowGlues_)
+    for (auto& impl : app_->windowImpls_)
     {
-        glue->makeTransaction(
+        impl->makeTransaction(
                 std::chrono::milliseconds(0),
                 std::nullopt
                 );
@@ -550,9 +348,9 @@ AnimationGuard::~AnimationGuard()
     if (!app_)
         return;
 
-    for (auto& glue : app_->windowGlues_)
+    for (auto& impl : app_->windowImpls_)
     {
-        glue->makeTransaction(
+        impl->makeTransaction(
                 std::chrono::milliseconds(0),
                 options_
                 );

--- a/src/bqui/src/window.cpp
+++ b/src/bqui/src/window.cpp
@@ -1,47 +1,47 @@
 #include "bqui/window.h"
 
-#include "bqui/modifier/background.h"
+#include "windowdata.h"
+
+#include <memory>
+#include <utility>
 
 namespace bqui
 {
 
-Window::Window(widget::AnyWidget widget,
-        bq::signal::AnySignal<std::string> const& title) :
-    widget_(std::move(widget)),
-    title_(title.share())
+Window::Window(bq::signal::AnySignal<std::string> const& title) :
+    data_(std::make_shared<WindowData>(title))
 {
 }
 
 Window Window::onClose(std::function<void()> const& cb) &&
 {
-    closeCallbacks_.push_back(cb);
+    data_->addCloseCallback(cb);
     return std::move(*this);
-}
-
-widget::AnyWidget Window::getWidget() const
-{
-    return widget_.clone()
-        | modifier::background()
-        ;
 }
 
 bq::signal::AnySignal<std::string> const& Window::getTitle() const
 {
-    return title_;
+    return data_->getTitle();
 }
 
 void Window::invokeOnClose() const
 {
-    auto cbs = closeCallbacks_;
-    for (auto const& cb : cbs)
-        cb();
+    data_->invokeOnClose();
 }
 
-auto window(bq::signal::AnySignal<std::string> const& title, widget::AnyWidget widget)
-    -> Window
+btl::UniqueId Window::getId() const
 {
-    return Window(std::move(widget), title);
+    return data_->getId();
+}
+
+void Window::close() const
+{
+    data_->close();
+}
+
+Window window(bq::signal::AnySignal<std::string> const& title)
+{
+    return Window(title);
 }
 
 }
-

--- a/src/bqui/src/windowdata.h
+++ b/src/bqui/src/windowdata.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <bq/signal/signal.h>
+
+#include <btl/uniqueid.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace bqui
+{
+    class AppDeferred;
+
+    /** @brief A window's persistent state, shared by every copy of a Window.
+     *
+     * Holds the window's identity, title and close callbacks — but none of its
+     * contents: the widget is supplied to App::addWindow at mount and lives in
+     * the app-owned impl, so a widget may capture the Window that owns it
+     * without a retain cycle. The link back to the app is weak, so close() is a
+     * no-op for a window that was never added or whose app is gone.
+     *
+     * The mutable parts (the app reference and the close callbacks) are guarded
+     * by a mutex, so a Window is safe to read and to close from any thread.
+     */
+    class WindowData
+    {
+    public:
+        explicit WindowData(bq::signal::AnySignal<std::string> const& title) :
+            title_(title.share())
+        {
+        }
+
+        WindowData(WindowData const&) = delete;
+        WindowData& operator=(WindowData const&) = delete;
+
+        btl::UniqueId getId() const
+        {
+            return id_;
+        }
+
+        bq::signal::AnySignal<std::string> const& getTitle() const
+        {
+            return title_;
+        }
+
+        void addCloseCallback(std::function<void()> const& cb)
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            closeCallbacks_.push_back(cb);
+        }
+
+        void invokeOnClose() const
+        {
+            std::vector<std::function<void()>> cbs;
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                cbs = closeCallbacks_;
+            }
+
+            for (auto const& cb : cbs)
+                cb();
+        }
+
+        /** @brief Removes the window from the app that owns it.
+         *
+         * A no-op if the window is in no app, or if that app is gone.
+         */
+        void close() const;
+
+        bool hasApp() const
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            return !app_.expired();
+        }
+
+        void setApp(std::weak_ptr<AppDeferred> app) const
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            app_ = std::move(app);
+        }
+
+        void clearApp() const
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            app_.reset();
+        }
+
+    private:
+        btl::UniqueId const id_ = btl::makeUniqueId();
+        bq::signal::AnySignal<std::string> title_;
+
+        mutable std::mutex mutex_;
+        mutable std::weak_ptr<AppDeferred> app_;
+        std::vector<std::function<void()>> closeCallbacks_;
+    };
+} // namespace bqui

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -1,0 +1,468 @@
+#pragma once
+
+#include "windowdata.h"
+
+#include "bqui/window.h"
+#include "bqui/buildparams.h"
+#include "bqui/inputarea.h"
+#include "bqui/keyboardinput.h"
+#include "bqui/hoverevent.h"
+#include "bqui/eventresult.h"
+#include "bqui/widget/instance.h"
+#include "bqui/widget/widget.h"
+#include "bqui/modifier/background.h"
+
+#include <bq/signal/input.h>
+#include <bq/signal/updateresult.h>
+#include <bq/signal/signalcontext.h>
+#include <bq/signal/signal.h>
+
+#include <avg/rendertree.h>
+#include <avg/painter.h>
+#include <avg/rendering.h>
+
+#include <ase/window.h>
+#include <ase/rendercontext.h>
+#include <ase/platform.h>
+#include <ase/keyevent.h>
+#include <ase/pointerbuttonevent.h>
+
+#include <pmr/statistics_resource.h>
+#include <pmr/unsynchronized_pool_resource.h>
+#include <pmr/new_delete_resource.h>
+
+#include <tracy/Tracy.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <cstdint>
+
+namespace bqui
+{
+
+inline uint64_t getNextFrameId()
+{
+    static uint64_t s_frameId = 0;
+    return ++s_frameId;
+}
+
+class WindowImpl
+{
+public:
+    WindowImpl(ase::Platform &platform, ase::RenderContext& context,
+            Window window, widget::AnyWidget widget)
+        : memoryPool_(pmr::new_delete_resource()),
+        memoryStatistics_(&memoryPool_),
+        memory_(&memoryStatistics_),
+        aseWindow(platform.makeWindow(ase::Vector2i(800, 600))),
+        context_(context),
+        windowData_(window.data()),
+        painter_(memory_, context_),
+        size_(bq::signal::makeInput(ase::Vector2f(800, 600))),
+        widgetInstanceSignal_((std::move(widget)
+                    | modifier::background())(
+                    BuildParams{}
+                    )(std::move(size_.signal)).getInstance()),
+        widgetInstance_(widgetInstanceSignal_.evaluate<0>().get<0>()),
+        titleSignal_(windowData_->getTitle()),
+        drawing_(memory_)
+    {
+        aseWindow.setVisible(true);
+        aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
+
+        aseWindow.setFrameCallback([this](ase::Frame const& frame) {
+                return onFrame(frame);
+                });
+
+        aseWindow.setCloseCallback([this]()
+        {
+            // The impl outlives the removal by up to a frame, so a second
+            // close event would otherwise run the window's callbacks again.
+            if (closed_)
+                return;
+
+            closed_ = true;
+
+            // Removing the window is what closes it, and the callbacks run
+            // first so that one of them still sees the window open.
+            windowData_->invokeOnClose();
+            windowData_->close();
+        });
+        aseWindow.setResizeCallback([this]()
+                {
+                    resized_ = true;
+                    animating_ = true;
+                });
+
+        aseWindow.setButtonCallback([this](ase::PointerButtonEvent const &e)
+        {
+            if (e.state == ase::ButtonState::down)
+            {
+                auto areas = widgetInstance_.getInputAreas();
+                for (auto const &a : areas)
+                {
+                    if (a.acceptsButtonEvent(e))
+                    {
+                        a.emitButtonEvent(e);
+                        areas_[e.button].push_back(a);
+
+                        aseWindow.requestFrame();
+                    }
+                }
+            }
+            else if (e.state == ase::ButtonState::up)
+            {
+                for (auto const &a : areas_[e.button])
+                {
+                    a.emitButtonEvent(e);
+                }
+
+                areas_[e.button].clear();
+
+                aseWindow.requestFrame();
+            }
+
+        });
+
+        aseWindow.setPointerCallback([this](ase::PointerMoveEvent const &e)
+        {
+            if (currentHoverArea_.has_value() && !currentHoverArea_->contains(e.pos))
+            {
+                currentHoverArea_->emitHoverEvent(HoverEvent{false, false});
+                currentHoverArea_ = std::nullopt;
+            }
+
+            auto areas = widgetInstance_.getInputAreas();
+            for (auto const &a : areas)
+            {
+                if (a.contains(e.pos))
+                {
+
+                    if (!currentHoverArea_.has_value() ||
+                        currentHoverArea_->getId() != a.getId())
+                    {
+                        if (currentHoverArea_.has_value())
+                        {
+                            currentHoverArea_->emitHoverEvent(HoverEvent{false, false});
+                        }
+
+                        currentHoverArea_ = a;
+
+                        a.emitHoverEvent(HoverEvent{true, true});
+                    }
+
+                    break;
+                }
+            }
+
+            bool accepted = false;
+            for (auto &item : areas_)
+            {
+                if (!e.buttons.at(item.first - 1))
+                    continue;
+
+                std::vector<InputArea> newAreas;
+                for (auto &&area : item.second)
+                {
+                    EventResult r = area.emitMoveEvent(e);
+                    if (r == EventResult::accept)
+                    {
+                        newAreas.clear();
+                        newAreas.emplace_back(std::move(area));
+                        accepted = true;
+                        break;
+                    }
+                    else if (r == EventResult::possible)
+                    {
+                        newAreas.push_back(std::move(area));
+                    }
+                    else if (r == EventResult::reject)
+                    {
+                    }
+                }
+
+                item.second = std::move(newAreas);
+
+                if (accepted)
+                    break;
+            }
+        });
+
+        aseWindow.setDragCallback([](ase::PointerDragEvent const & /*e*/)
+                {
+                });
+
+        aseWindow.setKeyCallback([this](ase::KeyEvent const &e)
+        {
+            if (currentKeyHandler_.has_value() && e.isDown())
+            {
+                (*currentKeyHandler_)(e);
+                keys_[e.getKey()] = *currentKeyHandler_;
+
+                aseWindow.requestFrame();
+            }
+            else
+            {
+                auto i = keys_.find(e.getKey());
+                if (i == keys_.end())
+                    return;
+                auto f = i->second;
+                keys_.erase(i);
+
+                f(e);
+
+                aseWindow.requestFrame();
+            }
+        });
+
+        aseWindow.setTextCallback([this](ase::TextEvent const& e)
+        {
+            if (currentTextHandler_.has_value())
+            {
+                (*currentTextHandler_)(e);
+
+                aseWindow.requestFrame();
+            }
+        });
+
+        aseWindow.setHoverCallback([this](ase::HoverEvent const &e)
+        {
+            if (!e.hover)
+            {
+                if (currentHoverArea_.has_value())
+                {
+                    currentHoverArea_->emitHoverEvent(e);
+                    currentHoverArea_ = std::nullopt;
+
+                    aseWindow.requestFrame();
+                }
+            }
+        });
+    }
+
+    WindowImpl(WindowImpl const &) = delete;
+    WindowImpl &operator=(WindowImpl const &) = delete;
+
+    virtual ~WindowImpl()
+    {
+        std::cout << "Maximum concurrent allocations: "
+            << memoryStatistics_.maximum_concurrent_bytes_allocated()
+            << std::endl;
+    }
+
+    std::optional<bq::signal::signal_time_t> makeTransaction(
+            std::chrono::microseconds dt,
+            std::optional<avg::AnimationOptions> const& animationOptions
+            )
+    {
+        ZoneScoped;
+
+        auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(timer_);
+
+        bq::signal::FrameInfo frameInfo(getNextFrameId(), dt);
+
+        auto updateResult = widgetInstanceSignal_.update(frameInfo);
+        updateResult = updateResult + titleSignal_.update(frameInfo);
+
+
+        if (titleSignal_.didChange<0>())
+            aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
+
+        if (widgetInstanceSignal_.didChange<0>())
+        {
+            ZoneScopedN("Widget instance signal evaluation");
+
+            widgetInstance_ = widgetInstanceSignal_.evaluate<0>().get<0>();
+
+            // If there's an area with the same id -> update
+            auto areas = widgetInstance_.getInputAreas();
+            for (auto&& area : areas_)
+            {
+                for (InputArea& area3 : area.second)
+                {
+                    for (InputArea& area2 : areas)
+                    {
+                        if (area3.getId() == area2.getId())
+                        {
+                            area3 = std::move(area2);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            auto inputs = widgetInstance_.getKeyboardInputs();
+            for (auto&& input : inputs)
+            {
+                auto handle = input.getFocusHandle();
+
+                bool focus = input.getRequestFocus() || input.hasFocus();
+                if (focus && handle.has_value())
+                {
+                    if (input.getRequestFocus())
+                    {
+                        if (currentHandle_.has_value())
+                            currentHandle_->set(false);
+                        handle->set(true);
+                    }
+
+                    currentHandle_ = handle;
+                    currentKeyHandler_ = input.getKeyHandler();
+                    currentTextHandler_ = input.getTextHandler();
+
+                    if (input.getRequestFocus())
+                        break;
+                }
+            }
+
+            if (!currentHandle_.has_value() && !inputs.empty())
+            {
+                auto handle = inputs[0];
+                currentHandle_ = handle.getFocusHandle();
+                if (currentHandle_.has_value())
+                    currentHandle_->set(true);
+                currentKeyHandler_ = handle.getKeyHandler();
+                currentTextHandler_ = handle.getTextHandler();
+            }
+        }
+
+        if (widgetInstanceSignal_.didChange<0>()
+                || (nextUpdate_ && *nextUpdate_ <= timer)
+                )
+        {
+            ZoneScopedN("RenderTree update");
+            auto [renderTree, nextUpdate] = std::move(renderTree_).update(
+                    btl::clone(widgetInstance_.getRenderTree()),
+                    animationOptions,
+                    timer
+                    );
+
+            if (nextUpdate_ && *nextUpdate_ < timer)
+                nextUpdate_ = std::nullopt;
+
+            if (nextUpdate && *nextUpdate < timer)
+                nextUpdate = std::nullopt;
+
+            nextUpdate_ = avg::earlier(nextUpdate_, nextUpdate);
+
+            renderTree_ = std::move(renderTree);
+
+            animating_ = true;
+
+            aseWindow.requestFrame();
+        }
+
+        return updateResult.nextUpdate;
+    }
+
+    std::optional<bq::signal::signal_time_t> frame(std::chrono::microseconds dt)
+    {
+        ZoneScoped;
+
+        return onFrame( { timer_, dt });
+    }
+
+    std::optional<std::chrono::microseconds> onFrame(ase::Frame const& frame)
+    {
+        ZoneScoped;
+
+        timer_ = frame.time;
+
+        if (resized_)
+        {
+            size_.handle.set(aseWindow.getSize().cast<float>());
+            painter_.setSize(aseWindow.getSize());
+            resized_ = false;
+        }
+
+        auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(
+                timer_);
+
+        auto timeToNext = makeTransaction(frame.dt, std::nullopt);
+
+        if (animating_)
+        {
+            auto [drawing, cont] = renderTree_.draw(
+                    avg::DrawContext(&painter_),
+                    avg::Obb(aseWindow.getSize().cast<float>()),
+                    timer
+                    );
+
+            drawing_ = std::move(drawing);
+            animating_ = cont;
+        }
+
+        painter_.clearWindow(aseWindow);
+        painter_.paintToWindow(aseWindow, drawing_);
+        painter_.presentWindow(aseWindow);
+        painter_.flush();
+
+        ++frames_;
+
+        if (animating_)
+            return std::chrono::microseconds(0);
+
+        return timeToNext;
+    }
+
+    btl::UniqueId getId() const
+    {
+        return windowData_->getId();
+    }
+
+    uint64_t getFrames() const
+    {
+        return frames_;
+    }
+
+    std::string getTitle() const
+    {
+        return titleSignal_.evaluate<0>().get<0>();
+    }
+
+    widget::Instance const& getWidgetInstance() const
+    {
+        return widgetInstance_;
+    }
+
+private:
+    pmr::unsynchronized_pool_resource memoryPool_;
+    pmr::statistics_resource memoryStatistics_;
+    pmr::memory_resource* memory_;
+    ase::Window aseWindow;
+    ase::RenderContext& context_;
+
+    std::shared_ptr<WindowData> windowData_;
+    avg::Painter painter_;
+    bq::signal::Input<bq::signal::SignalResult<ase::Vector2f>,
+        bq::signal::SignalResult<ase::Vector2f>> size_;
+    bq::signal::SignalContext<bq::signal::AnySignal<widget::Instance>>
+        widgetInstanceSignal_;
+    widget::Instance widgetInstance_;
+    bq::signal::SignalContext<bq::signal::AnySignal<std::string>> titleSignal_;
+    //RenderCache cache_;
+    std::unordered_map<unsigned int, std::vector<InputArea>> areas_;
+    std::unordered_map<ase::KeyCode,
+        std::function<void(ase::KeyEvent const&)>> keys_;
+    std::optional<bq::signal::InputHandle<bool>> currentHandle_;
+    std::optional<KeyboardInput::KeyHandler> currentKeyHandler_;
+    std::optional<KeyboardInput::TextHandler> currentTextHandler_;
+    uint64_t frames_ = 0;
+    std::optional<InputArea> currentHoverArea_;
+
+    std::chrono::microseconds timer_ = std::chrono::microseconds(0);
+    avg::RenderTree renderTree_;
+    std::optional<avg::AnimationOptions> animationOptions_;
+    avg::Drawing drawing_;
+    std::optional<std::chrono::milliseconds> nextUpdate_;
+    bool animating_ = true;
+    bool resized_ = true;
+    bool closed_ = false;
+};
+
+} // namespace bqui

--- a/src/bqui/test/apptest.cpp
+++ b/src/bqui/test/apptest.cpp
@@ -1,0 +1,570 @@
+#include <bqui/app.h>
+#include <bqui/window.h>
+
+#include <bqui/widget/widget.h>
+#include <bqui/modifier/onclick.h>
+
+#include <bq/signal/constant.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signalcontext.h>
+
+#include <btl/uniqueid.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace bqui;
+
+// Each test builds its own App rather than calling app(), whose App shares one
+// AppDeferred with every other caller — two tests would then run the same
+// window collection.
+//
+// The app's window collection is imperative: addWindow/removeWindow/close reach
+// it directly, and the run loop mounts one WindowImpl per window to it each
+// frame. Two things are observable from outside without any App-level hook:
+//
+//   - A window's title is read once when its impl mounts, when the impl builds
+//     its title SignalContext; every later read is cached, and the dummy
+//     platform runs no window frames that could invalidate it. Counting reads
+//     of a title therefore counts mountings, and a title read is equally the
+//     report that the window has opened.
+//   - A probe captured in a window's *widget* lives exactly as long as its
+//     mounted impl does: the widget is the impl's, torn down when the window
+//     leaves the collection. A window's persistent data does not hold it, so
+//     the probe expiring is the impl being torn down — the observable proof of
+//     an unmount, and, when the widget captured the owning Window, of that
+//     capture not leaking.
+
+namespace
+{
+    using Probe = std::shared_ptr<int>;
+    using Opens = std::map<std::string, int>;
+
+    auto countReads(Opens& opens)
+    {
+        return [&opens](std::string const& title)
+        {
+            ++opens[title];
+            return title;
+        };
+    }
+
+    // A widget whose mounted instance retains the probe: the click handler it
+    // carries holds it, so the probe lives as long as the impl and expires when
+    // the window unmounts.
+    widget::AnyWidget probeWidget(Probe probe)
+    {
+        return widget::makeWidget()
+            | modifier::onClick(0, bq::signal::constant(
+                        std::function<void()>([probe]() {})));
+    }
+
+    Window makeWindow(std::string title, Opens& opens)
+    {
+        return window(
+                bq::signal::constant(std::move(title)).map(countReads(opens)));
+    }
+
+    // The dummy platform's loop has no bound of its own, so a regression that
+    // stopped a script advancing would hang rather than fail.
+    constexpr int maxFrames = 100;
+
+    // A title that reports the window opening. The title is read once, when the
+    // impl builds its title SignalContext, which is the app loop mounting the
+    // window.
+    auto reportOpen(std::string title, std::atomic<bool>& opened)
+    {
+        return bq::signal::constant(std::move(title)).map(
+                [&opened](std::string const& text)
+                {
+                    opened = true;
+                    return text;
+                });
+    }
+
+    // Waits for the app loop to report something, and gives up rather than
+    // hanging if it never does — a stopped loop has to fail the test, not wedge
+    // the suite. The deadline is a backstop and not an ordering proxy: the test
+    // proceeds on the flag, never on the clock.
+    bool waitFor(std::atomic<bool> const& flag)
+    {
+        auto const deadline = std::chrono::steady_clock::now()
+            + std::chrono::seconds(30);
+
+        while (!flag)
+        {
+            if (std::chrono::steady_clock::now() > deadline)
+                return false;
+
+            std::this_thread::yield();
+        }
+
+        return true;
+    }
+} // namespace
+
+// A window added with its widget mounts and opens: its title is read once, and
+// it is in the collection. The script drives itself through a caller-supplied
+// 'running' signal, which also controls the loop.
+TEST(App, addWindowMountsAndOpens)
+{
+    Opens opens;
+
+    App app;
+
+    Window w = makeWindow("only", opens);
+    app.addWindow(w, probeWidget(std::make_shared<int>(0)));
+
+    int frames = 0;
+    bool openWhileRunning = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    // Runs when the context is built, before the initial sync
+                    // mounts the window; nothing to observe yet.
+                    break;
+
+                case 1:
+                    // The initial sync has mounted the window by now.
+                    openWhileRunning = opens["only"] == 1
+                        && app.getWindows().size() == 1u;
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    app.run(running);
+
+    EXPECT_LT(frames, maxFrames);
+    EXPECT_TRUE(openWhileRunning);
+    EXPECT_EQ(opens, (Opens{ { "only", 1 } }));
+}
+
+// The crucial cycle-safety case. A window's widget is a close button that
+// captures the *owning* Window and closes through it. Because the widget lives
+// in the app-owned impl and the Window points back at the app only weakly, this
+// closes no cycle: after the window is closed the impl is torn down, its widget
+// with it, and the probe the widget held expires. A retain cycle would keep the
+// impl alive and the probe would never expire.
+TEST(App, aCloseButtonCapturingItsOwnWindowDoesNotLeak)
+{
+    App app;
+
+    std::weak_ptr<int> probe;
+
+    Window w = window(bq::signal::constant<std::string>("cycle"));
+
+    {
+        Probe held = std::make_shared<int>(0);
+        probe = held;
+
+        // The widget captures the owning window (to close it) and the probe.
+        app.addWindow(w, widget::makeWidget()
+                | modifier::onClick(0, bq::signal::constant(
+                        std::function<void()>([w, held]() { w.close(); }))));
+    }
+
+    int frames = 0;
+    bool tornDown = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    // Built before the initial sync mounts the window; the
+                    // widget (and its probe) waits in the pending queue.
+                    break;
+
+                case 1:
+                    // Mounted now; the probe is held by the window's widget.
+                    EXPECT_FALSE(probe.expired());
+                    break;
+
+                case 2:
+                    // Close through the captured owning handle.
+                    w.close();
+                    break;
+
+                case 3:
+                    // Let the frame that removed it tear its impl down.
+                    break;
+
+                case 4:
+                    tornDown = probe.expired();
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    app.run(running);
+
+    EXPECT_LT(frames, maxFrames);
+
+    // The impl — and the widget that captured the owning window — is gone, so
+    // the probe it held has expired: the capture did not leak the window.
+    EXPECT_TRUE(tornDown);
+    EXPECT_TRUE(probe.expired());
+    EXPECT_TRUE(app.getWindows().empty());
+}
+
+// Removing a window during the run tears its impl down there and then, while
+// the window's own data — held by a Window the caller kept — lives on and still
+// reads its props.
+TEST(App, removeDuringRunTearsDownButDataPersists)
+{
+    App app;
+
+    std::weak_ptr<int> probe;
+
+    Window w = window(bq::signal::constant<std::string>("kept"));
+
+    {
+        Probe held = std::make_shared<int>(0);
+        probe = held;
+        app.addWindow(w, probeWidget(held));
+    }
+
+    int frames = 0;
+    bool aliveWhileOpen = false;
+    bool goneAfterClose = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    // Built before the initial sync mounts the window.
+                    break;
+
+                case 1:
+                    aliveWhileOpen = !probe.expired();
+                    app.removeWindow(w.getId());
+                    break;
+
+                case 2:
+                    break;
+
+                case 3:
+                    goneAfterClose = probe.expired();
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    app.run(running);
+
+    EXPECT_LT(frames, maxFrames);
+    EXPECT_TRUE(aliveWhileOpen);
+    EXPECT_TRUE(goneAfterClose);
+    EXPECT_TRUE(app.getWindows().empty());
+
+    // The widget is gone, but the window's data is not: the Window still reads
+    // its title.
+    EXPECT_EQ("kept", bq::signal::makeSignalContext(w.getTitle())
+            .evaluate<0>().get<0>());
+}
+
+// Adding the same window again after it was removed remounts it with a fresh
+// widget; the old widget is torn down and the new one is what the window runs.
+TEST(App, reAddAfterRemoveRemountsWithFreshWidget)
+{
+    App app;
+
+    std::weak_ptr<int> first;
+    std::weak_ptr<int> second;
+
+    Window w = window(bq::signal::constant<std::string>("remount"));
+
+    {
+        Probe held = std::make_shared<int>(0);
+        first = held;
+        app.addWindow(w, probeWidget(held));
+    }
+
+    int frames = 0;
+    bool firstGone = false;
+    bool secondAlive = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    // Built before the initial sync mounts the first widget.
+                    break;
+
+                case 1:
+                    // The first widget is mounted; remove it to unmount.
+                    app.removeWindow(w.getId());
+                    break;
+
+                case 2:
+                    // The old impl is torn down; re-add with a fresh widget.
+                    {
+                        Probe held = std::make_shared<int>(0);
+                        second = held;
+                        app.addWindow(w, probeWidget(held));
+                    }
+                    break;
+
+                case 3:
+                    // Let the re-add mount.
+                    break;
+
+                case 4:
+                    firstGone = first.expired();
+                    secondAlive = !second.expired();
+                    break;
+
+                case 5:
+                    app.removeWindow(w.getId());
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    app.run(running);
+
+    EXPECT_LT(frames, maxFrames);
+    EXPECT_TRUE(firstGone);
+    EXPECT_TRUE(secondAlive);
+    EXPECT_TRUE(first.expired());
+    EXPECT_TRUE(second.expired());
+    EXPECT_TRUE(app.getWindows().empty());
+}
+
+// A window that survives an edit keeps the impl it already had — its title is
+// not read twice — and a window that is removed is torn down there and then,
+// while the survivor lives on.
+TEST(App, windowsOpenAndCloseImperatively)
+{
+    Opens opens;
+    std::vector<std::weak_ptr<int>> probes;
+
+    App app;
+
+    std::vector<btl::UniqueId> ids;
+    auto open = [&](std::string title)
+    {
+        Probe held = std::make_shared<int>(0);
+        probes.push_back(held);
+
+        Window w = makeWindow(std::move(title), opens);
+        ids.push_back(w.getId());
+        app.addWindow(w, probeWidget(held));
+    };
+
+    open("first");
+
+    int frames = 0;
+    bool survivorOutlivedTheDeparted = false;
+
+    auto step = bq::signal::makeInput(0);
+
+    auto running = step.signal.map(
+            [&](int i) -> bool
+            {
+                if (++frames > maxFrames)
+                    return false;
+
+                switch (i)
+                {
+                case 0:
+                    open("second");
+                    break;
+
+                case 1:
+                    app.removeWindow(ids[0]);
+                    break;
+
+                case 2:
+                    // Let the frame that removed "first" tear its impl down.
+                    break;
+
+                case 3:
+                    survivorOutlivedTheDeparted = probes.size() == 2u
+                        && probes[0].expired()
+                        && !probes[1].expired();
+                    break;
+
+                case 4:
+                    app.removeWindow(ids[1]);
+                    break;
+
+                default:
+                    return false;
+                }
+
+                step.handle.set(i + 1);
+
+                return true;
+            });
+
+    app.run(running);
+
+    EXPECT_LT(frames, maxFrames);
+
+    EXPECT_TRUE(survivorOutlivedTheDeparted);
+
+    // The survivor opened when it arrived and not again when its neighbour
+    // left.
+    EXPECT_EQ(opens, (Opens{ { "first", 1 }, { "second", 1 } }));
+
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_TRUE(probes[0].expired());
+    EXPECT_TRUE(probes[1].expired());
+    EXPECT_TRUE(app.getWindows().empty());
+}
+
+// Windows added before the run all mount once, and all are torn down when the
+// app that owns them is destroyed.
+TEST(App, addedWindowsAllOpenOnce)
+{
+    Opens opens;
+    std::vector<std::weak_ptr<int>> probes;
+
+    int frames = 0;
+
+    {
+        App app;
+
+        for (auto title : { "a", "b", "c" })
+        {
+            Probe held = std::make_shared<int>(0);
+            probes.push_back(held);
+            app.addWindow(makeWindow(title, opens), probeWidget(held));
+        }
+
+        auto step = bq::signal::makeInput(0);
+
+        auto running = step.signal.map(
+                [&](int i) -> bool
+                {
+                    if (++frames > maxFrames || i != 0)
+                        return false;
+
+                    step.handle.set(1);
+
+                    return true;
+                });
+
+        app.run(running);
+
+        EXPECT_LT(frames, maxFrames);
+
+        EXPECT_EQ(opens, (Opens{ { "a", 1 }, { "b", 1 }, { "c", 1 } }));
+    }
+
+    // The app is destroyed with its three windows still mounted, which releases
+    // their impls and the widgets they held.
+    for (auto const& probe : probes)
+        EXPECT_TRUE(probe.expired());
+}
+
+TEST(App, runWithNoWindowsReturnsImmediately)
+{
+    EXPECT_EQ(0, App().run());
+}
+
+// run() with no signal runs while a window is open, so closing one of several
+// removes it and only the last one stops the app. A window added while the loop
+// runs opens, which is what proves the loop was still running.
+TEST(App, runStopsWhenTheLastWindowCloses)
+{
+    std::atomic<bool> firstOpened { false };
+    std::atomic<bool> laterOpened { false };
+
+    App app;
+
+    Window first = window(reportOpen("first", firstOpened));
+    Window second = window(bq::signal::constant<std::string>("second"));
+    Window later = window(reportOpen("later", laterOpened));
+
+    app.addWindow(first, widget::makeWidget());
+    app.addWindow(second, widget::makeWidget());
+
+    std::thread closer([&]()
+        {
+            if (waitFor(firstOpened))
+            {
+                first.close();
+                app.addWindow(later, widget::makeWidget());
+                waitFor(laterOpened);
+            }
+
+            // Closed unconditionally, and closing twice or closing a window
+            // that was never added is a no-op: a loop that did not report what
+            // was waited for has to fail the assertions rather than run on.
+            first.close();
+            second.close();
+            later.close();
+        });
+
+    EXPECT_EQ(0, app.run());
+
+    closer.join();
+
+    EXPECT_TRUE(laterOpened);
+    EXPECT_TRUE(app.getWindows().empty());
+}

--- a/src/bqui/test/windowtest.cpp
+++ b/src/bqui/test/windowtest.cpp
@@ -1,0 +1,245 @@
+#include <bqui/app.h>
+#include <bqui/window.h>
+
+#include <bqui/widget/widget.h>
+
+#include <bq/signal/constant.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/signalcontext.h>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace bqui;
+
+// The app's window collection, without running the app. A window is a handle
+// over its own persistent data, and everything here is true of that data and
+// of the collection an App holds it in — which is why these tests need no
+// display. App::run itself is covered in apptest.cpp, where the backend is
+// headless.
+//
+// A window's widget is mount-time content supplied to addWindow; it is not part
+// of the window and these tests never run it, so they pass an empty one.
+
+namespace
+{
+    Window makeWindow(std::string title)
+    {
+        return window(bq::signal::constant(std::move(title)));
+    }
+
+    void add(App& app, Window window)
+    {
+        app.addWindow(std::move(window), widget::makeWidget());
+    }
+
+    std::vector<std::string> titles(std::vector<Window> const& windows)
+    {
+        std::vector<std::string> result;
+
+        for (auto const& window : windows)
+        {
+            result.push_back(bq::signal::makeSignalContext(window.getTitle())
+                    .evaluate<0>().get<0>());
+        }
+
+        return result;
+    }
+} // namespace
+
+TEST(AppWindows, copiesAreOneWindow)
+{
+    Window w = makeWindow("a");
+    Window copy = w;
+
+    EXPECT_EQ(w.getId(), copy.getId());
+    EXPECT_NE(w.getId(), makeWindow("a").getId());
+}
+
+TEST(AppWindows, addWindowAppends)
+{
+    App app;
+
+    add(app, makeWindow("a"));
+    add(app, makeWindow("b"));
+    add(app, makeWindow("c"));
+
+    EXPECT_EQ((std::vector<std::string>{ "a", "b", "c" }),
+            titles(app.getWindows()));
+}
+
+TEST(AppWindows, removeWindowRemovesByIdentity)
+{
+    App app;
+
+    Window a = makeWindow("a");
+    Window b = makeWindow("b");
+    add(app, a);
+    add(app, b);
+
+    app.removeWindow(a.getId());
+
+    EXPECT_EQ(std::vector<std::string>{ "b" }, titles(app.getWindows()));
+}
+
+TEST(AppWindows, removingAWindowThatIsNotThereDoesNothing)
+{
+    App app;
+    add(app, makeWindow("a"));
+
+    app.removeWindow(makeWindow("b").getId());
+
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(app.getWindows()));
+}
+
+TEST(AppWindows, aWindowClosesItself)
+{
+    App app;
+
+    Window a = makeWindow("a");
+    Window b = makeWindow("b");
+    add(app, a);
+    add(app, b);
+
+    a.close();
+
+    EXPECT_EQ(std::vector<std::string>{ "b" }, titles(app.getWindows()));
+
+    // Closing twice is a race a UI can lose, so the second close is not an
+    // error.
+    a.close();
+
+    EXPECT_EQ(std::vector<std::string>{ "b" }, titles(app.getWindows()));
+}
+
+// A widget inside the window may hold the very Window that owns it and close it
+// through that. A window is a small handle now, so this closes no cycle: the
+// app owns the widget, the widget owns the window, and the window points back
+// at the app only weakly.
+TEST(AppWindows, aWidgetInsideTheWindowCanCloseIt)
+{
+    App app;
+
+    Window w = makeWindow("a");
+    std::function<void()> closeFromTheWidget = [w]() { w.close(); };
+
+    app.addWindow(w, widget::makeWidget());
+
+    ASSERT_EQ(1u, app.getWindows().size());
+    EXPECT_EQ(w.getId(), app.getWindows()[0].getId());
+
+    closeFromTheWidget();
+
+    EXPECT_TRUE(app.getWindows().empty());
+}
+
+TEST(AppWindows, closingAWindowThatWasNeverAddedDoesNothing)
+{
+    Window a = makeWindow("a");
+
+    a.close();
+
+    App app;
+    add(app, a);
+
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(app.getWindows()));
+}
+
+// A window outlives its app whenever a widget or a callback still names it,
+// and the app is what close() reaches. It is held weakly for exactly this.
+TEST(AppWindows, closingAWindowWhoseAppIsGoneDoesNothing)
+{
+    std::optional<App> app;
+    app.emplace();
+
+    Window a = makeWindow("a");
+    add(*app, a);
+
+    app.reset();
+
+    a.close();
+}
+
+TEST(AppWindows, aWindowCannotBeOpenedTwice)
+{
+    App app;
+
+    Window a = makeWindow("a");
+    add(app, a);
+
+    EXPECT_THROW(add(app, a), std::invalid_argument);
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(app.getWindows()));
+}
+
+// A window belongs to one app, because close() has to know which app to leave.
+// Being open in one is what makes it unavailable, not having ever been added.
+TEST(AppWindows, aWindowCannotBeOpenInTwoApps)
+{
+    App first;
+    App second;
+
+    Window a = makeWindow("a");
+    add(first, a);
+
+    EXPECT_THROW(add(second, a), std::invalid_argument);
+    EXPECT_TRUE(second.getWindows().empty());
+
+    first.removeWindow(a.getId());
+
+    add(second, a);
+
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(second.getWindows()));
+
+    // The window follows: it is the second app it closes out of now.
+    a.close();
+
+    EXPECT_TRUE(second.getWindows().empty());
+}
+
+TEST(AppWindows, aWindowThatWasClosedCanBeOpenedAgain)
+{
+    App app;
+
+    Window a = makeWindow("a");
+    add(app, a);
+    a.close();
+
+    add(app, a);
+
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(app.getWindows()));
+}
+
+TEST(AppWindows, theWindowSignalFollowsTheCollection)
+{
+    App app;
+    add(app, makeWindow("a"));
+
+    auto c = bq::signal::makeSignalContext(app.getWindowsSignal());
+
+    EXPECT_EQ(std::vector<std::string>{ "a" },
+            titles(c.evaluate<0>().get<0>()));
+
+    add(app, makeWindow("b"));
+    c.update(bq::signal::FrameInfo(1, {}));
+
+    EXPECT_EQ((std::vector<std::string>{ "a", "b" }),
+            titles(c.evaluate<0>().get<0>()));
+}
+
+// Copies of an App are one app: it is a handle to the state, which is what
+// lets app() hand the same one out everywhere.
+TEST(AppWindows, copiesShareTheCollection)
+{
+    App app;
+    App copy = app;
+
+    add(copy, makeWindow("a"));
+
+    EXPECT_EQ(std::vector<std::string>{ "a" }, titles(app.getWindows()));
+}

--- a/src/testapp1/main.cpp
+++ b/src/testapp1/main.cpp
@@ -33,7 +33,6 @@
 
 #include <bqui/simplesizehint.h>
 #include <bqui/keyboardinput.h>
-#include <bqui/send.h>
 #include <bqui/window.h>
 #include <bqui/app.h>
 #include <bqui/withanimation.h>
@@ -47,6 +46,8 @@
 #include <btl/future.h>
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 using namespace bqui;
 
@@ -68,6 +69,22 @@ std::vector<std::pair<std::string, avg::Curve>> curves = {
     { "easeOutBounce", avg::curve::easeOutBounce },
     { "easeInOutBounce", avg::curve::easeInOutBounce },
 };
+
+void openSecondWindow()
+{
+    Window w = window(bq::signal::constant<std::string>("Second window"));
+
+    app().addWindow(
+            w,
+            widget::button("Close me",
+                    bq::signal::constant(std::function<void()>(
+                            [w]()
+                            {
+                                w.close();
+                            })))
+                | modifier::frame()
+                | modifier::focusGroup());
+}
 
 int main()
 {
@@ -120,8 +137,50 @@ int main()
                 avg::RepeatMode::reverse
                 ));
 
+    auto showTracked = bq::signal::makeInput(false);
+    Window trackedWindow = window(
+            bq::signal::constant<std::string>("Tracked window"));
+    trackedWindow = std::move(trackedWindow).onClose(
+            [opened = showTracked.handle]() mutable { opened.set(false); });
+
+    auto openTracked = [trackedWindow, opened = showTracked.handle]() mutable
+    {
+        opened.set(true);
+
+        Window w = trackedWindow;
+
+        app().addWindow(
+                trackedWindow,
+                widget::button("Close me", bq::signal::constant(
+                        std::function<void()>([w]() mutable
+                            {
+                                w.close();
+                            })))
+                    | modifier::frame()
+                    | modifier::focusGroup());
+    };
+
     auto widgets = widget::hbox({
         widget::vbox({
+            widget::button("Open another window",
+                    bq::signal::constant(std::function<void()>(
+                            []() { openSecondWindow(); })))
+                | modifier::setSizeHint({ 250, 50 }),
+            widget::button(
+                    showTracked.signal.map([](bool b) -> std::string
+                        {
+                            return b ? "Close tracked window"
+                                : "Open tracked window";
+                        }),
+                    showTracked.signal.bindToFunction(
+                        [trackedWindow, openTracked](bool b) mutable
+                        {
+                            if (b)
+                                trackedWindow.close();
+                            else
+                                openTracked();
+                        }))
+                | modifier::setSizeHint({ 250, 50 }),
             shape::rectangle()
                 //.size(bq::signal::constant(avg::Vector2f(100, 100)))
                 //.transform(bq::signal::constant(avg::translate(10, 20)))
@@ -180,14 +239,11 @@ int main()
     });
 
     return app()
-        .windows({
-                window(
-                    bq::signal::constant<std::string>("Test program"),
-                    std::move(widgets)
-                    //| debug::drawKeyboardInputs()
-                    | modifier::focusGroup()
-                    )
-                })
+        .addWindow(
+                window(bq::signal::constant<std::string>("Test program")),
+                std::move(widgets)
+                //| debug::drawKeyboardInputs()
+                | modifier::focusGroup()
+                )
         .run();
 }
-


### PR DESCRIPTION
App owns its windows imperatively. `Window` is a copyable value handle; the widget is separate, supplied at mount.

## Window
- `window(title)` mints a handle with a fresh identity, belonging to no app, holding no widget.
- Copyable/movable; copies share one identity.
- API: `onClose(cb)`, `getTitle()`, `getId()`, `close()`, `clone()`.
- Backed by a shared `WindowData` (id, title, close callbacks, weak app ref); survives remove then re-add.

## App
- `addWindow(window, widget)` opens and mounts; the widget is content, not identity.
- `removeWindow(id)` / `Window::close()` unmount: destroy the widget, keep the data.
- Re-adding a removed window supplies a fresh widget.
- `getWindows()` snapshot; `getWindowsSignal()` reactive.
- `run(running)` runs until `running` is false; `run()` runs until the last window closes.
- `addWindow`/`removeWindow`/`getWindows`/`Window::close` are lock-guarded (usable from a worker thread); everything else is the app thread.
- Throws `std::invalid_argument` when adding a window already open here or in another app (a window and its copies are one window).

## Internals
- `WindowImpl` (App-owned, keyed by id) owns the OS window, painter, and widget; in `src/bqui/src/windowimpl.h`. `app.cpp` is the collection + run loop.
- No retain cycle: App -> WindowImpl -> widget -> Window -> WindowData, and WindowData -> app is weak. A close button capturing its own Window is safe; `apptest` asserts teardown.

## Behaviour change
- `run()` (no arg) stops at the last window close, not the first close (see `docs/decisions.md`). `run(running)` unchanged.

## Tests
- `windowtest.cpp`: backend-free; covers the handle and `close()` after the app is destroyed, on every platform.
- `apptest.cpp`: run loop; builds only where `ase` is headless (macOS CI).

`bq` untouched. Commits: code, then docs.
