### PR TITLE
Serve the render-tree snapshot over the inspector protocol

### DIFF
--- a/src/bqui/include/bqui/agent/session.h
+++ b/src/bqui/include/bqui/agent/session.h
@@ -6,6 +6,8 @@
 
 #include "bqui/bquivisibility.h"
 
+#include <avg/rendertree/snapshot.h>
+
 #include <ase/keycode.h>
 #include <ase/keyevent.h>
 #include <ase/pointerbuttonevent.h>
@@ -52,6 +54,9 @@ namespace bqui::agent
 
         /** @brief The current resolved (window-space) introspection. */
         virtual widget::Introspection introspect() const = 0;
+
+        /** @brief The current render-tree snapshot, in window space. */
+        virtual avg::Snapshot snapshot() const = 0;
 
         /** @brief Advance this window one frame by `dt` (update then draw). */
         virtual void advance(std::chrono::microseconds dt) = 0;

--- a/src/bqui/src/agent/session.cpp
+++ b/src/bqui/src/agent/session.cpp
@@ -3,6 +3,7 @@
 
 #include "introspectionjson.h"
 
+#include <avg/rendertree/snapshot.h>
 #include <btl/runloop.h>
 
 #include <nlohmann/json.hpp>
@@ -569,6 +570,23 @@ private:
         return { { "introspection", toJson(window->introspect()) } };
     }
 
+    json windowRenderTree(json const& params)
+    {
+        uint64_t id = requireWindowId(params);
+
+        auto windows = app_.liveWindows();
+        AgentWindow* window = findWindow(windows, id);
+        if (!window)
+            throw RpcError{ kInvalidParams,
+                "no live window with id " + std::to_string(id) };
+
+        // avg::toJson yields a whole JSON document, so it is parsed back into a
+        // value and embedded as the render tree sub-object — never quoted as a
+        // string.
+        json renderTree = json::parse(avg::toJson(window->snapshot()));
+        return { { "renderTree", std::move(renderTree) } };
+    }
+
     json windowInject(json const& params)
     {
         uint64_t id = requireWindowId(params);
@@ -641,6 +659,11 @@ private:
             "The window's resolved widget (introspection) tree.",
             { { "window", "number", true } },
             [this](json const& p) { return windowIntrospect(p); } });
+
+        registry_.push_back({ "window.renderTree",
+            "The window's render-tree snapshot (avg schema).",
+            { { "window", "number", true } },
+            [this](json const& p) { return windowRenderTree(p); } });
 
         registry_.push_back({ "window.inject",
             "Queue input events onto a window for the next step.",

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -15,6 +15,8 @@
 #include <bq/signal/sharedvector.h>
 
 #include <avg/rendertree.h>
+#include <avg/rendertree/snapshot.h>
+#include <avg/drawcontext.h>
 #include <avg/painter.h>
 #include <avg/rendering.h>
 
@@ -186,6 +188,11 @@ namespace
         widget::Introspection introspect() const override
         {
             return glue_.getResolvedIntrospection();
+        }
+
+        avg::Snapshot snapshot() const override
+        {
+            return glue_.snapshot();
         }
 
         void advance(std::chrono::microseconds dt) override

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -19,6 +19,7 @@
 #include <bq/signal/signal.h>
 
 #include <avg/rendertree.h>
+#include <avg/rendertree/snapshot.h>
 #include <avg/painter.h>
 #include <avg/rendering.h>
 
@@ -423,6 +424,17 @@ public:
 
         return animating_ ? std::optional<std::chrono::microseconds>(std::chrono::microseconds(0))
                           : std::nullopt;
+    }
+
+    // The render tree's current frame as a value snapshot. Matches render()'s
+    // obb and time so an agent observes exactly what the window presents.
+    avg::Snapshot snapshot() const
+    {
+        return renderTree_.snapshot(
+                avg::DrawContext(pmr::new_delete_resource()),
+                avg::Obb(aseWindow.getSize().cast<float>()),
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    agentTime_));
     }
 
     btl::UniqueId getId() const

