### PR TITLE
Sharpen the comment/Doxygen rule in the review rubric

### DIFF
--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -21,11 +21,9 @@ and `conventions.md`, which a reviewer also reads. Keep this curated, not a log.
   claim, rather than trusting the prose.
 - For code changes: correctness and logic first, then rubric compliance.
 - Weight findings by impact: a wrong/misleading claim outranks a cosmetic one.
-- **Flag comments that narrate mechanism or design reasoning, and Doxygen that
-  gives design rationale.** These are noise and a maintenance burden — every
-  change forces revisiting them and they rot. Usage/interface belongs in Doxygen,
-  the *why* in `decisions.md`, mechanism in `AGENTS.md`; only a terse note on a
-  genuinely surprising line or non-obvious invariant stays inline. `[should-fix]`.
+- **Weight comment/Doxygen narration of mechanism or design rationale heavily
+  — flag it** (see `style-guide.md` → Comments and the Doxygen bullet under
+  Documentation). `[should-fix]`.
 
 ## Known false-positives — do not flag
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -21,6 +21,11 @@ and `conventions.md`, which a reviewer also reads. Keep this curated, not a log.
   claim, rather than trusting the prose.
 - For code changes: correctness and logic first, then rubric compliance.
 - Weight findings by impact: a wrong/misleading claim outranks a cosmetic one.
+- **Flag comments that narrate mechanism or design reasoning, and Doxygen that
+  gives design rationale.** These are noise and a maintenance burden — every
+  change forces revisiting them and they rot. Usage/interface belongs in Doxygen,
+  the *why* in `decisions.md`, mechanism in `AGENTS.md`; only a terse note on a
+  genuinely surprising line or non-obvious invariant stays inline. `[should-fix]`.
 
 ## Known false-positives — do not flag
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -69,9 +69,11 @@ General rules:
 - **Doxygen documents usage, not design.** A header's docs say what a type or
   function is *for* and how to call it — the interface contract a caller needs.
   They do not explain how it is implemented or why it was designed that way; a
-  user should not have to care about the internals (lifetimes, ownership,
-  mechanism). Design rationale → `decisions.md`; mechanism → the library's
-  `AGENTS.md`.
+  user should not have to care about the internals (data structures,
+  algorithms, caching, internal mechanism). Ownership and lifetime stay in
+  Doxygen when they are part of the caller's contract — e.g. how long a returned
+  signal or view remains valid. Design rationale → `decisions.md`; mechanism →
+  the library's `AGENTS.md`.
 - **Docs may point at code; code never points at docs.**
 - **One home per fact:** concepts/usage → `readme.md`; API contract → Doxygen;
   cross-cutting model/conventions/decisions → top-level `docs/`; library-specific

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -66,6 +66,12 @@ General rules:
 
 - **API reference is Doxygen in the public headers.** Never transcribe
   signatures into Markdown.
+- **Doxygen documents usage, not design.** A header's docs say what a type or
+  function is *for* and how to call it — the interface contract a caller needs.
+  They do not explain how it is implemented or why it was designed that way; a
+  user should not have to care about the internals (lifetimes, ownership,
+  mechanism). Design rationale → `decisions.md`; mechanism → the library's
+  `AGENTS.md`.
 - **Docs may point at code; code never points at docs.**
 - **One home per fact:** concepts/usage → `readme.md`; API contract → Doxygen;
   cross-cutting model/conventions/decisions → top-level `docs/`; library-specific
@@ -84,9 +90,15 @@ General rules:
   previous version did, a reference to some discussion. That knowledge rots as a
   comment and confuses code readers; put it in an agent topic file (or
   `decisions.md` if it is a decision).
+- **Don't narrate how the code works or why it is designed this way.** If a
+  reader can see it from the code, the comment is noise; and it is a maintenance
+  burden — every change forces re-reading and re-checking the comments around it,
+  so they silently rot. The bar for an inline comment is a *surprise*, not an
+  *explanation*.
 - A short comment explaining a **non-obvious invariant or a genuinely surprising
   line** — timeless rationale the code reader needs — is good and stays inline.
-  The rule targets context and history, not all rationale.
+  The rule targets context, history, and mechanism, not this narrow kind of
+  rationale.
 - Prefer a small KB topic file over a long, context-heavy comment. Comments
   *describe*; the knowledge base *explains and remembers*.
 


### PR DESCRIPTION
Codifies a review lesson from the window-layer PR (#121): 

- **style-guide.md** - comments must not narrate *how* the code works or *why* it is designed that way (noise + maintenance burden); Doxygen documents **usage/interface, not design rationale or internals**.
- **reviewing.md** - matching `[should-fix]` heuristic so the clean-context reviewer flags mechanism/reasoning comments and design-rationale Doxygen without a human repeating it.

Docs-only. This is the AGENTS.md learning loop: rule -> style-guide.md, review heuristic -> reviewing.md.
