### PR TITLE
Let the render tree describe itself (avg::Snapshot)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -67,15 +67,15 @@ simply was not one.
 ## A render tree snapshot is hand-written JSON, in avg
 
 `avg::RenderTree::snapshot` builds a plain struct tree, and `avg::toJson`
-serialises it with a writer of about eighty lines in `avg` itself. No JSON
-library is vendored, and the writer is not shared with `bqui`.
+serialises it with a small writer in `avg` itself. No JSON library is vendored,
+and the writer is not shared with `bqui`.
 
 **Why:** the payload is one document of known shape — objects, arrays, strings,
 numbers — so a parser-grade dependency buys nothing and costs a subproject on
 every configure. The snapshot is a wire format, so it carries an explicit
 schema version; the struct tree stays separate from its encoding, which is what
 lets a second encoding be added without touching the walk. Sharing a writer
-with `bqui` would invert the dependency order (`avg` is beneath it), and
+with `bqui` would invert the dependency order (`avg` is beneath it), so
 duplicating the escaping rules is the cheaper of the two.
 
 ## `App::run()` with no arguments stops at zero windows, not at the first close

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -64,6 +64,20 @@ shorter run loop whose glue lifecycle reads straight down the page. `ArraySignal
 and `forEach` stay in `bq` — the layout engine is their real consumer; `App`
 simply was not one.
 
+## A render tree snapshot is hand-written JSON, in avg
+
+`avg::RenderTree::snapshot` builds a plain struct tree, and `avg::toJson`
+serialises it with a writer of about eighty lines in `avg` itself. No JSON
+library is vendored, and the writer is not shared with `bqui`.
+
+**Why:** the payload is one document of known shape — objects, arrays, strings,
+numbers — so a parser-grade dependency buys nothing and costs a subproject on
+every configure. The snapshot is a wire format, so it carries an explicit
+schema version; the struct tree stays separate from its encoding, which is what
+lets a second encoding be added without touching the walk. Sharing a writer
+with `bqui` would invert the dependency order (`avg` is beneath it), and
+duplicating the escaping rules is the cheaper of the two.
+
 ## `App::run()` with no arguments stops at zero windows, not at the first close
 
 `run()` used to stop when *any* window closed; it now runs while a window

--- a/src/avg/AGENTS.md
+++ b/src/avg/AGENTS.md
@@ -23,6 +23,9 @@ outgrows one file.
   `ShapeElement` / `TextEntry` / `ClipElement` / `RegionFill`. **Clipping is
   rectangular only**: `Drawing::clip` takes `Rect`/`Obb`, and there is no
   region/shape clip. (Path-level clipping is deferred — `docs/decisions.md`.)
+- **Trap:** `Shape::getControlBb` applies a composed element's transform twice
+  in its `Operation` branch; the sibling `StrokeToShape` branch is correct.
+  Known and unfixed — geometry derived from it inherits the error.
 
 ## Render tree
 
@@ -47,20 +50,22 @@ virtual, so adding a node kind means adding that override.
 - **Geometry is resolved, not authored.** A node reports its box already
   composed with every enclosing obb, so a reader places it without a transform
   of its own. It is derived from the nodes' `Animated<Obb>`, never from
-  `Shape::getControlBb`, so it does not inherit that function's double-transform
-  bug.
+  `Shape::getControlBb`, so it does not inherit that function's trap above.
 - **Text comes from drawing, not from the tree.** A leaf's content lives inside
   its draw function, so a leaf is drawn on its own out of the caller's memory
   and the `TextEntry`s of the result are collected; the drawing is discarded.
+  A snapshot therefore costs a whole draw pass. Because a leaf is drawn in
+  isolation, an enclosing `ClipNode` applies itself afterwards, through
+  `clipSnapshotText`.
 - **Nulls are expected.** An empty tree yields no root, and a node whose child
   is null yields no child; the walker never assumes a well-formed tree.
 
 `toJson` writes schema version 1: an envelope of `version`, `time`, `obb` and
-`root`, and per node `type`, `obb` (`center`/`size`/`angle`/`scale`), `text`
-and `children`, plus `id` when the node has one and `leaving` when the subtree
-is on its way out. Numbers are `%.9g` with non-finite written as zero. The
-schema is a contract — extend it additively and bump `Snapshot::version` when
-an existing field changes meaning.
+`root`, and per node `type`, `obb` (`center`/`size`/`angle`), `text` and
+`children`, plus `id` when the node has one and `leaving` when the subtree is
+on its way out. Text is passed through as the UTF-8 bytes the `TextEntry`
+carries. The schema is a contract — extend it additively and bump
+`Snapshot::version` when an existing field changes meaning.
 
 ## Animation
 

--- a/src/avg/AGENTS.md
+++ b/src/avg/AGENTS.md
@@ -1,6 +1,6 @@
 # avg — agent notes
 
-*Last verified against `9c47767` (2026-07-21).*
+*Last verified against `44d4091` (2026-07-22).*
 
 Internals, entry points, and traps for the vector-graphics layer. Concepts and
 usage are in `readme.md`; project-wide conventions are in the top-level `docs/`.
@@ -35,6 +35,32 @@ outgrows one file.
   transitions); `draw(context, obb, time)` is a **pure** function of the
   timestamp and returns whether animation continues, so nodes report when they
   next need a redraw.
+
+## Render tree snapshots
+
+`rendertree/snapshot.h` describes a tree instead of drawing it, for tooling
+outside the process. `RenderTree::snapshot` mirrors `draw`: same arguments,
+same pure-function contract, same subtree — a transition contributes only the
+branch that is on screen. Each node describes itself through the `snapshot`
+virtual, so adding a node kind means adding that override.
+
+- **Geometry is resolved, not authored.** A node reports its box already
+  composed with every enclosing obb, so a reader places it without a transform
+  of its own. It is derived from the nodes' `Animated<Obb>`, never from
+  `Shape::getControlBb`, so it does not inherit that function's double-transform
+  bug.
+- **Text comes from drawing, not from the tree.** A leaf's content lives inside
+  its draw function, so a leaf is drawn on its own out of the caller's memory
+  and the `TextEntry`s of the result are collected; the drawing is discarded.
+- **Nulls are expected.** An empty tree yields no root, and a node whose child
+  is null yields no child; the walker never assumes a well-formed tree.
+
+`toJson` writes schema version 1: an envelope of `version`, `time`, `obb` and
+`root`, and per node `type`, `obb` (`center`/`size`/`angle`/`scale`), `text`
+and `children`, plus `id` when the node has one and `leaving` when the subtree
+is on its way out. Numbers are `%.9g` with non-finite written as zero. The
+schema is a contract — extend it additively and bump `Snapshot::version` when
+an existing field changes meaning.
 
 ## Animation
 

--- a/src/avg/include/avg/rendertree.h
+++ b/src/avg/include/avg/rendertree.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rendertree/snapshot.h"
 #include "rendertree/uniqueid.h"
 #include "rendertree/updateresult.h"
 #include "rendertree/rendertreenode.h"

--- a/src/avg/include/avg/rendertree/clipnode.h
+++ b/src/avg/include/avg/rendertree/clipnode.h
@@ -40,6 +40,11 @@ namespace avg
                 std::chrono::milliseconds time
                 ) const override;
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time
+                ) const override;
+
         std::type_index getType() const override;
         std::shared_ptr<RenderTreeNode> clone() const override;
 

--- a/src/avg/include/avg/rendertree/containernode.h
+++ b/src/avg/include/avg/rendertree/containernode.h
@@ -58,6 +58,10 @@ namespace avg
                 avg::Obb const& parentObb,
                 std::chrono::milliseconds time) const override;
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time) const override;
+
         std::type_index getType() const override;
         std::shared_ptr<RenderTreeNode> clone() const override;
 

--- a/src/avg/include/avg/rendertree/idnode.h
+++ b/src/avg/include/avg/rendertree/idnode.h
@@ -42,6 +42,11 @@ namespace avg
                 std::chrono::milliseconds time
                 ) const override;
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time
+                ) const override;
+
         std::type_index getType() const override;
         std::shared_ptr<RenderTreeNode> clone() const override;
 

--- a/src/avg/include/avg/rendertree/rectnode.h
+++ b/src/avg/include/avg/rendertree/rectnode.h
@@ -26,6 +26,14 @@ namespace avg
                 Animated<std::optional<Pen>> pen
                 );
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time) const override
+        {
+            return makeLeafSnapshotNode("RectNode", *this, context, parentObb,
+                    time);
+        }
+
         std::shared_ptr<RenderTreeNode> clone() const override
         {
             return std::make_shared<RectNode>(

--- a/src/avg/include/avg/rendertree/rendertree.h
+++ b/src/avg/include/avg/rendertree/rendertree.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "snapshot.h"
+
 #include "avg/animated.h"
 #include "avg/drawing.h"
 #include "avg/transform.h"
@@ -34,6 +36,19 @@ namespace avg
                 ) &&;
 
         std::pair<Drawing, bool> draw(DrawContext const& drawContext,
+                avg::Obb const& obb,
+                std::chrono::milliseconds time) const;
+
+        /**
+         * @brief Describes what the tree draws into @p obb at @p time.
+         *
+         * A snapshot is a pure function of an immutable tree and a timestamp,
+         * so it describes exactly the frame draw() would produce for the same
+         * arguments and can be taken from any thread: hold the RenderTree of
+         * the frame you want, and give @p drawContext memory no other thread
+         * is allocating from.
+         */
+        Snapshot snapshot(DrawContext const& drawContext,
                 avg::Obb const& obb,
                 std::chrono::milliseconds time) const;
 

--- a/src/avg/include/avg/rendertree/rendertree.h
+++ b/src/avg/include/avg/rendertree/rendertree.h
@@ -42,11 +42,12 @@ namespace avg
         /**
          * @brief Describes what the tree draws into @p obb at @p time.
          *
-         * A snapshot is a pure function of an immutable tree and a timestamp,
-         * so it describes exactly the frame draw() would produce for the same
-         * arguments and can be taken from any thread: hold the RenderTree of
-         * the frame you want, and give @p drawContext memory no other thread
-         * is allocating from.
+         * A snapshot is a function of an immutable tree and a timestamp
+         * alone, and visits the subtree draw() visits for the same arguments,
+         * so holding a RenderTree holds a whole frame and a snapshot of it
+         * cannot be torn. It may be taken from a thread other than the one
+         * that renders, provided @p drawContext carries memory no other
+         * thread is using.
          */
         Snapshot snapshot(DrawContext const& drawContext,
                 avg::Obb const& obb,

--- a/src/avg/include/avg/rendertree/rendertreenode.h
+++ b/src/avg/include/avg/rendertree/rendertreenode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "snapshot.h"
 #include "uniqueid.h"
 #include "updateresult.h"
 
@@ -47,6 +48,19 @@ namespace avg
 
         virtual std::pair<Drawing, bool> draw(DrawContext const& context,
                 avg::Obb const& obb,
+                std::chrono::milliseconds time
+                ) const = 0;
+
+        /**
+         * @brief Describes what this node draws at @p time.
+         *
+         * Reports the same subtree draw() would visit, resolved into the
+         * space of @p parentObb. Nothing is mutated: the memory of @p context
+         * carries only the throwaway drawings the leaves are described from.
+         */
+        virtual SnapshotNode snapshot(
+                DrawContext const& context,
+                avg::Obb const& parentObb,
                 std::chrono::milliseconds time
                 ) const = 0;
 

--- a/src/avg/include/avg/rendertree/rendertreenode.h
+++ b/src/avg/include/avg/rendertree/rendertreenode.h
@@ -55,8 +55,10 @@ namespace avg
          * @brief Describes what this node draws at @p time.
          *
          * Reports the same subtree draw() would visit, resolved into the
-         * space of @p parentObb. Nothing is mutated: the memory of @p context
-         * carries only the throwaway drawings the leaves are described from.
+         * space of @p parentObb. The tree is left as it was, and the memory
+         * of @p context carries only the throwaway drawings the leaves are
+         * described from; the shared state a draw reaches, the font cache, is
+         * the same state a frame reaches and guards itself.
          */
         virtual SnapshotNode snapshot(
                 DrawContext const& context,

--- a/src/avg/include/avg/rendertree/rendertreenode.h
+++ b/src/avg/include/avg/rendertree/rendertreenode.h
@@ -54,11 +54,9 @@ namespace avg
         /**
          * @brief Describes what this node draws at @p time.
          *
-         * Reports the same subtree draw() would visit, resolved into the
-         * space of @p parentObb. The tree is left as it was, and the memory
-         * of @p context carries only the throwaway drawings the leaves are
-         * described from; the shared state a draw reaches, the font cache, is
-         * the same state a frame reaches and guards itself.
+         * Reports the same subtree draw() would visit, resolved into the space
+         * of @p parentObb. Leaves the tree unchanged; @p context's memory must
+         * not be shared with a concurrent draw.
          */
         virtual SnapshotNode snapshot(
                 DrawContext const& context,

--- a/src/avg/include/avg/rendertree/shapenode.h
+++ b/src/avg/include/avg/rendertree/shapenode.h
@@ -85,6 +85,14 @@ namespace avg
                     );
         }
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time) const override
+        {
+            return makeLeafSnapshotNode("ShapeNode", *this, context, parentObb,
+                    time);
+        }
+
         UpdateResult update(
                 RenderTree const& /*oldTree*/,
                 RenderTree const& /*newTree*/,

--- a/src/avg/include/avg/rendertree/snapshot.h
+++ b/src/avg/include/avg/rendertree/snapshot.h
@@ -2,9 +2,9 @@
 
 #include "uniqueid.h"
 
+#include "avg/avgvisibility.h"
 #include "avg/drawcontext.h"
 #include "avg/obb.h"
-#include "avg/avgvisibility.h"
 
 #include <chrono>
 #include <optional>
@@ -67,7 +67,7 @@ namespace avg
          */
         static constexpr int version = 1;
 
-        std::chrono::milliseconds time { 0 };
+        std::chrono::milliseconds time{ 0 };
 
         /**
          * @brief The box the tree was snapshotted into, usually the window.
@@ -93,9 +93,9 @@ namespace avg
     /**
      * @brief Describes a leaf @p node along with the text it draws.
      *
-     * The text is recovered by drawing @p node on its own out of @p context,
-     * which is the only place a leaf's content exists; the drawing is
-     * discarded.
+     * The text is recovered by running @p node's draw function in full out of
+     * @p context, which is the only place a leaf's content exists; the drawing
+     * is then discarded. A snapshot therefore costs what a frame costs.
      */
     AVG_EXPORT SnapshotNode makeLeafSnapshotNode(
             std::string type,
@@ -106,9 +106,21 @@ namespace avg
             );
 
     /**
-     * @brief Serialises @p snapshot as a JSON document.
+     * @brief Drops the text of @p node and of its descendants that lies
+     * entirely outside @p clip.
      *
-     * Non-finite numbers are written as zero.
+     * A leaf is described on its own, so an enclosing clip has to be applied
+     * afterwards for the snapshot to report only what is on screen.
+     */
+    AVG_EXPORT void clipSnapshotText(SnapshotNode& node, Obb const& clip);
+
+    /**
+     * @brief Serialises @p snapshot as a JSON document of schema version
+     * Snapshot::version.
+     *
+     * A box is written resolved, so its size is the extent it covers rather
+     * than the size it was authored with. Non-finite numbers are written as
+     * zero.
      */
     AVG_EXPORT std::string toJson(Snapshot const& snapshot);
 } // namespace avg

--- a/src/avg/include/avg/rendertree/snapshot.h
+++ b/src/avg/include/avg/rendertree/snapshot.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "uniqueid.h"
+
+#include "avg/drawcontext.h"
+#include "avg/obb.h"
+#include "avg/avgvisibility.h"
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace avg
+{
+    class RenderTreeNode;
+
+    /**
+     * @brief A run of text a node draws.
+     */
+    struct SnapshotText
+    {
+        std::string text;
+
+        /**
+         * @brief The box the text occupies, in the space the snapshot was
+         * taken in.
+         */
+        Obb obb;
+    };
+
+    /**
+     * @brief One node of a render tree snapshot.
+     *
+     * Geometry is resolved rather than authored: @c obb is the box the node
+     * occupies in the space of the obb the snapshot was taken with, so a
+     * reader needs no transform of its own to place a node.
+     */
+    struct SnapshotNode
+    {
+        std::string type;
+        std::optional<UniqueId> id;
+        Obb obb;
+
+        /**
+         * @brief The node is still drawn but is on its way out.
+         *
+         * Set for a container child that has been removed and for a transition
+         * that is running backwards.
+         */
+        bool leaving = false;
+
+        std::vector<SnapshotText> text;
+        std::vector<SnapshotNode> children;
+    };
+
+    /**
+     * @brief What a render tree draws at one instant.
+     *
+     * Only the subtree that is drawn at @c time is described, so a transition
+     * contributes the branch that is on screen and nothing else.
+     */
+    struct Snapshot
+    {
+        /**
+         * @brief The version of the JSON schema avg::toJson writes.
+         */
+        static constexpr int version = 1;
+
+        std::chrono::milliseconds time { 0 };
+
+        /**
+         * @brief The box the tree was snapshotted into, usually the window.
+         */
+        Obb obb;
+
+        std::optional<SnapshotNode> root;
+    };
+
+    /**
+     * @brief Describes @p node itself, with neither content nor children.
+     *
+     * @param type The name the node is reported under.
+     * @param parentObb The resolved box of the enclosing node.
+     */
+    AVG_EXPORT SnapshotNode makeSnapshotNode(
+            std::string type,
+            RenderTreeNode const& node,
+            Obb const& parentObb,
+            std::chrono::milliseconds time
+            );
+
+    /**
+     * @brief Describes a leaf @p node along with the text it draws.
+     *
+     * The text is recovered by drawing @p node on its own out of @p context,
+     * which is the only place a leaf's content exists; the drawing is
+     * discarded.
+     */
+    AVG_EXPORT SnapshotNode makeLeafSnapshotNode(
+            std::string type,
+            RenderTreeNode const& node,
+            DrawContext const& context,
+            Obb const& parentObb,
+            std::chrono::milliseconds time
+            );
+
+    /**
+     * @brief Serialises @p snapshot as a JSON document.
+     *
+     * Non-finite numbers are written as zero.
+     */
+    AVG_EXPORT std::string toJson(Snapshot const& snapshot);
+} // namespace avg

--- a/src/avg/include/avg/rendertree/snapshot.h
+++ b/src/avg/include/avg/rendertree/snapshot.h
@@ -42,12 +42,7 @@ namespace avg
         std::optional<UniqueId> id;
         Obb obb;
 
-        /**
-         * @brief The node is still drawn but is on its way out.
-         *
-         * Set for a container child that has been removed and for a transition
-         * that is running backwards.
-         */
+        /** @brief The node is still drawn but is on its way out. */
         bool leaving = false;
 
         std::vector<SnapshotText> text;
@@ -93,9 +88,8 @@ namespace avg
     /**
      * @brief Describes a leaf @p node along with the text it draws.
      *
-     * The text is recovered by running @p node's draw function in full out of
-     * @p context, which is the only place a leaf's content exists; the drawing
-     * is then discarded. A snapshot therefore costs what a frame costs.
+     * Costs a full draw pass, since a leaf's text exists only inside its draw
+     * function.
      */
     AVG_EXPORT SnapshotNode makeLeafSnapshotNode(
             std::string type,
@@ -108,9 +102,6 @@ namespace avg
     /**
      * @brief Drops the text of @p node and of its descendants that lies
      * entirely outside @p clip.
-     *
-     * A leaf is described on its own, so an enclosing clip has to be applied
-     * afterwards for the snapshot to report only what is on screen.
      */
     AVG_EXPORT void clipSnapshotText(SnapshotNode& node, Obb const& clip);
 

--- a/src/avg/include/avg/rendertree/transitionnode.h
+++ b/src/avg/include/avg/rendertree/transitionnode.h
@@ -56,6 +56,11 @@ namespace avg
                 std::chrono::milliseconds time
                 ) const override;
 
+        SnapshotNode snapshot(DrawContext const& context,
+                avg::Obb const& parentObb,
+                std::chrono::milliseconds time
+                ) const override;
+
         std::type_index getType() const override;
         std::shared_ptr<RenderTreeNode> clone() const override;
 

--- a/src/avg/include/avg/rendertree/uniqueid.h
+++ b/src/avg/include/avg/rendertree/uniqueid.h
@@ -16,6 +16,12 @@ namespace avg
 
         UniqueId& operator=(UniqueId const&) = default;
 
+        /**
+         * @brief The identity as a number, for reporting it outside the
+         * process.
+         */
+        uint64_t getValue() const;
+
         bool operator==(UniqueId const& id) const;
         bool operator!=(UniqueId const& id) const;
         bool operator<(UniqueId const& id) const;

--- a/src/avg/meson.build
+++ b/src/avg/meson.build
@@ -12,6 +12,7 @@ libavgsrc = [
   'src/rendertree/clipnode.cpp',
   'src/rendertree/idnode.cpp',
   'src/rendertree/rendertree.cpp',
+  'src/rendertree/snapshot.cpp',
   'src/fontmanager.cpp',
   'src/fontimpl.cpp',
   'src/font.cpp',
@@ -79,6 +80,7 @@ avgtest =  executable('avgtest',
   'test/pathtest.cpp',
   'test/pathcrossingtest.cpp',
   'test/pentest.cpp',
+  'test/snapshottest.cpp',
   dependencies: [gtestdep, libavgdep],
   )
 

--- a/src/avg/readme.md
+++ b/src/avg/readme.md
@@ -34,6 +34,13 @@ bounding boxes. Producing a frame splices a new tree against the old one (so
 changes can animate), and drawing it is a pure function of a timestamp. This is
 what lets rendering and state-updates run independently.
 
+A tree can also describe itself rather than draw itself. A **snapshot** is a
+machine-readable account of one tree at one instant — the node kinds, the
+identities they carry, their boxes resolved into the space the snapshot was
+taken in, and the text the leaves draw — serialised as a versioned JSON
+document for a reader outside the process. It is taken from the same immutable
+tree a frame is drawn from, so it can never describe a half-updated screen.
+
 ## Layout
 
 - `path.h`, `pathbuilder.h`, `shape.h` — geometry.

--- a/src/avg/src/rendertree/clipnode.cpp
+++ b/src/avg/src/rendertree/clipnode.cpp
@@ -180,6 +180,20 @@ std::pair<Drawing, bool> ClipNode::draw(DrawContext const& context,
     };
 }
 
+SnapshotNode ClipNode::snapshot(DrawContext const& context,
+        avg::Obb const& parentObb,
+        std::chrono::milliseconds time
+        ) const
+{
+    auto result = makeSnapshotNode("ClipNode", *this, parentObb, time);
+
+    if (childNode_)
+        result.children.push_back(childNode_->snapshot(context, result.obb,
+                    time));
+
+    return result;
+}
+
 std::type_index ClipNode::getType() const
 {
     return typeid(ClipNode);

--- a/src/avg/src/rendertree/clipnode.cpp
+++ b/src/avg/src/rendertree/clipnode.cpp
@@ -188,8 +188,11 @@ SnapshotNode ClipNode::snapshot(DrawContext const& context,
     auto result = makeSnapshotNode("ClipNode", *this, parentObb, time);
 
     if (childNode_)
-        result.children.push_back(childNode_->snapshot(context, result.obb,
-                    time));
+    {
+        auto child = childNode_->snapshot(context, result.obb, time);
+        clipSnapshotText(child, result.obb);
+        result.children.push_back(std::move(child));
+    }
 
     return result;
 }

--- a/src/avg/src/rendertree/containernode.cpp
+++ b/src/avg/src/rendertree/containernode.cpp
@@ -242,6 +242,26 @@ std::pair<Drawing, bool> ContainerNode::draw(DrawContext const& context,
             );
 }
 
+SnapshotNode ContainerNode::snapshot(DrawContext const& context,
+        avg::Obb const& parentObb,
+        std::chrono::milliseconds time) const
+{
+    auto result = makeSnapshotNode("ContainerNode", *this, parentObb, time);
+
+    for (auto const& child : children_)
+    {
+        if (!child.node)
+            continue;
+
+        auto childSnapshot = child.node->snapshot(context, result.obb, time);
+        childSnapshot.leaving = childSnapshot.leaving || !child.active;
+
+        result.children.push_back(std::move(childSnapshot));
+    }
+
+    return result;
+}
+
 std::type_index ContainerNode::getType() const
 {
     return typeid(ContainerNode);

--- a/src/avg/src/rendertree/idnode.cpp
+++ b/src/avg/src/rendertree/idnode.cpp
@@ -169,6 +169,20 @@ std::pair<Drawing, bool> IdNode::draw(DrawContext const& context,
     };
 }
 
+SnapshotNode IdNode::snapshot(DrawContext const& context,
+        avg::Obb const& parentObb,
+        std::chrono::milliseconds time
+        ) const
+{
+    auto result = makeSnapshotNode("IdNode", *this, parentObb, time);
+
+    if (childNode_)
+        result.children.push_back(childNode_->snapshot(context, result.obb,
+                    time));
+
+    return result;
+}
+
 std::type_index IdNode::getType() const
 {
     return typeid(IdNode);

--- a/src/avg/src/rendertree/rendertree.cpp
+++ b/src/avg/src/rendertree/rendertree.cpp
@@ -76,6 +76,24 @@ std::pair<Drawing, bool> RenderTree::draw(
     return root_->draw(context, obb, time);
 }
 
+Snapshot RenderTree::snapshot(
+        DrawContext const& drawContext,
+        avg::Obb const& obb,
+        std::chrono::milliseconds time) const
+{
+    ZoneScopedN("RenderTree::snapshot");
+
+    Snapshot result;
+
+    result.time = time;
+    result.obb = obb;
+
+    if (root_)
+        result.root = root_->snapshot(drawContext, obb, time);
+
+    return result;
+}
+
 RenderTree RenderTree::transform(Transform const& transform) &&
 {
     if (root_)

--- a/src/avg/src/rendertree/snapshot.cpp
+++ b/src/avg/src/rendertree/snapshot.cpp
@@ -1,14 +1,15 @@
 #include "rendertree/snapshot.h"
 
-#include "rendertree/rendertreenode.h"
-
 #include "drawing.h"
 #include "obb.h"
+#include "rendertree/rendertreenode.h"
 #include "textentry.h"
 #include "transform.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <iomanip>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -49,12 +50,7 @@ void collectText(
 
 void writeNumber(std::ostringstream& out, float value)
 {
-    char buffer[32];
-
-    std::snprintf(buffer, sizeof(buffer), "%.9g",
-            std::isfinite(value) ? static_cast<double>(value) : 0.0);
-
-    out << buffer;
+    out << (std::isfinite(value) ? value : 0.0f);
 }
 
 void writeString(std::ostringstream& out, std::string const& value)
@@ -108,6 +104,7 @@ void writeString(std::ostringstream& out, std::string const& value)
 void writeObb(std::ostringstream& out, Obb const& obb)
 {
     auto center = obb.getCenter();
+    auto scale = obb.getTransform().getScale();
     auto size = obb.getSize();
 
     out << "{\"center\":{\"x\":";
@@ -115,13 +112,11 @@ void writeObb(std::ostringstream& out, Obb const& obb)
     out << ",\"y\":";
     writeNumber(out, center[1]);
     out << "},\"size\":{\"w\":";
-    writeNumber(out, size[0]);
+    writeNumber(out, size[0] * scale);
     out << ",\"h\":";
-    writeNumber(out, size[1]);
+    writeNumber(out, size[1] * scale);
     out << "},\"angle\":";
     writeNumber(out, obb.getTransform().getRotation());
-    out << ",\"scale\":";
-    writeNumber(out, obb.getTransform().getScale());
     out << '}';
 }
 
@@ -205,10 +200,30 @@ SnapshotNode makeLeafSnapshotNode(
     return result;
 }
 
+void clipSnapshotText(SnapshotNode& node, Obb const& clip)
+{
+    auto bounds = clip.getBoundingRect();
+
+    node.text.erase(
+            std::remove_if(node.text.begin(), node.text.end(),
+                [&](SnapshotText const& text)
+                {
+                    return !text.obb.getBoundingRect().overlaps(bounds);
+                }),
+            node.text.end()
+            );
+
+    for (auto& child : node.children)
+        clipSnapshotText(child, clip);
+}
+
 std::string toJson(Snapshot const& snapshot)
 {
     std::ostringstream out;
+
+    // snprintf would take the decimal separator from the process locale.
     out.imbue(std::locale::classic());
+    out << std::setprecision(9);
 
     out << "{\"version\":" << Snapshot::version
         << ",\"time\":" << snapshot.time.count()

--- a/src/avg/src/rendertree/snapshot.cpp
+++ b/src/avg/src/rendertree/snapshot.cpp
@@ -1,0 +1,231 @@
+#include "rendertree/snapshot.h"
+
+#include "rendertree/rendertreenode.h"
+
+#include "drawing.h"
+#include "obb.h"
+#include "textentry.h"
+#include "transform.h"
+
+#include <cmath>
+#include <cstdio>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace avg
+{
+
+namespace
+{
+
+void collectText(
+        pmr::vector<Drawing::Element> const& elements,
+        Transform const& transform,
+        std::vector<SnapshotText>& result
+        )
+{
+    for (auto const& element : elements)
+    {
+        if (auto const* text = std::get_if<TextEntry>(&element))
+        {
+            result.push_back(SnapshotText {
+                    text->getText(),
+                    transform * text->getControlObb()
+                    });
+        }
+        else if (auto const* clip = std::get_if<Drawing::ClipElement>(&element))
+        {
+            collectText(
+                    (*clip->subDrawing).elements,
+                    transform * clip->transform,
+                    result
+                    );
+        }
+    }
+}
+
+void writeNumber(std::ostringstream& out, float value)
+{
+    char buffer[32];
+
+    std::snprintf(buffer, sizeof(buffer), "%.9g",
+            std::isfinite(value) ? static_cast<double>(value) : 0.0);
+
+    out << buffer;
+}
+
+void writeString(std::ostringstream& out, std::string const& value)
+{
+    out << '"';
+
+    for (char c : value)
+    {
+        switch (c)
+        {
+        case '"':
+            out << "\\\"";
+            break;
+        case '\\':
+            out << "\\\\";
+            break;
+        case '\b':
+            out << "\\b";
+            break;
+        case '\f':
+            out << "\\f";
+            break;
+        case '\n':
+            out << "\\n";
+            break;
+        case '\r':
+            out << "\\r";
+            break;
+        case '\t':
+            out << "\\t";
+            break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20)
+            {
+                char buffer[8];
+                std::snprintf(buffer, sizeof(buffer), "\\u%04x",
+                        static_cast<unsigned int>(
+                            static_cast<unsigned char>(c)));
+                out << buffer;
+            }
+            else
+            {
+                out << c;
+            }
+        }
+    }
+
+    out << '"';
+}
+
+void writeObb(std::ostringstream& out, Obb const& obb)
+{
+    auto center = obb.getCenter();
+    auto size = obb.getSize();
+
+    out << "{\"center\":{\"x\":";
+    writeNumber(out, center[0]);
+    out << ",\"y\":";
+    writeNumber(out, center[1]);
+    out << "},\"size\":{\"w\":";
+    writeNumber(out, size[0]);
+    out << ",\"h\":";
+    writeNumber(out, size[1]);
+    out << "},\"angle\":";
+    writeNumber(out, obb.getTransform().getRotation());
+    out << ",\"scale\":";
+    writeNumber(out, obb.getTransform().getScale());
+    out << '}';
+}
+
+void writeNode(std::ostringstream& out, SnapshotNode const& node)
+{
+    out << "{\"type\":";
+    writeString(out, node.type);
+
+    if (node.id)
+        out << ",\"id\":" << node.id->getValue();
+
+    out << ",\"obb\":";
+    writeObb(out, node.obb);
+
+    if (node.leaving)
+        out << ",\"leaving\":true";
+
+    out << ",\"text\":[";
+
+    bool first = true;
+    for (auto const& text : node.text)
+    {
+        if (!first)
+            out << ',';
+        first = false;
+
+        out << "{\"text\":";
+        writeString(out, text.text);
+        out << ",\"obb\":";
+        writeObb(out, text.obb);
+        out << '}';
+    }
+
+    out << "],\"children\":[";
+
+    first = true;
+    for (auto const& child : node.children)
+    {
+        if (!first)
+            out << ',';
+        first = false;
+
+        writeNode(out, child);
+    }
+
+    out << "]}";
+}
+
+} // anonymous namespace
+
+SnapshotNode makeSnapshotNode(
+        std::string type,
+        RenderTreeNode const& node,
+        Obb const& parentObb,
+        std::chrono::milliseconds time
+        )
+{
+    SnapshotNode result;
+
+    result.type = std::move(type);
+    result.id = node.getId();
+    result.obb = parentObb.getTransform() * node.getObbAt(time);
+
+    return result;
+}
+
+SnapshotNode makeLeafSnapshotNode(
+        std::string type,
+        RenderTreeNode const& node,
+        DrawContext const& context,
+        Obb const& parentObb,
+        std::chrono::milliseconds time
+        )
+{
+    auto result = makeSnapshotNode(std::move(type), node, parentObb, time);
+
+    auto drawing = node.draw(context, parentObb, time).first;
+
+    collectText(drawing.getElements(), Transform(), result.text);
+
+    return result;
+}
+
+std::string toJson(Snapshot const& snapshot)
+{
+    std::ostringstream out;
+    out.imbue(std::locale::classic());
+
+    out << "{\"version\":" << Snapshot::version
+        << ",\"time\":" << snapshot.time.count()
+        << ",\"obb\":";
+
+    writeObb(out, snapshot.obb);
+
+    out << ",\"root\":";
+
+    if (snapshot.root)
+        writeNode(out, *snapshot.root);
+    else
+        out << "null";
+
+    out << '}';
+
+    return out.str();
+}
+
+} // namespace avg

--- a/src/avg/src/rendertree/snapshot.cpp
+++ b/src/avg/src/rendertree/snapshot.cpp
@@ -221,7 +221,7 @@ std::string toJson(Snapshot const& snapshot)
 {
     std::ostringstream out;
 
-    // snprintf would take the decimal separator from the process locale.
+    // Numbers must use '.' regardless of the process locale.
     out.imbue(std::locale::classic());
     out << std::setprecision(9);
 

--- a/src/avg/src/rendertree/transitionnode.cpp
+++ b/src/avg/src/rendertree/transitionnode.cpp
@@ -173,6 +173,22 @@ std::pair<Drawing, bool> TransitionNode::draw(DrawContext const& context,
             );
 }
 
+SnapshotNode TransitionNode::snapshot(DrawContext const& context,
+        avg::Obb const& parentObb,
+        std::chrono::milliseconds time
+        ) const
+{
+    auto result = makeSnapshotNode("TransitionNode", *this, parentObb, time);
+
+    result.leaving = !isActive_;
+
+    if (activeNode_)
+        result.children.push_back(activeNode_->snapshot(context, result.obb,
+                    time));
+
+    return result;
+}
+
 std::type_index TransitionNode::getType() const
 {
     return typeid(TransitionNode);

--- a/src/avg/src/rendertree/uniqueid.cpp
+++ b/src/avg/src/rendertree/uniqueid.cpp
@@ -15,6 +15,11 @@ UniqueId::UniqueId() :
 {
 }
 
+uint64_t UniqueId::getValue() const
+{
+    return value_;
+}
+
 bool UniqueId::operator==(UniqueId const& id) const
 {
     return value_ == id.value_;

--- a/src/avg/test/snapshottest.cpp
+++ b/src/avg/test/snapshottest.cpp
@@ -1,0 +1,358 @@
+#include <avg/brush.h>
+#include <avg/animationoptions.h>
+#include <avg/color.h>
+#include <avg/curve/curves.h>
+#include <avg/drawcontext.h>
+#include <avg/drawing.h>
+#include <avg/font.h>
+#include <avg/obb.h>
+#include <avg/rect.h>
+#include <avg/rendertree.h>
+#include <avg/textentry.h>
+#include <avg/transform.h>
+#include <avg/vector.h>
+
+#include <pmr/new_delete_resource.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace
+{
+
+std::chrono::milliseconds const zero(0);
+
+std::string const fontPath = "data/fonts/OpenSans-Regular.ttf";
+
+avg::Obb placed(float x, float y, float width, float height)
+{
+    return avg::Obb(avg::Vector2f(width, height), avg::translate(x, y));
+}
+
+std::shared_ptr<avg::RectNode> rect(avg::Obb const& obb)
+{
+    return std::make_shared<avg::RectNode>(
+            obb,
+            std::nullopt,
+            0.0f,
+            std::make_optional(avg::Brush(avg::Color(1.0f, 1.0f, 1.0f, 1.0f))),
+            std::nullopt
+            );
+}
+
+std::shared_ptr<avg::RenderTreeNode> text(avg::Obb const& obb,
+        std::string const& content)
+{
+    avg::Font font(fontPath, 0);
+
+    std::function<avg::Drawing(avg::DrawContext const&, avg::Vector2f)> draw =
+        [font, content](avg::DrawContext const& context, avg::Vector2f)
+        {
+            return context.drawing(avg::TextEntry(
+                        font,
+                        avg::Transform().scale(10.0f),
+                        content,
+                        std::make_optional(avg::Brush(
+                                avg::Color(1.0f, 1.0f, 1.0f, 1.0f))),
+                        std::nullopt
+                        ));
+        };
+
+    return avg::makeShapeNode(obb, std::nullopt, std::move(draw));
+}
+
+avg::Snapshot snapshotOf(avg::RenderTree const& tree, avg::Obb const& obb)
+{
+    avg::DrawContext context(pmr::new_delete_resource());
+
+    return tree.snapshot(context, obb, zero);
+}
+
+/**
+ * @brief The bounding rectangle of every shape a drawing holds, in order.
+ */
+std::vector<avg::Rect> shapeBounds(avg::Drawing const& drawing)
+{
+    std::vector<avg::Rect> result;
+
+    for (auto const& element : drawing.getElements())
+    {
+        auto const* shape = std::get_if<avg::Drawing::ShapeElement>(&element);
+        if (shape)
+            result.push_back(shape->shape.getControlBb());
+    }
+
+    return result;
+}
+
+void expectObb(avg::Obb const& obb, float x, float y,
+        float width, float height)
+{
+    auto r = obb.getBoundingRect();
+
+    EXPECT_FLOAT_EQ(x, r.getLeft());
+    EXPECT_FLOAT_EQ(y, r.getBottom());
+    EXPECT_FLOAT_EQ(width, r.getWidth());
+    EXPECT_FLOAT_EQ(height, r.getHeight());
+}
+
+} // anonymous namespace
+
+TEST(Snapshot, describesTypeIdentityAndNesting)
+{
+    auto id = avg::UniqueId();
+
+    auto container = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    container->addChild(std::make_shared<avg::IdNode>(
+                id,
+                placed(10.0f, 0.0f, 100.0f, 50.0f),
+                rect(placed(0.0f, 0.0f, 100.0f, 50.0f))
+                ));
+
+    container->addChild(std::make_shared<avg::ClipNode>(
+                placed(200.0f, 0.0f, 50.0f, 50.0f),
+                rect(placed(0.0f, 0.0f, 80.0f, 50.0f))
+                ));
+
+    auto snapshot = snapshotOf(
+            avg::RenderTree(std::move(container)),
+            avg::Obb(avg::Vector2f(300.0f, 50.0f))
+            );
+
+    ASSERT_TRUE(snapshot.root.has_value());
+
+    auto const& root = *snapshot.root;
+    EXPECT_EQ("ContainerNode", root.type);
+    EXPECT_FALSE(root.id.has_value());
+    ASSERT_EQ(2u, root.children.size());
+
+    auto const& idNode = root.children[0];
+    EXPECT_EQ("IdNode", idNode.type);
+    ASSERT_TRUE(idNode.id.has_value());
+    EXPECT_EQ(id, *idNode.id);
+    expectObb(idNode.obb, 10.0f, 0.0f, 100.0f, 50.0f);
+    ASSERT_EQ(1u, idNode.children.size());
+    EXPECT_EQ("RectNode", idNode.children[0].type);
+
+    auto const& clipNode = root.children[1];
+    EXPECT_EQ("ClipNode", clipNode.type);
+    expectObb(clipNode.obb, 200.0f, 0.0f, 50.0f, 50.0f);
+    ASSERT_EQ(1u, clipNode.children.size());
+    EXPECT_EQ("RectNode", clipNode.children[0].type);
+}
+
+TEST(Snapshot, geometryIsResolvedToTheSnapshotObb)
+{
+    auto outer = std::make_shared<avg::ContainerNode>(
+            placed(10.0f, 20.0f, 300.0f, 50.0f));
+
+    auto inner = std::make_shared<avg::ContainerNode>(
+            placed(1.0f, 2.0f, 300.0f, 50.0f));
+
+    inner->addChild(rect(placed(5.0f, 5.0f, 100.0f, 50.0f)));
+    outer->addChild(std::move(inner));
+
+    auto snapshot = snapshotOf(
+            avg::RenderTree(std::move(outer)),
+            placed(100.0f, 200.0f, 300.0f, 50.0f)
+            );
+
+    ASSERT_TRUE(snapshot.root.has_value());
+
+    auto const& root = *snapshot.root;
+    expectObb(root.obb, 110.0f, 220.0f, 300.0f, 50.0f);
+
+    ASSERT_EQ(1u, root.children.size());
+    expectObb(root.children[0].obb, 111.0f, 222.0f, 300.0f, 50.0f);
+
+    ASSERT_EQ(1u, root.children[0].children.size());
+    expectObb(root.children[0].children[0].obb,
+            116.0f, 227.0f, 100.0f, 50.0f);
+}
+
+TEST(Snapshot, reportsTheTextALeafDraws)
+{
+    auto container = std::make_shared<avg::ContainerNode>(
+            placed(10.0f, 20.0f, 300.0f, 50.0f));
+
+    container->addChild(text(placed(5.0f, 5.0f, 100.0f, 50.0f), "Ok"));
+
+    auto snapshot = snapshotOf(
+            avg::RenderTree(std::move(container)),
+            avg::Obb(avg::Vector2f(300.0f, 50.0f))
+            );
+
+    ASSERT_TRUE(snapshot.root.has_value());
+    ASSERT_EQ(1u, snapshot.root->children.size());
+
+    auto const& leaf = snapshot.root->children[0];
+    EXPECT_EQ("ShapeNode", leaf.type);
+    ASSERT_EQ(1u, leaf.text.size());
+    EXPECT_EQ("Ok", leaf.text[0].text);
+
+    auto bounds = leaf.text[0].obb.getBoundingRect();
+    EXPECT_FALSE(bounds.isEmpty());
+
+    // The text is placed by every enclosing obb, not just its own.
+    EXPECT_GE(bounds.getLeft(), 15.0f);
+    EXPECT_GE(bounds.getBottom(), 25.0f);
+}
+
+TEST(Snapshot, reportsASubtreeOnItsWayOut)
+{
+    auto leaving = [](avg::UniqueId const& id)
+    {
+        return std::make_shared<avg::IdNode>(
+                id,
+                placed(0.0f, 0.0f, 100.0f, 50.0f),
+                std::make_shared<avg::TransitionNode>(
+                    placed(0.0f, 0.0f, 100.0f, 50.0f),
+                    true,
+                    rect(placed(0.0f, 0.0f, 100.0f, 50.0f)),
+                    rect(placed(0.0f, 0.0f, 100.0f, 50.0f))
+                    )
+                );
+    };
+
+    auto oldContainer = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    oldContainer->addChild(leaving(avg::UniqueId()));
+
+    auto newContainer = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    avg::AnimationOptions options { std::chrono::milliseconds(100),
+        avg::curve::linear };
+
+    auto [tree, nextUpdate] = avg::RenderTree(std::move(oldContainer)).update(
+            avg::RenderTree(std::move(newContainer)),
+            std::make_optional(options),
+            zero
+            );
+
+    auto snapshot = snapshotOf(tree, avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    ASSERT_TRUE(snapshot.root.has_value());
+    ASSERT_EQ(1u, snapshot.root->children.size());
+
+    auto const& idNode = snapshot.root->children[0];
+    EXPECT_EQ("IdNode", idNode.type);
+    EXPECT_TRUE(idNode.leaving);
+
+    ASSERT_EQ(1u, idNode.children.size());
+    EXPECT_EQ("TransitionNode", idNode.children[0].type);
+    EXPECT_TRUE(idNode.children[0].leaving);
+}
+
+TEST(Snapshot, anEmptyTreeHasNoRoot)
+{
+    auto snapshot = snapshotOf(avg::RenderTree(),
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    EXPECT_FALSE(snapshot.root.has_value());
+    EXPECT_NE(std::string::npos, avg::toJson(snapshot).find("\"root\":null"));
+}
+
+TEST(Snapshot, nullSubtreesAreDescribedWithoutChildren)
+{
+    auto container = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    container->addChild(std::make_shared<avg::IdNode>(
+                avg::UniqueId(),
+                placed(0.0f, 0.0f, 100.0f, 50.0f),
+                nullptr
+                ));
+
+    container->addChild(std::make_shared<avg::ClipNode>(
+                placed(100.0f, 0.0f, 100.0f, 50.0f),
+                nullptr
+                ));
+
+    container->addChild(std::make_shared<avg::TransitionNode>(
+                placed(200.0f, 0.0f, 100.0f, 50.0f),
+                true,
+                nullptr,
+                nullptr
+                ));
+
+    auto snapshot = snapshotOf(
+            avg::RenderTree(std::move(container)),
+            avg::Obb(avg::Vector2f(300.0f, 50.0f))
+            );
+
+    ASSERT_TRUE(snapshot.root.has_value());
+    ASSERT_EQ(3u, snapshot.root->children.size());
+
+    for (auto const& child : snapshot.root->children)
+        EXPECT_TRUE(child.children.empty());
+}
+
+TEST(Snapshot, leavesTheTreeUnchanged)
+{
+    avg::DrawContext context(pmr::new_delete_resource());
+
+    auto container = std::make_shared<avg::ContainerNode>(
+            placed(10.0f, 20.0f, 300.0f, 50.0f));
+
+    container->addChild(rect(placed(5.0f, 5.0f, 100.0f, 50.0f)));
+
+    auto tree = avg::RenderTree(std::move(container));
+    auto const* root = tree.getRoot().get();
+
+    auto viewport = avg::Obb(avg::Vector2f(300.0f, 50.0f));
+
+    auto before = shapeBounds(tree.draw(context, viewport, zero).first);
+
+    tree.snapshot(context, viewport, zero);
+
+    auto after = shapeBounds(tree.draw(context, viewport, zero).first);
+
+    EXPECT_EQ(root, tree.getRoot().get());
+
+    ASSERT_EQ(before.size(), after.size());
+    for (size_t i = 0; i < before.size(); ++i)
+    {
+        EXPECT_FLOAT_EQ(before[i].getLeft(), after[i].getLeft());
+        EXPECT_FLOAT_EQ(before[i].getBottom(), after[i].getBottom());
+        EXPECT_FLOAT_EQ(before[i].getWidth(), after[i].getWidth());
+        EXPECT_FLOAT_EQ(before[i].getHeight(), after[i].getHeight());
+    }
+}
+
+TEST(Snapshot, jsonCarriesTheSchemaVersionAndEscapesText)
+{
+    auto container = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    auto id = avg::UniqueId();
+
+    container->addChild(std::make_shared<avg::IdNode>(
+                id,
+                placed(0.0f, 0.0f, 100.0f, 50.0f),
+                text(placed(0.0f, 0.0f, 100.0f, 50.0f), "a\"b\nc")
+                ));
+
+    auto json = avg::toJson(snapshotOf(
+                avg::RenderTree(std::move(container)),
+                avg::Obb(avg::Vector2f(300.0f, 50.0f))
+                ));
+
+    EXPECT_NE(std::string::npos, json.find("\"version\":1"));
+    EXPECT_NE(std::string::npos, json.find("\"type\":\"ContainerNode\""));
+    EXPECT_NE(std::string::npos,
+            json.find("\"id\":" + std::to_string(id.getValue())));
+    EXPECT_NE(std::string::npos, json.find("\"text\":\"a\\\"b\\nc\""));
+    EXPECT_NE(std::string::npos, json.find("\"angle\":"));
+}

--- a/src/avg/test/snapshottest.cpp
+++ b/src/avg/test/snapshottest.cpp
@@ -110,23 +110,32 @@ TEST(Snapshot, describesTypeIdentityAndNesting)
 {
     auto id = avg::UniqueId();
 
+    // Every enclosing box is placed, so a child that failed to compose one of
+    // them cannot land where it is expected.
     auto container = std::make_shared<avg::ContainerNode>(
-            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+            placed(1000.0f, 500.0f, 300.0f, 50.0f));
 
     container->addChild(std::make_shared<avg::IdNode>(
                 id,
-                placed(10.0f, 0.0f, 100.0f, 50.0f),
-                rect(placed(0.0f, 0.0f, 100.0f, 50.0f))
+                placed(10.0f, 3.0f, 100.0f, 50.0f),
+                rect(placed(7.0f, 0.0f, 100.0f, 50.0f))
                 ));
 
     container->addChild(std::make_shared<avg::ClipNode>(
-                placed(200.0f, 0.0f, 50.0f, 50.0f),
-                rect(placed(0.0f, 0.0f, 80.0f, 50.0f))
+                placed(200.0f, 4.0f, 50.0f, 50.0f),
+                rect(placed(6.0f, 0.0f, 80.0f, 50.0f))
+                ));
+
+    container->addChild(std::make_shared<avg::TransitionNode>(
+                placed(20.0f, 5.0f, 50.0f, 50.0f),
+                true,
+                rect(placed(9.0f, 0.0f, 30.0f, 50.0f)),
+                rect(placed(0.0f, 0.0f, 30.0f, 50.0f))
                 ));
 
     auto snapshot = snapshotOf(
             avg::RenderTree(std::move(container)),
-            avg::Obb(avg::Vector2f(300.0f, 50.0f))
+            placed(1.0f, 2.0f, 300.0f, 50.0f)
             );
 
     ASSERT_TRUE(snapshot.root.has_value());
@@ -134,21 +143,31 @@ TEST(Snapshot, describesTypeIdentityAndNesting)
     auto const& root = *snapshot.root;
     EXPECT_EQ("ContainerNode", root.type);
     EXPECT_FALSE(root.id.has_value());
-    ASSERT_EQ(2u, root.children.size());
+    expectObb(root.obb, 1001.0f, 502.0f, 300.0f, 50.0f);
+    ASSERT_EQ(3u, root.children.size());
 
     auto const& idNode = root.children[0];
     EXPECT_EQ("IdNode", idNode.type);
     ASSERT_TRUE(idNode.id.has_value());
     EXPECT_EQ(id, *idNode.id);
-    expectObb(idNode.obb, 10.0f, 0.0f, 100.0f, 50.0f);
+    expectObb(idNode.obb, 1011.0f, 505.0f, 100.0f, 50.0f);
     ASSERT_EQ(1u, idNode.children.size());
     EXPECT_EQ("RectNode", idNode.children[0].type);
+    expectObb(idNode.children[0].obb, 1018.0f, 505.0f, 100.0f, 50.0f);
 
     auto const& clipNode = root.children[1];
     EXPECT_EQ("ClipNode", clipNode.type);
-    expectObb(clipNode.obb, 200.0f, 0.0f, 50.0f, 50.0f);
+    expectObb(clipNode.obb, 1201.0f, 506.0f, 50.0f, 50.0f);
     ASSERT_EQ(1u, clipNode.children.size());
     EXPECT_EQ("RectNode", clipNode.children[0].type);
+    expectObb(clipNode.children[0].obb, 1207.0f, 506.0f, 80.0f, 50.0f);
+
+    auto const& transitionNode = root.children[2];
+    EXPECT_EQ("TransitionNode", transitionNode.type);
+    EXPECT_FALSE(transitionNode.leaving);
+    expectObb(transitionNode.obb, 1021.0f, 507.0f, 50.0f, 50.0f);
+    ASSERT_EQ(1u, transitionNode.children.size());
+    expectObb(transitionNode.children[0].obb, 1030.0f, 507.0f, 30.0f, 50.0f);
 }
 
 TEST(Snapshot, geometryIsResolvedToTheSnapshotObb)
@@ -200,12 +219,21 @@ TEST(Snapshot, reportsTheTextALeafDraws)
     ASSERT_EQ(1u, leaf.text.size());
     EXPECT_EQ("Ok", leaf.text[0].text);
 
-    auto bounds = leaf.text[0].obb.getBoundingRect();
-    EXPECT_FALSE(bounds.isEmpty());
-
     // The text is placed by every enclosing obb, not just its own.
-    EXPECT_GE(bounds.getLeft(), 15.0f);
-    EXPECT_GE(bounds.getBottom(), 25.0f);
+    auto expected = avg::translate(15.0f, 25.0f) * avg::TextEntry(
+            avg::Font(fontPath, 0),
+            avg::Transform().scale(10.0f),
+            "Ok"
+            ).getControlObb();
+
+    auto bounds = leaf.text[0].obb.getBoundingRect();
+    auto expectedBounds = expected.getBoundingRect();
+
+    EXPECT_FALSE(bounds.isEmpty());
+    EXPECT_FLOAT_EQ(expectedBounds.getLeft(), bounds.getLeft());
+    EXPECT_FLOAT_EQ(expectedBounds.getBottom(), bounds.getBottom());
+    EXPECT_FLOAT_EQ(expectedBounds.getWidth(), bounds.getWidth());
+    EXPECT_FLOAT_EQ(expectedBounds.getHeight(), bounds.getHeight());
 }
 
 TEST(Snapshot, reportsASubtreeOnItsWayOut)
@@ -253,6 +281,57 @@ TEST(Snapshot, reportsASubtreeOnItsWayOut)
     ASSERT_EQ(1u, idNode.children.size());
     EXPECT_EQ("TransitionNode", idNode.children[0].type);
     EXPECT_TRUE(idNode.children[0].leaving);
+
+    EXPECT_NE(std::string::npos,
+            avg::toJson(snapshot).find("\"leaving\":true"));
+}
+
+TEST(Snapshot, textClippedAwayIsNotReported)
+{
+    auto container = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(300.0f, 50.0f)));
+
+    container->addChild(std::make_shared<avg::ClipNode>(
+                placed(0.0f, 0.0f, 20.0f, 20.0f),
+                text(placed(500.0f, 500.0f, 100.0f, 50.0f), "hidden")
+                ));
+
+    container->addChild(std::make_shared<avg::ClipNode>(
+                placed(0.0f, 0.0f, 20.0f, 20.0f),
+                text(placed(0.0f, 0.0f, 100.0f, 50.0f), "shown")
+                ));
+
+    auto snapshot = snapshotOf(
+            avg::RenderTree(std::move(container)),
+            avg::Obb(avg::Vector2f(300.0f, 50.0f))
+            );
+
+    ASSERT_TRUE(snapshot.root.has_value());
+    ASSERT_EQ(2u, snapshot.root->children.size());
+
+    ASSERT_EQ(1u, snapshot.root->children[0].children.size());
+    EXPECT_TRUE(snapshot.root->children[0].children[0].text.empty());
+
+    ASSERT_EQ(1u, snapshot.root->children[1].children.size());
+    ASSERT_EQ(1u, snapshot.root->children[1].children[0].text.size());
+    EXPECT_EQ("shown", snapshot.root->children[1].children[0].text[0].text);
+}
+
+TEST(Snapshot, jsonWritesBoxesResolvedRatherThanAuthored)
+{
+    auto container = std::make_shared<avg::ContainerNode>(
+            avg::Obb(avg::Vector2f(100.0f, 50.0f)));
+
+    auto json = avg::toJson(snapshotOf(
+                avg::RenderTree(std::move(container)),
+                avg::Obb(avg::Vector2f(300.0f, 50.0f), avg::scale(2.0f))
+                ));
+
+    // The authored size is 100x50 under a scale of two.
+    EXPECT_NE(std::string::npos,
+            json.find("\"size\":{\"w\":200,\"h\":100}"));
+    EXPECT_NE(std::string::npos,
+            json.find("\"center\":{\"x\":100,\"y\":50}"));
 }
 
 TEST(Snapshot, anEmptyTreeHasNoRoot)
@@ -307,6 +386,7 @@ TEST(Snapshot, leavesTheTreeUnchanged)
             placed(10.0f, 20.0f, 300.0f, 50.0f));
 
     container->addChild(rect(placed(5.0f, 5.0f, 100.0f, 50.0f)));
+    container->addChild(text(placed(5.0f, 5.0f, 100.0f, 50.0f), "Ok"));
 
     auto tree = avg::RenderTree(std::move(container));
     auto const* root = tree.getRoot().get();
@@ -315,11 +395,13 @@ TEST(Snapshot, leavesTheTreeUnchanged)
 
     auto before = shapeBounds(tree.draw(context, viewport, zero).first);
 
-    tree.snapshot(context, viewport, zero);
+    auto first = avg::toJson(tree.snapshot(context, viewport, zero));
+    auto second = avg::toJson(tree.snapshot(context, viewport, zero));
 
     auto after = shapeBounds(tree.draw(context, viewport, zero).first);
 
     EXPECT_EQ(root, tree.getRoot().get());
+    EXPECT_EQ(first, second);
 
     ASSERT_EQ(before.size(), after.size());
     for (size_t i = 0; i < before.size(); ++i)
@@ -341,7 +423,7 @@ TEST(Snapshot, jsonCarriesTheSchemaVersionAndEscapesText)
     container->addChild(std::make_shared<avg::IdNode>(
                 id,
                 placed(0.0f, 0.0f, 100.0f, 50.0f),
-                text(placed(0.0f, 0.0f, 100.0f, 50.0f), "a\"b\nc")
+                text(placed(0.0f, 0.0f, 100.0f, 50.0f), "a\"b\\d\nc\x01")
                 ));
 
     auto json = avg::toJson(snapshotOf(
@@ -353,6 +435,9 @@ TEST(Snapshot, jsonCarriesTheSchemaVersionAndEscapesText)
     EXPECT_NE(std::string::npos, json.find("\"type\":\"ContainerNode\""));
     EXPECT_NE(std::string::npos,
             json.find("\"id\":" + std::to_string(id.getValue())));
-    EXPECT_NE(std::string::npos, json.find("\"text\":\"a\\\"b\\nc\""));
-    EXPECT_NE(std::string::npos, json.find("\"angle\":"));
+    EXPECT_NE(std::string::npos,
+            json.find("\"text\":\"a\\\"b\\\\d\\nc\\u0001\""));
+    EXPECT_NE(std::string::npos, json.find("\"angle\":0"));
+    EXPECT_EQ(std::string::npos, json.find("nan"));
+    EXPECT_EQ(std::string::npos, json.find("inf"));
 }


### PR DESCRIPTION
The avg render tree can snapshot itself to a concrete value.

## Snapshot
- `RenderTree::snapshot(DrawContext, Obb, time)` returns `avg::Snapshot`: a concrete node tree of what the tree presents at that time.
- Leaf text is recovered by running the leaf's draw through a memory-only `DrawContext` (no window painter); the throwaway drawing is discarded.
- `SnapshotNode` / `SnapshotText`; a `leaving` flag marks a node still drawn but on its way out.
- `avg::toJson(Snapshot)` serializes it (hand-written, so avg stays dependency-free).

avg only.