--- a/src/bqui/test/sessiontest.cpp
+++ b/src/bqui/test/sessiontest.cpp
@@ -15,12 +15,17 @@
 #include <bqui/shape/shape.h>
 #include <bqui/shape/rectangle.h>
 
+#include <bqui/widget/label.h>
+
 #include <bq/signal/signal.h>
 #include <bq/signal/input.h>
 
 #include <ase/platform.h>
 #include <ase/dummyplatform.h>
 #include <avg/color.h>
+#include <avg/obb.h>
+#include <avg/vector.h>
+#include <avg/rendertree/snapshot.h>
 
 #include <btl/uniqueid.h>
 
@@ -194,6 +199,26 @@ namespace
             return node;
         }
 
+        // A synthetic render-tree snapshot with a recognizable root node and a
+        // single text run, so a render reply can be asserted against without a
+        // real render tree. The text is keyed to the window name so a
+        // multi-window reply can be matched entry-by-entry.
+        avg::Snapshot snapshot() const override
+        {
+            avg::SnapshotNode root;
+            root.type = "FakeShape";
+            root.obb = avg::Obb(avg::Vector2f(100.0f, 50.0f));
+            root.text.push_back(avg::SnapshotText{
+                    "fake:" + name_,
+                    avg::Obb(avg::Vector2f(80.0f, 20.0f)) });
+
+            avg::Snapshot snap;
+            snap.time = std::chrono::milliseconds(0);
+            snap.obb = avg::Obb(avg::Vector2f(200.0f, 100.0f));
+            snap.root = std::move(root);
+            return snap;
+        }
+
         void advance(std::chrono::microseconds dt) override
         {
             ++advances_;
@@ -310,6 +335,39 @@ TEST(session, introspectResolvesByIdAndErrorsOnUnknown)
 
     auto stray = btl::makeUniqueId();
     auto err = s.call("window.introspect", { { "window", stray.getValue() } });
+    EXPECT_EQ(-32602, err.at("error").at("code").get<int>());
+}
+
+// window.renderTree resolves the window by id and returns its render-tree
+// snapshot as a raw JSON sub-object (avg's schema), not a quoted string. The
+// fake's synthetic snapshot carries a known node type and text run.
+TEST(session, renderTreeResolvesByIdAndErrorsOnUnknown)
+{
+    auto idA = btl::makeUniqueId();
+    auto idB = btl::makeUniqueId();
+    FakeAgentWindow a(idA, "w0");
+    FakeAgentWindow b(idB, "w1");
+    SessionFixture s("rendertree", { a, b });
+
+    auto reply = s.call("window.renderTree", { { "window", idB.getValue() } });
+    auto const& tree = reply.at("result").at("renderTree");
+
+    // Embedded as an object, so it is navigable in place rather than a string.
+    ASSERT_TRUE(tree.is_object());
+    EXPECT_EQ(avg::Snapshot::version, tree.at("version").get<int>());
+
+    auto const& root = tree.at("root");
+    EXPECT_EQ("FakeShape", root.at("type").get<std::string>());
+    ASSERT_EQ(1u, root.at("text").size());
+    EXPECT_EQ("fake:w1", root.at("text").at(0).at("text").get<std::string>());
+
+    // Observation only: neither window advances.
+    EXPECT_EQ(0, a.advances());
+    EXPECT_EQ(0, b.advances());
+
+    // An unknown id is invalid params, like window.introspect.
+    auto stray = btl::makeUniqueId();
+    auto err = s.call("window.renderTree", { { "window", stray.getValue() } });
     EXPECT_EQ(-32602, err.at("error").at("code").get<int>());
 }
 
@@ -464,8 +522,8 @@ TEST(session, describeReportsTheRegistry)
     EXPECT_TRUE(has("window.list"));
     EXPECT_TRUE(has("window.introspect"));
     EXPECT_TRUE(has("window.inject"));
-    // renderTree lands one layer up (avg snapshot); it is not in this build.
-    EXPECT_FALSE(has("window.renderTree"));
+    // renderTree is served in this build (it rides on avg's snapshot).
+    EXPECT_TRUE(has("window.renderTree"));
 
     // The parameter schema is first-class: window.introspect requires `window`.
     ASSERT_TRUE(introspectParams.is_array());
@@ -826,6 +884,98 @@ TEST(session, describeListIntrospectDriveARealApp)
     auto count1 = findCount(intro1.at("result").at("introspection"));
     ASSERT_TRUE(count1.has_value());
     EXPECT_EQ(1.0, *count1);
+
+    rpc(*agent, id++, "app.shutdown");
+    appThread.join();
+}
+
+// --- Render integration: a real render tree over the wire ----------------
+
+namespace
+{
+    // Whether a rendertree node (or any descendant) draws the given text run.
+    bool treeHasText(json const& node, std::string const& text)
+    {
+        auto runs = node.find("text");
+        if (runs != node.end() && runs->is_array())
+            for (auto const& run : *runs)
+            {
+                auto t = run.find("text");
+                if (t != run.end() && t->is_string() && *t == text)
+                    return true;
+            }
+
+        auto children = node.find("children");
+        if (children != node.end() && children->is_array())
+            for (auto const& child : *children)
+                if (treeHasText(child, text))
+                    return true;
+
+        return false;
+    }
+
+    // Whether a rendertree node (or any descendant) has the given node type.
+    bool treeHasType(json const& node, std::string const& type)
+    {
+        auto t = node.find("type");
+        if (t != node.end() && t->is_string() && *t == type)
+            return true;
+
+        auto children = node.find("children");
+        if (children != node.end() && children->is_array())
+            for (auto const& child : *children)
+                if (treeHasType(child, type))
+                    return true;
+
+        return false;
+    }
+} // namespace
+
+// A real headless app whose one window draws a "hello" label: window.renderTree
+// returns that window's render-tree snapshot as a schema-version-1 document
+// embedded as a raw object, and the drawn text is recoverable from it.
+TEST(session, renderTreeReturnsARealWindowsRenderTree)
+{
+    auto endpoint = uniqueEndpoint("agentrender");
+    auto listener = listen(endpoint);
+
+    std::thread appThread([&]
+    {
+        App()
+            .platform(ase::makeDummyPlatform())
+            .agentic(true)
+            .agentEndpoint(endpoint)
+            .addWindow(
+                    window(bq::signal::constant<std::string>("Render")),
+                    label("hello"))
+            .run();
+    });
+
+    auto agent = listener->accept();
+    int id = 1;
+
+    // Build one frame so the render tree exists (agentic mode never free-runs).
+    auto step = rpc(*agent, id++, "app.step", { { "dt_us", 16667 } });
+    EXPECT_EQ("paused", step.at("result").at("state"));
+
+    auto list = rpc(*agent, id++, "window.list");
+    ASSERT_EQ(1u, list.at("result").at("windows").size());
+    uint64_t windowId =
+        list.at("result").at("windows").at(0).at("id").get<uint64_t>();
+
+    // Observe the render tree: a schema-version-1 object, not a quoted string.
+    auto reply = rpc(*agent, id++, "window.renderTree",
+            { { "window", windowId } });
+    auto const& tree = reply.at("result").at("renderTree");
+    ASSERT_TRUE(tree.is_object());
+    EXPECT_EQ(avg::Snapshot::version, tree.at("version").get<int>());
+
+    auto const& root = tree.at("root");
+    ASSERT_TRUE(root.is_object());
+
+    // The label is a shape leaf that draws the text "hello".
+    EXPECT_TRUE(treeHasType(root, "ShapeNode"));
+    EXPECT_TRUE(treeHasText(root, "hello"));
 
     rpc(*agent, id++, "app.shutdown");
     appThread.join();


### PR DESCRIPTION
Adds `window.renderTree` to the inspector protocol: the window's render-tree snapshot as a value.

## Change
- `WindowImpl::snapshot()` returns the render tree's current frame as an `avg::Snapshot`, at `render()`'s obb and time.
- `AgentWindow::snapshot()` (pure virtual) exposes it; `GlueAgentWindow` forwards to the `WindowImpl`.
- The session registers `window.renderTree`, returning `avg::toJson(snapshot)` embedded as a sub-object.

bq untouched.
