### PR TITLE
Add btl::RunLoop and render the platforms on demand

### DIFF
--- a/docs/design/frameclock.md
+++ b/docs/design/frameclock.md
@@ -1,0 +1,184 @@
+# Design: the frame model - windows, vsync, and on-demand rendering
+
+> **Status: design (ahead of the code).** This pins the model we build the `ase`
+> frame layer and `bqui`'s `FrameClock` against; the API contract will be Doxygen
+> in the headers. It sits on top of [`runloop.md`](runloop.md) and does not change
+> `btl::RunLoop`. Verified against the `runloop-design` branch (2026-07-29).
+
+## Why
+
+The desktop loop today busy-spins: the frame tick re-posts itself every iteration,
+`requestFrame` is an empty stub, and the GPU fence is awaited with a blocking
+`wait()` on the loop thread. So the loop never sleeps, never paces to the display,
+and cannot host a platform that *pushes* frames (iOS, Android, web). None of the
+"only render when needed" machinery was ever built.
+
+This model fixes all of that with one shift: **frames are driven by a per-window
+vsync source that the app arms on demand, not by a platform-owned loop that calls
+the frame body.** Everything else - idle sleep, vsync pacing, async GPU
+completion, and platform-pushed frames - falls out of that.
+
+## What a window is
+
+The desktop assumption baked into "the app creates N OS windows, each with an
+always-present surface" is false on mobile in two independent ways, so the model
+splits the window from its surface:
+
+- **Logical window** - app-owned, stable identity, part of the reactive window set
+  the `App` declares. The app says *what it wants*; it has its own signal context.
+- **Surface** - platform-owned renderable (swapchain / `CAMetalLayer` /
+  `ANativeWindow`). It may be **absent**, and it **attaches and detaches** on a
+  lifecycle the platform controls.
+
+The platform **reconciles** declared windows against available surfaces:
+
+| platform | creation | surface lifetime |
+|---|---|---|
+| desktop | app-driven, 1:1 | always present while the window lives |
+| iOS | system hands a `UIWindow` per `UIScreen` | drawable attaches/detaches; extra windows are scenes (later) |
+| Android | one `Surface` per `Activity` | `surfaceCreated` / `surfaceDestroyed` |
+| web | one `<canvas>` | present while mounted |
+
+When the surface is absent (backgrounded), the **logical window persists** and its
+vsync goes quiet, so rendering simply pauses; it resumes when the surface
+reattaches. This is why *declare-and-reconcile* beats imperative window creation:
+the platform matches intent against reality instead of assuming it can conjure OS
+windows.
+
+## vsync is a per-window, armable source
+
+Vsync is a `RunLoop` source (see [`runloop.md`](runloop.md)), in the same category
+as a socket or a timer - registered on the loop, its callback runs on the loop
+thread, and the idle loop blocks on it alongside everything else. Two things make
+it special:
+
+1. **It is per-window** - really per *display*, surfaced through the window, which
+   knows its display. Two monitors at 60/144 Hz each pace their own window. A
+   window owns its vsync source.
+2. **It is armable / maskable.** Unlike a socket ("ready when data arrives"), a
+   vsync tick is only wanted when a frame is pending. `requestFrame` arms it; after
+   a frame renders with nothing more wanted, it disarms and the loop stops waking
+   on it. That arm/disarm *is* the on-demand mechanism.
+
+Its `btl` backing differs per platform, but the frame scheduler sees one thing -
+"call me at the next frame boundary for this window":
+
+| platform | vsync backing |
+|---|---|
+| Windows | a **waitable-swapchain HANDLE** (the `addReadable(HANDLE)` kind the loop already has) |
+| GLX | a **refresh-interval timer** (no vsync fd to wait on) |
+| iOS / Android / web | a **native callback** (`CADisplayLink` / `AChoreographer` / `requestAnimationFrame`) that `post`s into the adapter loop |
+
+No new loop type: `ase` registers a source and adds a scheduling *policy*; it never
+owns iteration, so the mobile `RunLoopImpl`-as-adapter story holds.
+
+## The cadence
+
+Per window, the frame scheduler is a two-state machine:
+
+```
+        external change (observe fires -> requestFrame)
+  IDLE ------------------------------------------------> ACTIVE
+   ^                                                       |
+   |  render result: not animating (re-arm observe)        | render result:
+   +-------------------------------------------------------+ still animating
+                                                           (requestFrame)
+```
+
+- **idle**: `observe` is armed on the window's root signal; the loop sleeps. The
+  window renders nothing.
+- **idle -> active**: an external leaf invokes `observe`'s stored callback, which
+  calls `requestFrame` and arms the window's vsync.
+- **active tick** (on a vsync fire): advance the window's frame-time signal,
+  evaluate the graph to build the render tree, render it, and submit with an
+  async fence. The **render result reports whether animations are still running**.
+- **active -> active**: still animating -> `requestFrame` again (stay armed).
+- **active -> idle**: nothing animating -> **re-arm `observe`**, disarm vsync,
+  sleep.
+
+Two drivers, cleanly separated: **`observe` drives idle -> active** (discrete
+external changes), and the **render result drives active -> active** (animation).
+`observe` alone cannot drive animation - an animated value depends on the
+frame-time signal, which only advances when we render, so there is nothing for
+`observe` to fire on. The render result closes that loop.
+
+## `signal::observe`
+
+`observe` is the idle wakeup, and the whole on-demand story rests on it:
+
+- It walks the graph from the window root and registers a callback on every leaf
+  that can change from **outside** - `signal::input`, stream-to-signal connectors,
+  async-backed signals.
+- On an external change the leaf invokes the callback **immediately, without
+  evaluating the graph**. So the callback is cheap (just `requestFrame`), and a
+  burst of changes coalesces into one armed frame.
+- It is **one-shot and re-armed on each idle entry**. This is not a limitation but
+  the correct choice for a *dynamic* graph: `forEach` and conditionals reshape
+  which leaves are external, and re-walking on idle re-discovers them. A persistent
+  subscription would go stale. During active mode `observe` is not armed at all -
+  every frame evaluates fresh - so reshaping there is picked up for free.
+
+Because `observe` is armed **only while idle**, the frame-time advance we do each
+active tick cannot masquerade as an external change and re-arm us into a
+busy-loop.
+
+**Ordering rule (a real correctness dependency on single-threadedness):** re-arm
+`observe` *inside* the going-idle step of the tick, before yielding to the loop. An
+input or stream delivery only runs as a source callback *after* the current tick
+returns, so as long as re-arm is part of the tick, the next external change is
+always caught. Re-arming after yielding would open a lost-wakeup window.
+
+**What to verify.** The failure mode is not a leaf type - it is a *combinator that
+does not forward `observe` registration to its inputs*. If `map` / `join` /
+`forEach` / conditional register on themselves but not recursively on their
+upstream external leaves, a change below them fires nothing and that subtree
+silently freezes while idle. The test matrix is therefore **{`signal::input`,
+stream->signal, async-backed} x {reached through `map`/`join` and the dynamic
+`forEach`/conditional}**, asserting the callback fires exactly once per change.
+
+## The GPU fence is async, not awaited
+
+The frame submits a command buffer with a fence and **posts** its completion back
+onto the loop rather than blocking on it: the fence's continuation runs on the loop
+thread via the threadpool -> `post` seam ([`runloop.md`](runloop.md)). The loop
+keeps servicing input and vsync while the GPU works. Back-pressure is an in-flight
+cap: the fence continuation is what releases a slot and requests the next frame, so
+the pipeline never queues more than N frames deep and never stalls the loop thread.
+The cost is a touch of latency the frame after a stall actually resolves - an
+acceptable trade for a responsive loop.
+
+## Per-window independence
+
+Each window owns its **surface, signal context, vsync source, `observe`
+registration, `requestFrame` state, and frame-time signal**. Nothing is shared, so
+windows on different displays tick at different rates and idle independently. The
+"one fused app frame" of the current `App` (evaluate the graph once, advance all
+windows together) is a **v1 collapse** - drive every window off one clock - kept
+only because it is simpler for same-refresh desktop. The per-window signal contexts
+already exist, so relaxing the collapse into true independence is additive, not a
+rewrite. The frame-time signal is per-window from the start precisely so that
+collapse is a policy choice, not a structural one.
+
+## What lives where
+
+- **`btl::RunLoop`** - unchanged. Readable/timer/post is enough; the HANDLE source
+  already covers a waitable swapchain. Frames and vsync stay out of it.
+- **`ase`** - the per-window vsync source and the frame scheduler (arm/disarm,
+  render, async fence). On the push platforms the vsync callback feeds the adapter
+  loop.
+- **`bqui`** - `FrameClock` as the policy over the scheduler (`observe` wiring, the
+  cadence state machine, `requestFrame`, animation continuation), and the
+  window/surface reconciliation in `App`. The frame callback's result reports
+  "wants another frame" (animating), distinct from the old "shut down" bool.
+
+## First implementation and non-goals
+
+- **Desktop first**, both backings: the waitable-swapchain HANDLE on Windows and
+  the refresh-interval timer on GLX. The iOS/Android/web vsync sources are deferred
+  behind the same source abstraction; the point of the abstraction is that they
+  slot in without reshaping the scheduler.
+- **v1 may keep the single-clock collapse** (one vsync drives the app frame) while
+  building everything per-window underneath, so the multi-refresh, per-window-paced
+  case is *designed for* but not necessarily *shipped* first.
+- The window/surface split is introduced now, because it is what makes the model
+  mobile-ready and it degrades to "surface always present" on desktop at no cost.

--- a/docs/design/runloop.md
+++ b/docs/design/runloop.md
@@ -1,0 +1,249 @@
+# Design: `btl::RunLoop`, the platform run loop
+
+> **Status: design record, not yet implemented.** This file pins the principles
+> agreed before code so the first implementation does not have to be reworked as
+> functionality is added. Verified against `4edc9a0` (2026-07-26). When the work
+> lands, the stable parts move to their normal homes - the API contract to
+> Doxygen in the new `btl` headers, the settled *why* to `docs/decisions.md` -
+> and this file is trimmed to the parts still ahead of the code.
+
+## Purpose
+
+One reactor that services window frames, sockets, timers, and file work from a
+single loop. Today `bqui`'s `App::runUntil` has an `if (agentic)` branch that
+runs a wholly separate `runSession` loop (its own reader thread plus a command
+queue), so an app is *either* a normal windowed app *or* an agent-driven headless
+one, never both. The run loop unifies those into one loop with pluggable sources.
+
+Three payoffs:
+
+- **A live remote channel on a real app.** A headful, free-running app can have a
+  remote/inspection channel attached and serviced by the same loop - not only a
+  headless, frame-stepped one.
+- **Less concurrency.** The remote channel becomes one readable source on the app
+  thread, which deletes the reader thread and command queue - the machinery whose
+  abrupt-disconnect handling produced the SIGPIPE and SIGABRT bugs.
+- **A general primitive.** A reactor is useful with zero graphics dependencies (a
+  headless server, a CLI tool), which is why it lives in `btl`.
+
+## Layering
+
+- **`btl::RunLoop`** is the reactor: readable/writable/timer/post sources, and
+  `run`/`stop`. It knows nothing about graphics, windows, or vsync.
+- **`ase`** supplies the platform sources - window events and the vsync source
+  (below) - and embeds a `btl::RunLoop` **by value** in `PlatformImpl`, exposing
+  it via `runLoop()` so `bqui` and the remote layer register their own sources
+  from outside.
+- **`bqui`** builds a `FrameClock` pacing policy on top (below), and drives the
+  loop from `App::run`.
+
+## Core principle: the app never owns the iteration
+
+The one rule that makes this portable to platforms whose loop is owned by the OS:
+**the app registers sources and yields control; it never writes its own
+`while (true) { pump(); }`, and it never relies on code after `run()`.**
+
+- `run()` hands control to the loop and **may never return** (iOS, web).
+- All app logic lives in source callbacks.
+- Teardown is a callback the loop invokes on exit, not sequential code after
+  `run()`.
+
+The consequence for the backends: on a platform whose loop is native (iOS
+`CFRunLoop`, Android `ALooper`, web), `RunLoopImpl` **must be a thin adapter over
+that native loop, not a homegrown `select` loop** - otherwise the platform's
+vsync source (which is delivered *by* the native loop) cannot reach it.
+
+## Interface
+
+A concrete value type, move-only, with an internal pimpl:
+
+```cpp
+namespace btl
+{
+    class RunLoop
+    {
+    public:
+        RunLoop();
+        ~RunLoop();
+        RunLoop(RunLoop&&) noexcept;
+        RunLoop& operator=(RunLoop&&) noexcept;
+
+        SourceId addReadable(NativeHandle, std::function<void()> onReadable);
+        SourceId addWritable(NativeHandle, std::function<void()> onWritable);
+        TimerId  addTimer(std::chrono::microseconds delay, std::function<void()>);
+        void     post(std::function<void()>);   // thread-safe: wake + run on loop thread
+        void     remove(SourceId);
+        void     cancel(TimerId);
+
+        void     run();    // yield control; may never return
+        void     stop();   // wake and exit; callable from any thread or callback
+
+    private:
+        std::unique_ptr<class RunLoopImpl> impl_;   // the only allocation; per-platform
+    };
+}
+```
+
+Contract to pin, because it differs across backends:
+
+- **Level-triggered** readiness: a readable/writable callback keeps firing while
+  the handle stays ready (matches `select`), rather than edge-triggered `epoll`
+  semantics.
+- **Single-thread affinity**: a `RunLoop` and its sources belong to one thread.
+  Anything from another thread goes through `post`.
+- **Removal from within a callback is allowed** - a source may `remove()` itself.
+- `run()` may not return; see the core principle.
+
+## `NativeHandle`
+
+The loop refers to an OS handle without exposing the platform type. `NativeHandle`
+is an **opaque, fixed-size inline buffer** - non-owning, no RAII, trivially
+copyable, and free of any platform header:
+
+```cpp
+// btl/nativehandle.h  (public, <cstdint> only)
+class NativeHandle
+{
+public:
+    NativeHandle() = default;            // invalid
+    bool valid() const;
+private:
+    alignas(std::max_align_t) unsigned char storage_[2 * sizeof(void*)] = {};
+    bool valid_ = false;
+    friend struct NativeHandleAccess;    // the only door for platform code
+};
+```
+
+- **The kind is hidden inside the bytes.** Whether the handle is a POSIX fd, a
+  Win32 `SOCKET`, or a Win32 `HANDLE` is a private contract between each
+  platform's conversion header and its `RunLoopImpl`; it is *not* a public enum,
+  so there is nothing to map at the public level.
+- **Per-platform conversion headers, included only in platform code:**
+
+  ```
+  btl/posix/nativehandle_posix.h   NativeHandle fromFd(int);     int    toFd(NativeHandle);
+  btl/win32/nativehandle_win32.h   NativeHandle fromSocket(..);  SOCKET toSocket(NativeHandle);
+                                   // later fromHandle/toHandle - pulls in winsock/windows,
+                                   // so it never escapes a platform .cpp
+  ```
+
+  A socket transport calls `fromSocket(sock)` in its own `.cpp` to register; the
+  Windows `RunLoopImpl` calls `toSocket(h)` to wait on it. The winsock include is
+  confined to those files; every other header just carries `NativeHandle` blind.
+- **Storage bound** is generous: 16 bytes covers an fd (4), a `SOCKET`/`HANDLE`
+  (8), or a pair (16). A platform that needs more is a one-line bump, not a
+  redesign. The value need not be a scalar - a backend may store a small struct.
+- **No ownership.** `NativeHandle` names a handle the transport still owns; the
+  transport keeps it alive while registered and `remove()`s before `close()`. If
+  an owning wrapper is ever wanted, it is a *separate* `Socket`/`OwnedFd` type
+  that hands its non-owning `NativeHandle` to the loop.
+
+This is the shape `libuv` (`uv_os_sock_t`), Asio (`native_handle_type`), and Qt
+(`qintptr` handles) all use.
+
+## Frames and vsync are not `btl` primitives
+
+Vsync is a **platform source**, not a timer, because the model differs: iOS, and
+Android, and the web *push* a frame callback at each display refresh with a
+precise timestamp (`CADisplayLink`, `AChoreographer`, `requestAnimationFrame`),
+auto-adapting to 60/90/120 Hz. A `btl` timer would drift, ignore variable refresh,
+and fight the compositor there. So the vsync source lives in `ase`:
+
+| platform | vsync source |
+|---|---|
+| iOS | `CADisplayLink` on the `CFRunLoop` |
+| Android | `AChoreographer` on the `ALooper` |
+| web | `requestAnimationFrame` |
+| desktop | a timer, or a waitable swapchain (DXGI on Windows, GLX sync on Linux) |
+
+It rides on the `RunLoop`; on the push platforms it is delivered by the same
+native loop that `RunLoopImpl` adapts, alongside the sockets.
+
+`bqui`'s **`FrameClock`** is the pacing policy on top:
+
+- **On-demand:** an FRP invalidation `post`s a render. An idle UI schedules
+  nothing, so the loop sleeps in the wait until real I/O or a real change - zero
+  idle wakeups. This is the natural fit for a reactive toolkit that already knows
+  when content changed.
+- **Animating:** an animation source drives renders off the vsync source.
+- **Adaptive / GPU-bound:** the render measures itself and schedules the next via
+  `addTimer(max(0, interval - elapsed))` - a 0 delay means "keep rendering", a
+  positive delay waits out the remaining budget.
+
+A `btl` timer is only the desktop vsync fallback. `FrameClock` may still offer
+multiple frame callbacks, a settable interval, and pause/step as ergonomics over
+the primitives - it just is not part of the reactor.
+
+## Relationship to the threadpool
+
+`btl::RunLoop` (a single-thread main executor) and the existing `btl` threadpool
+(a multi-thread worker executor) do not overlap. The seam between them is `post`:
+blocking work runs on the pool and `post`s its completion back to the loop thread.
+A common `Executor` concept, or loop-aware futures that complete *onto* a
+`RunLoop`, is an attractive follow-up but not needed now.
+
+## Source taxonomy and per-platform mapping
+
+Most sources fit the readiness model - "the handle is ready, you do the
+non-blocking op" - on every platform family:
+
+| source | POSIX | Windows | iOS / Android | web |
+|---|---|---|---|---|
+| socket r/w, accept, connect | `select`/`epoll` fd | `WSAEventSelect` -> event, WFMO | `CFSocket` / `ALooper_addFd` | async cb |
+| pipe / FIFO | fd | overlapped `ReadFile` -> event | same | - |
+| FS watch | `inotify` / `kqueue` fd | `ReadDirectoryChangesW` -> event | `FSEvents` / `inotify` | - |
+| timer | wait timeout / `timerfd` | WFMO timeout / waitable timer | `CFRunLoopTimer` / choreographer | `setTimeout` |
+| cross-thread wake / `post` | `eventfd` / self-pipe | manual-reset event | `performBlock` / `ALooper_wake` | microtask |
+| stdin / tty | fd | console HANDLE (WFMO) | fd | - |
+| **regular file read/write** | **not selectable** | **overlapped / IOCP only** | - | - |
+| vsync, window events | (ase) | (ase) | native | native |
+
+Windows bridges its overlapped (completion) handles for pipes and FS-watch into
+readiness by signalling an event, which WFMO waits on.
+
+## The readiness-vs-completion fault line, and files
+
+POSIX is natively a **readiness** model (`select`/`epoll`); Windows is natively a
+**completion** model (IOCP: "your read finished, here is the data"). For sockets
+and pipes the two reconcile (Windows fakes readiness with `WSAEventSelect` and
+overlapped-to-event). **Regular file read/write fits neither readiness model**: a
+POSIX file fd is always reported "ready" yet the read still blocks on disk, and
+Windows file I/O is completion-only.
+
+Decision: **file I/O is not a reactor source.** It is threadpool-offload plus
+`post` - a blocking read/write on a worker thread that posts its result to the
+loop. That is thread-offloaded blocking I/O, which is all a GUI toolkit needs
+(assets, config, hot-reload). True async file I/O (Windows IOCP, Linux
+`io_uring`) is a deferred optimization behind the same surface, not a gap.
+
+## Known limits and non-goals
+
+- **Windows `WaitForMultipleObjects` caps at 64 handles.** Fine for a GUI and for
+  #96 (one socket); a high-connection-count server would need IOCP, which slots
+  behind the same `addReadable`/`addWritable` API later.
+- **True async file I/O** (IOCP / `io_uring`) is deferred.
+- **Signals (`signalfd`), child-process exit (`pidfd` / process HANDLE), and
+  device/serial I/O** are out of scope - server and tooling concerns a UI toolkit
+  rarely needs. Each is just another handle kind on the same reactor if wanted.
+
+## Minimal scope for #96
+
+Implement `btl::RunLoop` with a **POSIX (`select`)** and a **Windows
+(`WSAEventSelect` / WFMO)** backend, **sockets only** - `addReadable`, `addTimer`,
+`post`, `run`/`stop`, with `addWritable` present in the interface. That covers the
+Linux, macOS, and Windows CI legs.
+
+#96 then reworks `runUntil` / `runSession` onto it: one loop, the remote socket is
+one `addReadable` source (reader thread and command queue gone), and run/pause/step
+become `FrameClock` timer and `post` operations.
+
+Deferred behind the same interface, needing no rework to add later: the iOS,
+Android, and web `RunLoopImpl`s; FS-watch and file I/O sources; Win32 `HANDLE`
+kinds; and the `addWritable` backend.
+
+## Sequencing
+
+1. This doc.
+2. Implement the minimal `btl::RunLoop` - its own PR, lands **before** #96.
+3. Rework #96 onto it.
+4. Rebase #122 and #123.

--- a/docs/design/runloop.md
+++ b/docs/design/runloop.md
@@ -163,20 +163,12 @@ and fight the compositor there. So the vsync source lives in `ase`:
 It rides on the `RunLoop`; on the push platforms it is delivered by the same
 native loop that `RunLoopImpl` adapts, alongside the sockets.
 
-`bqui`'s **`FrameClock`** is the pacing policy on top:
-
-- **On-demand:** an FRP invalidation `post`s a render. An idle UI schedules
-  nothing, so the loop sleeps in the wait until real I/O or a real change - zero
-  idle wakeups. This is the natural fit for a reactive toolkit that already knows
-  when content changed.
-- **Animating:** an animation source drives renders off the vsync source.
-- **Adaptive / GPU-bound:** the render measures itself and schedules the next via
-  `addTimer(max(0, interval - elapsed))` - a 0 delay means "keep rendering", a
-  positive delay waits out the remaining budget.
-
-A `btl` timer is only the desktop vsync fallback. `FrameClock` may still offer
-multiple frame callbacks, a settable interval, and pause/step as ergonomics over
-the primitives - it just is not part of the reactor.
+`bqui`'s **`FrameClock`** is the pacing policy on top - on-demand via
+`signal::observe`, animating off the vsync source, with the GPU fence completing
+*onto* the loop rather than blocking it. The full frame and window model - the
+per-window armable vsync source, the on-demand cadence, and the window/surface
+split for mobile - is its own design: [`frameclock.md`](frameclock.md). A `btl`
+timer is only the desktop vsync fallback; frames are not part of the reactor.
 
 ## Relationship to the threadpool
 

--- a/docs/design/runloop.md
+++ b/docs/design/runloop.md
@@ -1,11 +1,10 @@
 # Design: `btl::RunLoop`, the platform run loop
 
-> **Status: design record, not yet implemented.** This file pins the principles
-> agreed before code so the first implementation does not have to be reworked as
-> functionality is added. Verified against `4edc9a0` (2026-07-26). When the work
-> lands, the stable parts move to their normal homes - the API contract to
-> Doxygen in the new `btl` headers, the settled *why* to `docs/decisions.md` -
-> and this file is trimmed to the parts still ahead of the code.
+> **Status: implemented (sockets, timers, post; POSIX + Win32).** This file pins
+> the principles behind the design; the API contract itself is Doxygen in the
+> `btl` headers. Verified against the `runloop-design` branch (2026-07-29). The
+> parts still ahead of the code are the deferred backends and source kinds noted
+> below.
 
 ## Purpose
 
@@ -55,44 +54,58 @@ vsync source (which is delivered *by* the native loop) cannot reach it.
 
 ## Interface
 
-A concrete value type, move-only, with an internal pimpl:
+`RunLoop` is a move-only value with an internal pimpl. Its public surface is
+deliberately small - `run`, `post`, `stop` - because it is the *only* part that
+is shared across threads. Everything else (registering sources and timers,
+removing them) lives on a **`RunLoop::Controller`**, which the loop hands to every
+callback for the length of that call. So the registration API is reachable only
+from the loop thread: you are either already in a callback (you have a
+`Controller`), or you `post` yourself onto the loop thread to get one.
 
-```cpp
-namespace btl
-{
-    class RunLoop
-    {
-    public:
-        RunLoop();
-        ~RunLoop();
-        RunLoop(RunLoop&&) noexcept;
-        RunLoop& operator=(RunLoop&&) noexcept;
-
-        SourceId addReadable(NativeHandle, std::function<void()> onReadable);
-        SourceId addWritable(NativeHandle, std::function<void()> onWritable);
-        TimerId  addTimer(std::chrono::microseconds delay, std::function<void()>);
-        void     post(std::function<void()>);   // thread-safe: wake + run on loop thread
-        void     remove(SourceId);
-        void     cancel(TimerId);
-
-        void     run();    // yield control; may never return
-        void     stop();   // wake and exit; callable from any thread or callback
-
-    private:
-        std::unique_ptr<class RunLoopImpl> impl_;   // the only allocation; per-platform
-    };
-}
-```
+Registering returns an RAII handle - `RunLoop::Source` / `RunLoop::Timer` - that
+removes its registration when dropped. `detach()` opts out (a fire-and-forget
+one-shot timer, or a source that lives as long as the loop).
 
 Contract to pin, because it differs across backends:
 
 - **Level-triggered** readiness: a readable/writable callback keeps firing while
   the handle stays ready (matches `select`), rather than edge-triggered `epoll`
   semantics.
-- **Single-thread affinity**: a `RunLoop` and its sources belong to one thread.
-  Anything from another thread goes through `post`.
-- **Removal from within a callback is allowed** - a source may `remove()` itself.
+- **Removal from within a callback is allowed** - a callback may drop a handle or
+  `Controller::remove` a source by id.
 - `run()` may not return; see the core principle.
+
+## Thread safety and ownership
+
+Only `post` and `stop` cross threads. The split is what makes that safe *by
+construction*: the non-thread-safe API cannot even be named off the loop thread,
+because a `Controller` only exists inside a loop-thread callback. A worker thread
+holds at most a `RunLoop&` (for `post`/`stop`); to touch sources it posts a task
+and is handed a `Controller` on the loop thread.
+
+The payoff is that the loop's own state needs almost no locking:
+
+- **Shared, so protected:** the posted-task queue (a mutex) and the running flag
+  (an atomic). `post` appends under the lock and wakes the loop; `stop` clears the
+  flag and wakes it.
+- **Loop-thread-only, so lock-free:** the source and timer maps and the id
+  counter. Nothing off the loop thread reaches them, so they carry no mutex.
+
+Lifetime rules:
+
+- `run()` pins a local `shared_ptr` to the impl before dispatching, so the loop
+  survives its owning `RunLoop` being destroyed mid-run (for instance,
+  reentrantly from a callback). When `run()` unwinds, that pin drops and the impl
+  is freed on the loop thread.
+- `~RunLoop()` asks the loop to stop but does **not** block - a join would
+  deadlock the reentrant-destroy case, which is the only in-run destruction the
+  contract allows. Destroy a `RunLoop` on its loop thread, or after `run()` has
+  returned; do not destroy it from another thread while `run()` is blocked
+  elsewhere.
+- Calling `run()` again while it is already running throws.
+- A handle's destructor may run on any thread: it removes its registration
+  directly if it is on the loop thread, and otherwise posts the removal (a no-op
+  if the loop is already gone).
 
 ## `NativeHandle`
 
@@ -100,24 +113,15 @@ The loop refers to an OS handle without exposing the platform type. `NativeHandl
 is an **opaque, fixed-size inline buffer** - non-owning, no RAII, trivially
 copyable, and free of any platform header:
 
-```cpp
-// btl/nativehandle.h  (public, <cstdint> only)
-class NativeHandle
-{
-public:
-    NativeHandle() = default;            // invalid
-    bool valid() const;
-private:
-    alignas(std::max_align_t) unsigned char storage_[2 * sizeof(void*)] = {};
-    bool valid_ = false;
-    friend struct NativeHandleAccess;    // the only door for platform code
-};
-```
+`NativeHandle` is a fixed-size inline byte buffer plus a small `Kind` tag,
+default-invalid, with no platform header in the public type. The bytes are filled
+and read only by two friend function templates (`makeNativeHandle` /
+`loadNativeHandle`) that the per-platform conversion headers call - no general
+access, no allocation.
 
-- **The kind is hidden inside the bytes.** Whether the handle is a POSIX fd, a
-  Win32 `SOCKET`, or a Win32 `HANDLE` is a private contract between each
-  platform's conversion header and its `RunLoopImpl`; it is *not* a public enum,
-  so there is nothing to map at the public level.
+- **The `Kind` tag says how to wait** (POSIX fd, Win32 `SOCKET`, Win32 `HANDLE`)
+  so a backend picks the right wait primitive, but the payload type itself never
+  escapes the platform conversion header.
 - **Per-platform conversion headers, included only in platform code:**
 
   ```
@@ -237,9 +241,10 @@ Linux, macOS, and Windows CI legs.
 one `addReadable` source (reader thread and command queue gone), and run/pause/step
 become `FrameClock` timer and `post` operations.
 
-Deferred behind the same interface, needing no rework to add later: the iOS,
-Android, and web `RunLoopImpl`s; FS-watch and file I/O sources; Win32 `HANDLE`
-kinds; and the `addWritable` backend.
+Win32 `HANDLE` sources (for overlapped-I/O events, e.g. named pipes) are also
+implemented. Deferred behind the same interface, needing no rework to add later:
+the iOS, Android, and web `RunLoopImpl`s; FS-watch and file I/O sources; and the
+`addWritable` backend.
 
 ## Sequencing
 

--- a/src/ase/include/ase/dummyplatform.h
+++ b/src/ase/include/ase/dummyplatform.h
@@ -25,6 +25,7 @@ namespace ase
         // Set to true by requestFrame() (possibly off-thread) to coalesce a
         // burst of wake requests into a single posted task.
         std::atomic<bool> wakePosted_ = false;
+
         // Installed by run() so requestFrame(), which cannot see run()'s local
         // tick, can schedule one while the loop is active; cleared at run() exit.
         std::function<void(btl::RunLoop::Controller&)> scheduleTick_;

--- a/src/ase/include/ase/dummyplatform.h
+++ b/src/ase/include/ase/dummyplatform.h
@@ -4,6 +4,11 @@
 
 #include "asevisibility.h"
 
+#include <btl/runloop.h>
+
+#include <atomic>
+#include <functional>
+
 namespace ase
 {
     class ASE_EXPORT DummyPlatform : public PlatformImpl
@@ -15,6 +20,14 @@ namespace ase
         void run(RenderContext& renderContext,
                 std::function<bool(Frame const&)> frameCallback) override;
         void requestFrame() override;
+
+    private:
+        // Set to true by requestFrame() (possibly off-thread) to coalesce a
+        // burst of wake requests into a single posted task.
+        std::atomic<bool> wakePosted_ = false;
+        // Installed by run() so requestFrame(), which cannot see run()'s local
+        // tick, can schedule one while the loop is active; cleared at run() exit.
+        std::function<void(btl::RunLoop::Controller&)> scheduleTick_;
     };
 
 } // namespace ase

--- a/src/ase/include/ase/dummyplatform.h
+++ b/src/ase/include/ase/dummyplatform.h
@@ -21,6 +21,12 @@ namespace ase
                 std::function<bool(Frame const&)> frameCallback) override;
         void requestFrame() override;
 
+        /** @brief Cap the headless frame rate. Zero (the default) leaves the loop
+         * uncapped: a tick runs as soon as requestFrame() wakes it. A positive
+         * value paces ticks to at most fps frames per second. Set before run().
+         */
+        void setMaxFps(unsigned int fps);
+
     private:
         // Set to true by requestFrame() (possibly off-thread) to coalesce a
         // burst of wake requests into a single posted task.
@@ -29,6 +35,10 @@ namespace ase
         // Installed by run() so requestFrame(), which cannot see run()'s local
         // tick, can schedule one while the loop is active; cleared at run() exit.
         std::function<void(btl::RunLoop::Controller&)> scheduleTick_;
+
+        // Frame-rate cap; 0 means uncapped. Read only on the loop thread, so it
+        // must be set before run().
+        unsigned int maxFps_ = 0;
     };
 
 } // namespace ase

--- a/src/ase/include/ase/glxplatform.h
+++ b/src/ase/include/ase/glxplatform.h
@@ -4,11 +4,15 @@
 
 #include "asevisibility.h"
 
+#include <btl/runloop.h>
+
 #include <tracy/Tracy.hpp>
 
 #include <GL/glx.h>
 #include <X11/Xlib.h>
 
+#include <atomic>
+#include <functional>
 #include <string>
 #include <mutex>
 
@@ -65,6 +69,13 @@ namespace ase
         inline GlxPlatformDeferred* d() { return deferred_; }
         inline GlxPlatformDeferred const* d() const { return deferred_; }
         GlxPlatformDeferred* deferred_;
+
+        // Set to true by requestFrame() (possibly off-thread) to coalesce a
+        // burst of wake requests into a single posted task.
+        std::atomic<bool> wakePosted_ = false;
+        // Installed by run() so requestFrame(), which cannot see run()'s local
+        // tick, can schedule one while the loop is active; cleared at run() exit.
+        std::function<void(btl::RunLoop::Controller&)> scheduleTick_;
     };
 }
 

--- a/src/ase/include/ase/glxplatform.h
+++ b/src/ase/include/ase/glxplatform.h
@@ -73,6 +73,7 @@ namespace ase
         // Set to true by requestFrame() (possibly off-thread) to coalesce a
         // burst of wake requests into a single posted task.
         std::atomic<bool> wakePosted_ = false;
+
         // Installed by run() so requestFrame(), which cannot see run()'s local
         // tick, can schedule one while the loop is active; cleared at run() exit.
         std::function<void(btl::RunLoop::Controller&)> scheduleTick_;

--- a/src/ase/include/ase/platformimpl.h
+++ b/src/ase/include/ase/platformimpl.h
@@ -3,7 +3,10 @@
 #include "vector.h"
 #include "asevisibility.h"
 
+#include <btl/runloop.h>
+
 #include <chrono>
+#include <functional>
 #include <optional>
 
 namespace ase
@@ -23,6 +26,17 @@ namespace ase
         virtual void run(RenderContext& renderContext,
                 std::function<bool(Frame const&)> frameCallback) = 0;
         virtual void requestFrame() = 0;
+
+        /** @brief The platform's run loop, for registering sources (sockets,
+         * timers) serviced alongside the frame loop.
+         */
+        btl::RunLoop& runLoop()
+        {
+            return loop_;
+        }
+
+    protected:
+        btl::RunLoop loop_;
     };
 }
 

--- a/src/ase/include/ase/wglplatform.h
+++ b/src/ase/include/ase/wglplatform.h
@@ -50,6 +50,7 @@ namespace ase
         // Set to true by requestFrame() (possibly off-thread) to coalesce a
         // burst of wake requests into a single posted task.
         std::atomic<bool> wakePosted_ = false;
+
         // Installed by run() so requestFrame(), which cannot see run()'s local
         // tick, can schedule one while the loop is active; cleared at run() exit.
         std::function<void(btl::RunLoop::Controller&)> scheduleTick_;

--- a/src/ase/include/ase/wglplatform.h
+++ b/src/ase/include/ase/wglplatform.h
@@ -4,10 +4,15 @@
 
 #include "asevisibility.h"
 
+#include <btl/runloop.h>
+
 #include <windows.h>
 
 #include <GL/gl.h>
 #include <GL/wglext.h>
+
+#include <atomic>
+#include <functional>
 
 namespace ase
 {
@@ -41,6 +46,13 @@ namespace ase
         HGLRC dummyContext_ = nullptr;
         HDC dummyDc_ = nullptr;
         PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB_ = nullptr;
+
+        // Set to true by requestFrame() (possibly off-thread) to coalesce a
+        // burst of wake requests into a single posted task.
+        std::atomic<bool> wakePosted_ = false;
+        // Installed by run() so requestFrame(), which cannot see run()'s local
+        // tick, can schedule one while the loop is active; cleared at run() exit.
+        std::function<void(btl::RunLoop::Controller&)> scheduleTick_;
     };
 
 } // namespace ase

--- a/src/ase/src/dummy/dummyplatform.cpp
+++ b/src/ase/src/dummy/dummyplatform.cpp
@@ -34,13 +34,11 @@ void DummyPlatform::run(RenderContext&,
 {
     Frame frame{};
 
-    // A tick is "scheduled" while one is posted; this loop-thread-only flag
-    // dedupes so ticks never stack.
     bool tickScheduled = false;
 
     std::function<void(btl::RunLoop::Controller&)> tick;
 
-    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
+    auto scheduleTick = [&tickScheduled, &tick](btl::RunLoop::Controller& controller)
     {
         if (tickScheduled)
             return;
@@ -52,7 +50,7 @@ void DummyPlatform::run(RenderContext&,
     // render). It does not re-post; the loop blocks until requestFrame() wakes
     // it, so any sources registered on it (a remote socket, a timer) are
     // serviced meanwhile.
-    tick = [&](btl::RunLoop::Controller& controller)
+    tick = [&tickScheduled, &frameCallback, &frame](btl::RunLoop::Controller& controller)
     {
         tickScheduled = false;
 
@@ -63,9 +61,10 @@ void DummyPlatform::run(RenderContext&,
         }
     };
 
-    runLoop().post([&](btl::RunLoop::Controller& controller)
+    scheduleTick_ = [&scheduleTick](btl::RunLoop::Controller& c) { scheduleTick(c); };
+
+    runLoop().post([&scheduleTick](btl::RunLoop::Controller& controller)
         {
-            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
             scheduleTick(controller);
         });
     runLoop().run();

--- a/src/ase/src/dummy/dummyplatform.cpp
+++ b/src/ase/src/dummy/dummyplatform.cpp
@@ -29,30 +29,64 @@ RenderContext DummyPlatform::makeRenderContext()
     return RenderContext(std::make_shared<DummyRenderContext>());
 }
 
+void DummyPlatform::setMaxFps(unsigned int fps)
+{
+    maxFps_ = fps;
+}
+
 void DummyPlatform::run(RenderContext&,
         std::function<bool(Frame const&)> frameCallback)
 {
-    Frame frame{};
+    std::chrono::steady_clock clock;
+    auto startTime = clock.now();
+    auto lastFrame = startTime;
 
     bool tickScheduled = false;
 
     std::function<void(btl::RunLoop::Controller&)> tick;
 
-    auto scheduleTick = [&tickScheduled, &tick](btl::RunLoop::Controller& controller)
+    // Uncapped, a due tick is posted straight away and the loop stays purely
+    // on-demand. With a cap, a tick that comes due sooner than the frame
+    // interval is deferred by a one-shot timer for the remainder instead.
+    auto scheduleTick = [this, &tickScheduled, &tick, &clock, &lastFrame](
+            btl::RunLoop::Controller& controller)
     {
         if (tickScheduled)
             return;
         tickScheduled = true;
-        controller.post(tick);
+
+        if (maxFps_ == 0)
+        {
+            controller.post(tick);
+            return;
+        }
+
+        auto interval = std::chrono::microseconds(1000000 / maxFps_);
+        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+                clock.now() - lastFrame);
+        if (elapsed >= interval)
+            controller.post(tick);
+        else
+            controller.addTimer(interval - elapsed, tick).detach();
     };
 
-    // Headless: a tick only runs the frame callback (there is nothing to
-    // render). It does not re-post; the loop blocks until requestFrame() wakes
-    // it, so any sources registered on it (a remote socket, a timer) are
-    // serviced meanwhile.
-    tick = [&tickScheduled, &frameCallback, &frame](btl::RunLoop::Controller& controller)
+    // Headless: a tick runs the frame callback with the elapsed time (there is
+    // nothing to render). It does not re-post; the loop blocks until
+    // requestFrame() wakes it, so any sources registered on it (a remote socket,
+    // a timer) are serviced meanwhile.
+    tick = [&tickScheduled, &clock, &startTime, &lastFrame, &frameCallback](
+            btl::RunLoop::Controller& controller)
     {
         tickScheduled = false;
+
+        auto thisFrame = clock.now();
+        auto time = std::chrono::duration_cast<std::chrono::microseconds>(
+                thisFrame - startTime);
+        auto dt = std::chrono::duration_cast<std::chrono::microseconds>(
+                thisFrame - lastFrame);
+
+        Frame frame { time, dt };
+        lastFrame = thisFrame;
 
         if (!frameCallback(frame))
         {

--- a/src/ase/src/dummy/dummyplatform.cpp
+++ b/src/ase/src/dummy/dummyplatform.cpp
@@ -33,8 +33,20 @@ void DummyPlatform::run(RenderContext&,
         std::function<bool(Frame const&)> frameCallback)
 {
     Frame frame{};
-    while (frameCallback(frame)) {
-    }
+
+    // Drive frames through the run loop so any sources registered on it (a
+    // remote socket, a timer) are serviced between frames. Each frame re-posts
+    // the next; a false return stops the loop.
+    std::function<void()> tick = [&]()
+    {
+        if (frameCallback(frame))
+            runLoop().post(tick);
+        else
+            runLoop().stop();
+    };
+
+    runLoop().post(tick);
+    runLoop().run();
 }
 
 void DummyPlatform::requestFrame()

--- a/src/ase/src/dummy/dummyplatform.cpp
+++ b/src/ase/src/dummy/dummyplatform.cpp
@@ -37,12 +37,13 @@ void DummyPlatform::run(RenderContext&,
     // Drive frames through the run loop so any sources registered on it (a
     // remote socket, a timer) are serviced between frames. Each frame re-posts
     // the next; a false return stops the loop.
-    std::function<void()> tick = [&]()
+    std::function<void(btl::RunLoop::Controller&)> tick =
+        [&](btl::RunLoop::Controller& controller)
     {
         if (frameCallback(frame))
-            runLoop().post(tick);
+            controller.post(tick);
         else
-            runLoop().stop();
+            controller.stop();
     };
 
     runLoop().post(tick);

--- a/src/ase/src/dummy/dummyplatform.cpp
+++ b/src/ase/src/dummy/dummyplatform.cpp
@@ -34,24 +34,58 @@ void DummyPlatform::run(RenderContext&,
 {
     Frame frame{};
 
-    // Drive frames through the run loop so any sources registered on it (a
-    // remote socket, a timer) are serviced between frames. Each frame re-posts
-    // the next; a false return stops the loop.
-    std::function<void(btl::RunLoop::Controller&)> tick =
-        [&](btl::RunLoop::Controller& controller)
+    // A tick is "scheduled" while one is posted; this loop-thread-only flag
+    // dedupes so ticks never stack.
+    bool tickScheduled = false;
+
+    std::function<void(btl::RunLoop::Controller&)> tick;
+
+    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
     {
-        if (frameCallback(frame))
-            controller.post(tick);
-        else
-            controller.stop();
+        if (tickScheduled)
+            return;
+        tickScheduled = true;
+        controller.post(tick);
     };
 
-    runLoop().post(tick);
+    // Headless: a tick only runs the frame callback (there is nothing to
+    // render). It does not re-post; the loop blocks until requestFrame() wakes
+    // it, so any sources registered on it (a remote socket, a timer) are
+    // serviced meanwhile.
+    tick = [&](btl::RunLoop::Controller& controller)
+    {
+        tickScheduled = false;
+
+        if (!frameCallback(frame))
+        {
+            controller.stop();
+            return;
+        }
+    };
+
+    runLoop().post([&](btl::RunLoop::Controller& controller)
+        {
+            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
+            scheduleTick(controller);
+        });
     runLoop().run();
+
+    scheduleTick_ = nullptr;
 }
 
 void DummyPlatform::requestFrame()
 {
+    // May be called off the loop thread (e.g. an async signal completing), so
+    // wake through a thread-safe post; the atomic coalesces a burst into one.
+    if (!wakePosted_.exchange(true))
+    {
+        runLoop().post([this](btl::RunLoop::Controller& controller)
+            {
+                wakePosted_ = false;
+                if (scheduleTick_)
+                    scheduleTick_(controller);
+            });
+    }
 }
 
 } // namespace ase

--- a/src/ase/src/glx/glxplatform.cpp
+++ b/src/ase/src/glx/glxplatform.cpp
@@ -355,15 +355,9 @@ void GlxPlatform::run(RenderContext& renderContext,
     auto lastFrame = startTime;
     auto nextFrame = startTime + step;
 
-    std::queue<btl::future::Future<>> frameFutures;
+    auto framesInFlight = std::make_shared<int>(0);
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    // Service the X connection through the run loop: when its socket has data,
-    // drain every queued event. handleEvents() is also called per frame below,
-    // which is what actually guarantees delivery today - a busy render loop, and
-    // Xlib can buffer events without new socket data (so select would not
-    // re-fire). This source prepares for on-demand pacing, where the loop blocks
-    // and the fd wakes it.
     btl::RunLoop::Source xSource;
 
     // Drive frames through the run loop; each frame re-posts the next, a false
@@ -392,18 +386,28 @@ void GlxPlatform::run(RenderContext& renderContext,
             return;
         }
 
-        for (auto& weakWindow : d()->windows_)
+        // Skip producing a new frame while the GPU still has earlier ones in
+        // flight; a fence completion frees a slot and a re-post picks it up.
+        if (*framesInFlight < 2)
         {
-            if (auto window = weakWindow.lock())
+            for (auto& weakWindow : d()->windows_)
             {
-                if (window->needsRedraw())
-                    window->frame(frame);
+                if (auto window = weakWindow.lock())
+                {
+                    if (window->needsRedraw())
+                        window->frame(frame);
+                }
             }
-        }
 
-        ase::CommandBuffer commandBuffer;
-        frameFutures.push(commandBuffer.pushFence());
-        mainQueue.submit(std::move(commandBuffer));
+            ase::CommandBuffer commandBuffer;
+            ++*framesInFlight;
+            commandBuffer.pushFence([this, framesInFlight]
+                {
+                    runLoop().post([framesInFlight](btl::RunLoop::Controller&)
+                        { --*framesInFlight; });
+                });
+            mainQueue.submit(std::move(commandBuffer));
+        }
 
         auto now = clock.now();
         nextFrame += step;
@@ -421,21 +425,11 @@ void GlxPlatform::run(RenderContext& renderContext,
         }
         */
 
-        if (frameFutures.size() > 1)
-        {
-            ZoneScopedN("Wait for frame to finish");
-            ZoneValue(frameFutures.size());
-            frameFutures.front().wait();
-            frameFutures.pop();
-        }
-
         lastFrame = thisFrame;
 
         controller.post(tick);
     };
 
-    // Register the X source and start the frame loop on the loop thread; the
-    // Source is removed when xSource goes out of scope below.
     runLoop().post([&](btl::RunLoop::Controller& controller)
         {
             xSource = controller.addReadable(
@@ -445,13 +439,7 @@ void GlxPlatform::run(RenderContext& renderContext,
         });
     runLoop().run();
 
-    while (!frameFutures.empty())
-    {
-        ZoneScopedN("Wait for frame to finish");
-        ZoneValue(frameFutures.size());
-        frameFutures.front().wait();
-        frameFutures.pop();
-    }
+    mainQueue.finish();
 
     DBG("Shutting down GlxPlatform..");
 }

--- a/src/ase/src/glx/glxplatform.cpp
+++ b/src/ase/src/glx/glxplatform.cpp
@@ -346,7 +346,6 @@ void GlxPlatform::run(RenderContext& renderContext,
 {
     DBG("Starting GlxPlatform::run");
 
-    bool const lockStep = true;
     int const targetFps = 60;
     auto const step = std::chrono::microseconds(1000000 / targetFps);
 
@@ -360,23 +359,29 @@ void GlxPlatform::run(RenderContext& renderContext,
 
     btl::RunLoop::Source xSource;
 
-    // Drive frames through the run loop; each frame re-posts the next, a false
-    // callback stops it.
-    std::function<void(btl::RunLoop::Controller&)> tick =
-        [&](btl::RunLoop::Controller& controller)
-    {
-        std::chrono::steady_clock::time_point thisFrame;
-        if (lockStep)
-            thisFrame = nextFrame;
-        else
-            thisFrame = clock.now();
+    // A tick is "scheduled" while one is posted or a paced timer is pending;
+    // this loop-thread-only flag dedupes so ticks never stack.
+    bool tickScheduled = false;
 
+    std::function<void(btl::RunLoop::Controller&)> tick;
+
+    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
+    {
+        if (tickScheduled)
+            return;
+        tickScheduled = true;
+        controller.post(tick);
+    };
+
+    tick = [&](btl::RunLoop::Controller& controller)
+    {
+        tickScheduled = false;
+
+        auto thisFrame = clock.now();
         auto time = std::chrono::duration_cast<std::chrono::microseconds>(
                 thisFrame - startTime);
         auto dt = std::chrono::duration_cast<std::chrono::microseconds>(
                 thisFrame - lastFrame);
-
-        handleEvents();
 
         Frame frame { time, dt };
 
@@ -387,7 +392,7 @@ void GlxPlatform::run(RenderContext& renderContext,
         }
 
         // Skip producing a new frame while the GPU still has earlier ones in
-        // flight; a fence completion frees a slot and a re-post picks it up.
+        // flight; a fence completion frees a slot and a re-arm picks it up.
         if (*framesInFlight < 2)
         {
             for (auto& weakWindow : d()->windows_)
@@ -414,30 +419,56 @@ void GlxPlatform::run(RenderContext& renderContext,
         while (nextFrame < now)
             nextFrame += step;
 
-        /*
-        auto frameTime = std::chrono::duration_cast<
-            std::chrono::microseconds>(now - thisFrame);
-        auto remaining = nextFrame - now;
-        if (remaining.count() > 0)
-        {
-            ZoneScopedN("sleep");
-            std::this_thread::sleep_for(remaining);
-        }
-        */
-
         lastFrame = thisFrame;
 
-        controller.post(tick);
+        // Re-arm only while there is work: a window still wants to draw, or the
+        // GPU is saturated and we must retry when a fence frees a slot. When
+        // neither holds we do not re-post, and the loop blocks on the X source
+        // and posts until requestFrame() wakes it.
+        bool armed = *framesInFlight >= 2;
+        for (auto& weakWindow : d()->windows_)
+        {
+            if (auto window = weakWindow.lock())
+            {
+                if (window->needsRedraw())
+                {
+                    armed = true;
+                    break;
+                }
+            }
+        }
+
+        if (armed && !tickScheduled)
+        {
+            tickScheduled = true;
+            auto delay = std::chrono::duration_cast<std::chrono::microseconds>(
+                    nextFrame - clock.now());
+            if (delay.count() < 0)
+                delay = std::chrono::microseconds(0);
+            controller.addTimer(delay, tick).detach();
+        }
     };
 
     runLoop().post([&](btl::RunLoop::Controller& controller)
         {
+            // Wake on X input; the callback drains the connection (firing the
+            // window event handlers) and schedules a tick so frameCallback
+            // (running/sync) runs and any armed window redraws.
             xSource = controller.addReadable(
                     btl::fromFd(ConnectionNumber(d()->dpy_)),
-                    [this](btl::RunLoop::Controller&) { handleEvents(); });
-            controller.post(tick);
+                    [&](btl::RunLoop::Controller& c)
+                    {
+                        handleEvents();
+                        scheduleTick(c);
+                    });
+
+            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
+
+            scheduleTick(controller);
         });
     runLoop().run();
+
+    scheduleTick_ = nullptr;
 
     mainQueue.finish();
 
@@ -446,6 +477,17 @@ void GlxPlatform::run(RenderContext& renderContext,
 
 void GlxPlatform::requestFrame()
 {
+    // May be called off the loop thread (e.g. an async signal completing), so
+    // wake through a thread-safe post; the atomic coalesces a burst into one.
+    if (!wakePosted_.exchange(true))
+    {
+        runLoop().post([this](btl::RunLoop::Controller& controller)
+            {
+                wakePosted_ = false;
+                if (scheduleTick_)
+                    scheduleTick_(controller);
+            });
+    }
 }
 
 GLXContext createNewGlContext(Display* display, GLXContext sharedContext,

--- a/src/ase/src/glx/glxplatform.cpp
+++ b/src/ase/src/glx/glxplatform.cpp
@@ -11,6 +11,9 @@
 
 #include "debug.h"
 
+#include <btl/runloop.h>
+#include <btl/posix/nativehandle_posix.h>
+
 #include <GL/glx.h>
 
 #include <X11/extensions/sync.h>
@@ -355,7 +358,19 @@ void GlxPlatform::run(RenderContext& renderContext,
     std::queue<btl::future::Future<>> frameFutures;
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    while (true)
+    // Service the X connection through the run loop: when its socket has data,
+    // drain every queued event. handleEvents() is also called per frame below,
+    // which is what actually guarantees delivery today - a busy render loop, and
+    // Xlib can buffer events without new socket data (so select would not
+    // re-fire). This source prepares for on-demand pacing, where the loop blocks
+    // and the fd wakes it.
+    btl::SourceId const xSource = runLoop().addReadable(
+            btl::fromFd(ConnectionNumber(d()->dpy_)),
+            [this]() { handleEvents(); });
+
+    // Drive frames through the run loop; each frame re-posts the next, a false
+    // callback stops it.
+    std::function<void()> tick = [&]()
     {
         std::chrono::steady_clock::time_point thisFrame;
         if (lockStep)
@@ -373,7 +388,10 @@ void GlxPlatform::run(RenderContext& renderContext,
         Frame frame { time, dt };
 
         if (!frameCallback(frame))
-            break;
+        {
+            runLoop().stop();
+            return;
+        }
 
         for (auto& weakWindow : d()->windows_)
         {
@@ -413,7 +431,14 @@ void GlxPlatform::run(RenderContext& renderContext,
         }
 
         lastFrame = thisFrame;
-    }
+
+        runLoop().post(tick);
+    };
+
+    runLoop().post(tick);
+    runLoop().run();
+
+    runLoop().remove(xSource);
 
     while (!frameFutures.empty())
     {

--- a/src/ase/src/glx/glxplatform.cpp
+++ b/src/ase/src/glx/glxplatform.cpp
@@ -364,13 +364,12 @@ void GlxPlatform::run(RenderContext& renderContext,
     // Xlib can buffer events without new socket data (so select would not
     // re-fire). This source prepares for on-demand pacing, where the loop blocks
     // and the fd wakes it.
-    btl::SourceId const xSource = runLoop().addReadable(
-            btl::fromFd(ConnectionNumber(d()->dpy_)),
-            [this]() { handleEvents(); });
+    btl::RunLoop::Source xSource;
 
     // Drive frames through the run loop; each frame re-posts the next, a false
     // callback stops it.
-    std::function<void()> tick = [&]()
+    std::function<void(btl::RunLoop::Controller&)> tick =
+        [&](btl::RunLoop::Controller& controller)
     {
         std::chrono::steady_clock::time_point thisFrame;
         if (lockStep)
@@ -389,7 +388,7 @@ void GlxPlatform::run(RenderContext& renderContext,
 
         if (!frameCallback(frame))
         {
-            runLoop().stop();
+            controller.stop();
             return;
         }
 
@@ -432,13 +431,19 @@ void GlxPlatform::run(RenderContext& renderContext,
 
         lastFrame = thisFrame;
 
-        runLoop().post(tick);
+        controller.post(tick);
     };
 
-    runLoop().post(tick);
+    // Register the X source and start the frame loop on the loop thread; the
+    // Source is removed when xSource goes out of scope below.
+    runLoop().post([&](btl::RunLoop::Controller& controller)
+        {
+            xSource = controller.addReadable(
+                    btl::fromFd(ConnectionNumber(d()->dpy_)),
+                    [this](btl::RunLoop::Controller&) { handleEvents(); });
+            controller.post(tick);
+        });
     runLoop().run();
-
-    runLoop().remove(xSource);
 
     while (!frameFutures.empty())
     {

--- a/src/ase/src/glx/glxplatform.cpp
+++ b/src/ase/src/glx/glxplatform.cpp
@@ -359,13 +359,11 @@ void GlxPlatform::run(RenderContext& renderContext,
 
     btl::RunLoop::Source xSource;
 
-    // A tick is "scheduled" while one is posted or a paced timer is pending;
-    // this loop-thread-only flag dedupes so ticks never stack.
     bool tickScheduled = false;
 
     std::function<void(btl::RunLoop::Controller&)> tick;
 
-    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
+    auto scheduleTick = [&tickScheduled, &tick](btl::RunLoop::Controller& controller)
     {
         if (tickScheduled)
             return;
@@ -373,7 +371,9 @@ void GlxPlatform::run(RenderContext& renderContext,
         controller.post(tick);
     };
 
-    tick = [&](btl::RunLoop::Controller& controller)
+    tick = [this, &tickScheduled, &clock, &startTime, &lastFrame, &frameCallback,
+            &framesInFlight, &mainQueue, &nextFrame, &step, &tick](
+            btl::RunLoop::Controller& controller)
     {
         tickScheduled = false;
 
@@ -421,10 +421,6 @@ void GlxPlatform::run(RenderContext& renderContext,
 
         lastFrame = thisFrame;
 
-        // Re-arm only while there is work: a window still wants to draw, or the
-        // GPU is saturated and we must retry when a fence frees a slot. When
-        // neither holds we do not re-post, and the loop blocks on the X source
-        // and posts until requestFrame() wakes it.
         bool armed = *framesInFlight >= 2;
         for (auto& weakWindow : d()->windows_)
         {
@@ -449,20 +445,21 @@ void GlxPlatform::run(RenderContext& renderContext,
         }
     };
 
-    runLoop().post([&](btl::RunLoop::Controller& controller)
+    scheduleTick_ = [&scheduleTick](btl::RunLoop::Controller& c) { scheduleTick(c); };
+
+    runLoop().post([this, &xSource, &scheduleTick](
+            btl::RunLoop::Controller& controller)
         {
             // Wake on X input; the callback drains the connection (firing the
             // window event handlers) and schedules a tick so frameCallback
             // (running/sync) runs and any armed window redraws.
             xSource = controller.addReadable(
                     btl::fromFd(ConnectionNumber(d()->dpy_)),
-                    [&](btl::RunLoop::Controller& c)
+                    [this, &scheduleTick](btl::RunLoop::Controller& c)
                     {
                         handleEvents();
                         scheduleTick(c);
                     });
-
-            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
 
             scheduleTick(controller);
         });

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -303,7 +303,8 @@ void WglPlatform::run(RenderContext& renderContext,
     // Win32 message queue, renders, then re-posts the next; a false callback
     // stops the loop. The message pump stays here in ase - btl has no HWND
     // awareness.
-    std::function<void()> tick = [&]()
+    std::function<void(btl::RunLoop::Controller&)> tick =
+        [&](btl::RunLoop::Controller& controller)
     {
         auto thisFrame = clock.now();
         auto time = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -317,7 +318,7 @@ void WglPlatform::run(RenderContext& renderContext,
 
         if (!frameCallback(frame))
         {
-            runLoop().stop();
+            controller.stop();
             return;
         }
 
@@ -364,7 +365,7 @@ void WglPlatform::run(RenderContext& renderContext,
 
         lastFrame = thisFrame;
 
-        runLoop().post(tick);
+        controller.post(tick);
     };
 
     runLoop().post(tick);

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -295,14 +295,9 @@ void WglPlatform::run(RenderContext& renderContext,
     auto lastFrame = startTime;
     auto nextFrame = startTime + std::chrono::microseconds(16667);
 
-    std::queue<btl::future::Future<>> frameFutures;
+    auto framesInFlight = std::make_shared<int>(0);
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    // Drive frames through the run loop so sources registered on it (a future
-    // remote socket, timers) are serviced between frames. Each frame pumps the
-    // Win32 message queue, renders, then re-posts the next; a false callback
-    // stops the loop. The message pump stays here in ase - btl has no HWND
-    // awareness.
     std::function<void(btl::RunLoop::Controller&)> tick =
         [&](btl::RunLoop::Controller& controller)
     {
@@ -322,18 +317,28 @@ void WglPlatform::run(RenderContext& renderContext,
             return;
         }
 
-        for (auto& weakWindow : windows)
+        // Skip producing a new frame while the GPU still has earlier ones in
+        // flight; a fence completion frees a slot and a re-post picks it up.
+        if (*framesInFlight < 2)
         {
-            if (auto window = weakWindow.second.lock())
+            for (auto& weakWindow : windows)
             {
-                if (window->needsRedraw())
-                    window->frame(frame);
+                if (auto window = weakWindow.second.lock())
+                {
+                    if (window->needsRedraw())
+                        window->frame(frame);
+                }
             }
-        }
 
-        ase::CommandBuffer commandBuffer;
-        frameFutures.push(commandBuffer.pushFence());
-        mainQueue.submit(std::move(commandBuffer));
+            ase::CommandBuffer commandBuffer;
+            ++*framesInFlight;
+            commandBuffer.pushFence([this, framesInFlight]
+                {
+                    runLoop().post([framesInFlight](btl::RunLoop::Controller&)
+                        { --*framesInFlight; });
+                });
+            mainQueue.submit(std::move(commandBuffer));
+        }
 
         auto now = clock.now();
         nextFrame += std::chrono::microseconds(16667);
@@ -355,14 +360,6 @@ void WglPlatform::run(RenderContext& renderContext,
         }
         */
 
-        if (frameFutures.size() > 1)
-        {
-            ZoneScopedN("Wait for frame to finish");
-            ZoneValue(frameFutures.size());
-            frameFutures.front().wait();
-            frameFutures.pop();
-        }
-
         lastFrame = thisFrame;
 
         controller.post(tick);
@@ -371,13 +368,7 @@ void WglPlatform::run(RenderContext& renderContext,
     runLoop().post(tick);
     runLoop().run();
 
-    while (!frameFutures.empty())
-    {
-        ZoneScopedN("Wait for frame to finish");
-        ZoneValue(frameFutures.size());
-        frameFutures.front().wait();
-        frameFutures.pop();
-    }
+    mainQueue.finish();
 
     DBG("Shutting down WglPlatform...");
 }

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -13,6 +13,7 @@
 #include "tracy/Tracy.hpp"
 
 #include <btl/future.h>
+#include <btl/runloop.h>
 
 #include <windows.h>
 
@@ -297,7 +298,12 @@ void WglPlatform::run(RenderContext& renderContext,
     std::queue<btl::future::Future<>> frameFutures;
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    while (true)
+    // Drive frames through the run loop so sources registered on it (a future
+    // remote socket, timers) are serviced between frames. Each frame pumps the
+    // Win32 message queue, renders, then re-posts the next; a false callback
+    // stops the loop. The message pump stays here in ase - btl has no HWND
+    // awareness.
+    std::function<void()> tick = [&]()
     {
         auto thisFrame = clock.now();
         auto time = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -310,7 +316,10 @@ void WglPlatform::run(RenderContext& renderContext,
         Frame frame { time, dt };
 
         if (!frameCallback(frame))
-            break;
+        {
+            runLoop().stop();
+            return;
+        }
 
         for (auto& weakWindow : windows)
         {
@@ -354,7 +363,12 @@ void WglPlatform::run(RenderContext& renderContext,
         }
 
         lastFrame = thisFrame;
-    }
+
+        runLoop().post(tick);
+    };
+
+    runLoop().post(tick);
+    runLoop().run();
 
     while (!frameFutures.empty())
     {

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -302,13 +302,11 @@ void WglPlatform::run(RenderContext& renderContext,
     auto framesInFlight = std::make_shared<int>(0);
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    // A tick is "scheduled" while one is posted or a paced timer is pending;
-    // this loop-thread-only flag dedupes so ticks never stack.
     bool tickScheduled = false;
 
     std::function<void(btl::RunLoop::Controller&)> tick;
 
-    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
+    auto scheduleTick = [&tickScheduled, &tick](btl::RunLoop::Controller& controller)
     {
         if (tickScheduled)
             return;
@@ -316,7 +314,9 @@ void WglPlatform::run(RenderContext& renderContext,
         controller.post(tick);
     };
 
-    tick = [&](btl::RunLoop::Controller& controller)
+    tick = [this, &tickScheduled, &clock, &startTime, &lastFrame, &frameCallback,
+            &framesInFlight, &mainQueue, &nextFrame, &tick](
+            btl::RunLoop::Controller& controller)
     {
         tickScheduled = false;
 
@@ -364,10 +364,6 @@ void WglPlatform::run(RenderContext& renderContext,
 
         lastFrame = thisFrame;
 
-        // Re-arm only while there is work: a window still wants to draw, or the
-        // GPU is saturated and we must retry when a fence frees a slot. When
-        // neither holds we do not re-post, and the loop blocks on the message
-        // source and posts until requestFrame() wakes it.
         bool armed = *framesInFlight >= 2;
         for (auto& weakWindow : windows)
         {
@@ -394,19 +390,20 @@ void WglPlatform::run(RenderContext& renderContext,
 
     btl::RunLoop::Source msgSource;
 
-    runLoop().post([&](btl::RunLoop::Controller& controller)
+    scheduleTick_ = [&scheduleTick](btl::RunLoop::Controller& c) { scheduleTick(c); };
+
+    runLoop().post([this, &msgSource, &scheduleTick](
+            btl::RunLoop::Controller& controller)
         {
             // Wake on Windows input; the callback drains the queue (firing the
             // window event callbacks) and schedules a tick so frameCallback
             // (running/sync) runs and any armed window redraws.
             msgSource = controller.addReadable(btl::fromMessageQueue(),
-                    [&](btl::RunLoop::Controller& c)
+                    [this, &scheduleTick](btl::RunLoop::Controller& c)
                     {
                         handleEvents();
                         scheduleTick(c);
                     });
-
-            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
 
             scheduleTick(controller);
         });

--- a/src/ase/src/windows/wglplatform.cpp
+++ b/src/ase/src/windows/wglplatform.cpp
@@ -1,3 +1,7 @@
+// Must precede any header that pulls in windows.h: it brings in winsock2 first,
+// which blocks the older winsock.h that windows.h would otherwise include.
+#include <btl/win32/nativehandle_win32.h>
+
 #include "wglplatform.h"
 
 #include "wglwindow.h"
@@ -298,16 +302,29 @@ void WglPlatform::run(RenderContext& renderContext,
     auto framesInFlight = std::make_shared<int>(0);
     auto mainQueue = renderContext.getMainRenderQueue();
 
-    std::function<void(btl::RunLoop::Controller&)> tick =
-        [&](btl::RunLoop::Controller& controller)
+    // A tick is "scheduled" while one is posted or a paced timer is pending;
+    // this loop-thread-only flag dedupes so ticks never stack.
+    bool tickScheduled = false;
+
+    std::function<void(btl::RunLoop::Controller&)> tick;
+
+    auto scheduleTick = [&](btl::RunLoop::Controller& controller)
     {
+        if (tickScheduled)
+            return;
+        tickScheduled = true;
+        controller.post(tick);
+    };
+
+    tick = [&](btl::RunLoop::Controller& controller)
+    {
+        tickScheduled = false;
+
         auto thisFrame = clock.now();
         auto time = std::chrono::duration_cast<std::chrono::microseconds>(
                 thisFrame - startTime);
         auto dt = std::chrono::duration_cast<std::chrono::microseconds>(
                 thisFrame - lastFrame);
-
-        handleEvents();
 
         Frame frame { time, dt };
 
@@ -318,7 +335,7 @@ void WglPlatform::run(RenderContext& renderContext,
         }
 
         // Skip producing a new frame while the GPU still has earlier ones in
-        // flight; a fence completion frees a slot and a re-post picks it up.
+        // flight; a fence completion frees a slot and a re-arm picks it up.
         if (*framesInFlight < 2)
         {
             for (auto& weakWindow : windows)
@@ -343,30 +360,60 @@ void WglPlatform::run(RenderContext& renderContext,
         auto now = clock.now();
         nextFrame += std::chrono::microseconds(16667);
         while (nextFrame < now)
-        {
             nextFrame += std::chrono::microseconds(16667);
-        }
-
-        /*
-        auto frameTime = std::chrono::duration_cast<
-            std::chrono::microseconds>(now - thisFrame);
-        auto remaining = nextFrame - now;
-        if (remaining.count() > 0)
-        {
-            ZoneScopedN("sleep");
-            timeBeginPeriod(1);
-            std::this_thread::sleep_for(remaining);
-            timeEndPeriod(1);
-        }
-        */
 
         lastFrame = thisFrame;
 
-        controller.post(tick);
+        // Re-arm only while there is work: a window still wants to draw, or the
+        // GPU is saturated and we must retry when a fence frees a slot. When
+        // neither holds we do not re-post, and the loop blocks on the message
+        // source and posts until requestFrame() wakes it.
+        bool armed = *framesInFlight >= 2;
+        for (auto& weakWindow : windows)
+        {
+            if (auto window = weakWindow.second.lock())
+            {
+                if (window->needsRedraw())
+                {
+                    armed = true;
+                    break;
+                }
+            }
+        }
+
+        if (armed && !tickScheduled)
+        {
+            tickScheduled = true;
+            auto delay = std::chrono::duration_cast<std::chrono::microseconds>(
+                    nextFrame - clock.now());
+            if (delay.count() < 0)
+                delay = std::chrono::microseconds(0);
+            controller.addTimer(delay, tick).detach();
+        }
     };
 
-    runLoop().post(tick);
+    btl::RunLoop::Source msgSource;
+
+    runLoop().post([&](btl::RunLoop::Controller& controller)
+        {
+            // Wake on Windows input; the callback drains the queue (firing the
+            // window event callbacks) and schedules a tick so frameCallback
+            // (running/sync) runs and any armed window redraws.
+            msgSource = controller.addReadable(btl::fromMessageQueue(),
+                    [&](btl::RunLoop::Controller& c)
+                    {
+                        handleEvents();
+                        scheduleTick(c);
+                    });
+
+            scheduleTick_ = [&](btl::RunLoop::Controller& c) { scheduleTick(c); };
+
+            scheduleTick(controller);
+        });
+
     runLoop().run();
+
+    scheduleTick_ = nullptr;
 
     mainQueue.finish();
 
@@ -375,6 +422,17 @@ void WglPlatform::run(RenderContext& renderContext,
 
 void WglPlatform::requestFrame()
 {
+    // May be called off the loop thread (e.g. an async signal completing), so
+    // wake through a thread-safe post; the atomic coalesces a burst into one.
+    if (!wakePosted_.exchange(true))
+    {
+        runLoop().post([this](btl::RunLoop::Controller& controller)
+            {
+                wakePosted_ = false;
+                if (scheduleTick_)
+                    scheduleTick_(controller);
+            });
+    }
 }
 
 } // namespace ase

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -271,6 +271,10 @@ int App::runUntil(bq::signal::AnySignal<bool> running)
 
     auto runningContext = bq::signal::makeSignalContext(std::move(running));
 
+    // Wake the loop when the run condition changes, so an on-demand platform
+    // re-evaluates it instead of sleeping through the change.
+    runningContext.observe([this] { d()->wakeLoop(); });
+
     // Syncs the live impls to the window collection: mounts an impl for any
     // window not yet mounted, tears down any impl whose window has left. The
     // collection (which close()/removeWindow update directly) is read straight,

--- a/src/bqui/src/app.cpp
+++ b/src/bqui/src/app.cpp
@@ -69,6 +69,10 @@ public:
      */
     void removeWindow(btl::UniqueId id);
 
+    // Wakes the run loop, if one is running, so a pending window change is
+    // reconciled by the next sync().
+    void wakeLoop();
+
     std::vector<Window> getWindows() const
     {
         return *windows_.read();
@@ -78,6 +82,11 @@ public:
 
     std::mutex pendingMutex_;
     std::vector<std::pair<Window, widget::AnyWidget>> pendingMounts_;
+
+    // The platform is a runUntil local; it is published here for the duration
+    // of the run so add/removeWindow can wake the loop. Guarded by
+    // pendingMutex_, and nulled before the platform is destroyed.
+    ase::Platform* runningPlatform_ = nullptr;
 
     std::vector<btl::shared<WindowImpl>> windowImpls_;
 };
@@ -147,6 +156,15 @@ void AppDeferred::removeWindow(btl::UniqueId id)
 
     for (auto const& window : departing)
         window.data()->clearApp();
+
+    wakeLoop();
+}
+
+void AppDeferred::wakeLoop()
+{
+    std::lock_guard<std::mutex> lock(pendingMutex_);
+    if (runningPlatform_)
+        runningPlatform_->requestFrame();
 }
 
 App::App() :
@@ -186,6 +204,8 @@ App& App::addWindow(Window window, widget::AnyWidget widget)
         d()->pendingMounts_.emplace_back(std::move(window), std::move(widget));
     }
 
+    d()->wakeLoop();
+
     return *this;
 }
 
@@ -221,6 +241,24 @@ int App::run()
 int App::runUntil(bq::signal::AnySignal<bool> running)
 {
     ase::Platform platform = ase::makeDefaultPlatform();
+
+    // Published for the run's duration so add/removeWindow can wake the loop;
+    // declared after `platform` so it is nulled under the lock before the
+    // platform is destroyed.
+    struct PlatformScope
+    {
+        ~PlatformScope()
+        {
+            std::lock_guard<std::mutex> lock(app.pendingMutex_);
+            app.runningPlatform_ = nullptr;
+        }
+        AppDeferred& app;
+    } platformScope { *d() };
+
+    {
+        std::lock_guard<std::mutex> lock(d()->pendingMutex_);
+        d()->runningPlatform_ = &platform;
+    }
 
     ase::RenderContext context = platform.makeRenderContext();
 

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -33,6 +33,7 @@
 
 #include <tracy/Tracy.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <iostream>
@@ -75,7 +76,7 @@ public:
         aseWindow.setVisible(true);
         aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
 
-        auto wake = [this] { aseWindow.requestFrame(); };
+        auto wake = [this] { needsUpdate_ = true; aseWindow.requestFrame(); };
         widgetInstanceSignal_.observe(wake);
         titleSignal_.observe(wake);
 
@@ -394,7 +395,12 @@ public:
         auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(
                 timer_);
 
-        makeTransaction(frame.dt, std::nullopt);
+        // Frames are scheduled to render and advance the render tree; the
+        // signal graph is re-evaluated only when the observe wake flagged an
+        // external change, not on every animation frame.
+        std::optional<bq::signal::signal_time_t> timeToNext;
+        if (needsUpdate_.exchange(false))
+            timeToNext = makeTransaction(frame.dt, std::nullopt);
 
         if (animating_)
         {
@@ -471,6 +477,10 @@ private:
     std::optional<avg::AnimationOptions> animationOptions_;
     avg::Drawing drawing_;
     std::optional<std::chrono::milliseconds> nextUpdate_;
+    // Set by the observe wake when an external signal changed; makeTransaction
+    // runs only while it is set, so animation frames re-draw without
+    // re-evaluating the signal graph.
+    std::atomic<bool> needsUpdate_{true};
     bool animating_ = true;
     bool resized_ = true;
     bool closed_ = false;

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -75,6 +75,10 @@ public:
         aseWindow.setVisible(true);
         aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
 
+        auto wake = [this] { aseWindow.requestFrame(); };
+        widgetInstanceSignal_.observe(wake);
+        titleSignal_.observe(wake);
+
         aseWindow.setFrameCallback([this](ase::Frame const& frame) {
                 return onFrame(frame);
                 });

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -76,12 +76,17 @@ public:
         aseWindow.setVisible(true);
         aseWindow.setTitle(titleSignal_.evaluate<0>().get<0>());
 
-        auto wake = [this] { needsUpdate_ = true; aseWindow.requestFrame(); };
+        auto wake = [this]
+        {
+            needsUpdate_ = true;
+            aseWindow.requestFrame();
+        };
         widgetInstanceSignal_.observe(wake);
         titleSignal_.observe(wake);
 
-        aseWindow.setFrameCallback([this](ase::Frame const& frame) {
-                return onFrame(frame);
+        aseWindow.setFrameCallback([this](ase::Frame const& frame)
+                {
+                    return onFrame(frame);
                 });
 
         aseWindow.setCloseCallback([this]()
@@ -393,9 +398,6 @@ public:
         auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(
                 timer_);
 
-        // Frames are scheduled to render and advance the render tree; the
-        // signal graph is re-evaluated only when the observe wake flagged an
-        // external change, not on every animation frame.
         if (needsUpdate_.exchange(false))
             makeTransaction(frame.dt, std::nullopt);
 

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -474,9 +474,6 @@ private:
     std::optional<avg::AnimationOptions> animationOptions_;
     avg::Drawing drawing_;
     std::optional<std::chrono::milliseconds> nextUpdate_;
-    // Set by the observe wake when an external signal changed; makeTransaction
-    // runs only while it is set, so animation frames re-draw without
-    // re-evaluating the signal graph.
     std::atomic<bool> needsUpdate_{true};
     bool animating_ = true;
     bool resized_ = true;

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -266,6 +266,8 @@ public:
     {
         ZoneScoped;
 
+        auto updateStart = std::chrono::steady_clock::now();
+
         auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(timer_);
 
         bq::signal::FrameInfo frameInfo(getNextFrameId(), dt);
@@ -360,6 +362,13 @@ public:
 
             aseWindow.requestFrame();
         }
+
+        auto updateElapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - updateStart);
+        std::cout << "Update took " << updateElapsed.count() << " us, changed="
+            << updateResult.didChange << std::endl;
+
+        return updateResult.nextUpdate;
     }
 
     std::optional<bq::signal::signal_time_t> frame(std::chrono::microseconds dt)

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -273,8 +273,8 @@ public:
 
         bq::signal::FrameInfo frameInfo(getNextFrameId(), dt);
 
-        widgetInstanceSignal_.update(frameInfo);
-        titleSignal_.update(frameInfo);
+        auto updateResult = widgetInstanceSignal_.update(frameInfo);
+        updateResult = updateResult + titleSignal_.update(frameInfo);
 
 
         if (titleSignal_.didChange<0>())
@@ -368,8 +368,6 @@ public:
                 std::chrono::steady_clock::now() - updateStart);
         std::cout << "Update took " << updateElapsed.count() << " us, changed="
             << updateResult.didChange << std::endl;
-
-        return updateResult.nextUpdate;
     }
 
     std::optional<bq::signal::signal_time_t> frame(std::chrono::microseconds dt)
@@ -398,9 +396,8 @@ public:
         // Frames are scheduled to render and advance the render tree; the
         // signal graph is re-evaluated only when the observe wake flagged an
         // external change, not on every animation frame.
-        std::optional<bq::signal::signal_time_t> timeToNext;
         if (needsUpdate_.exchange(false))
-            timeToNext = makeTransaction(frame.dt, std::nullopt);
+            makeTransaction(frame.dt, std::nullopt);
 
         if (animating_)
         {
@@ -421,10 +418,8 @@ public:
 
         ++frames_;
 
-        if (animating_)
-            return std::chrono::microseconds(0);
-
-        return std::nullopt;
+        return animating_ ? std::optional<std::chrono::microseconds>(std::chrono::microseconds(0))
+                          : std::nullopt;
     }
 
     btl::UniqueId getId() const

--- a/src/btl/include/btl/nativehandle.h
+++ b/src/btl/include/btl/nativehandle.h
@@ -8,21 +8,35 @@ namespace btl
 {
     /** @brief An opaque, non-owning reference to an OS handle.
      *
-     * Carries a platform handle (a POSIX fd, a Win32 SOCKET, ...) without
-     * exposing its type, so a NativeHandle can pass through headers that must
-     * not pull in winsock or windows.h. It is a trivially copyable value with no
-     * ownership: it names a handle the caller still owns and must keep alive
-     * while registered. Build one only through the per-platform conversion
+     * Carries a platform handle (a POSIX fd, a Win32 SOCKET or HANDLE, ...)
+     * without exposing its type, so a NativeHandle can pass through headers that
+     * must not pull in winsock or windows.h. It is a trivially copyable value
+     * with no ownership: it names a handle the caller still owns and must keep
+     * alive while registered. Build one only through the per-platform conversion
      * headers (btl/posix/nativehandle_posix.h, btl/win32/nativehandle_win32.h).
      */
     class NativeHandle
     {
     public:
+        /** @brief What the stored bytes are, so a backend waits the right way. */
+        enum class Kind
+        {
+            None,
+            Fd,     // POSIX file descriptor: select/poll.
+            Socket, // Win32 SOCKET: WSAEventSelect onto an event.
+            Handle, // Win32 waitable HANDLE (e.g. an overlapped-I/O event).
+        };
+
         NativeHandle() = default;
 
         bool valid() const noexcept
         {
-            return valid_;
+            return kind_ != Kind::None;
+        }
+
+        Kind kind() const noexcept
+        {
+            return kind_;
         }
 
     private:
@@ -30,7 +44,7 @@ namespace btl
 
         alignas(alignof(std::max_align_t)) unsigned char
             storage_[2 * sizeof(void*)] = {};
-        bool valid_ = false;
+        Kind kind_ = Kind::None;
     };
 
     /** @brief The one door platform conversion code uses to fill or read a
@@ -39,7 +53,7 @@ namespace btl
     struct NativeHandleAccess
     {
         template <typename T>
-        static NativeHandle make(T value)
+        static NativeHandle make(T value, NativeHandle::Kind kind)
         {
             static_assert(std::is_trivially_copyable<T>::value,
                     "native handle payload must be trivially copyable");
@@ -48,7 +62,7 @@ namespace btl
 
             NativeHandle handle;
             std::memcpy(handle.storage_, &value, sizeof(T));
-            handle.valid_ = true;
+            handle.kind_ = kind;
             return handle;
         }
 

--- a/src/btl/include/btl/nativehandle.h
+++ b/src/btl/include/btl/nativehandle.h
@@ -21,7 +21,7 @@ namespace btl
         /** @brief What the stored bytes are, so a backend waits the right way. */
         enum class Kind
         {
-            None,
+            Invalid, // Xlib #defines None, so avoid that name here.
             Fd,     // POSIX file descriptor: select/poll.
             Socket, // Win32 SOCKET: WSAEventSelect onto an event.
             Handle, // Win32 waitable HANDLE (e.g. an overlapped-I/O event).
@@ -31,7 +31,7 @@ namespace btl
 
         bool valid() const noexcept
         {
-            return kind_ != Kind::None;
+            return kind_ != Kind::Invalid;
         }
 
         Kind kind() const noexcept
@@ -44,7 +44,7 @@ namespace btl
 
         alignas(alignof(std::max_align_t)) unsigned char
             storage_[2 * sizeof(void*)] = {};
-        Kind kind_ = Kind::None;
+        Kind kind_ = Kind::Invalid;
     };
 
     /** @brief The one door platform conversion code uses to fill or read a

--- a/src/btl/include/btl/nativehandle.h
+++ b/src/btl/include/btl/nativehandle.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
+
+namespace btl
+{
+    /** @brief An opaque, non-owning reference to an OS handle.
+     *
+     * Carries a platform handle (a POSIX fd, a Win32 SOCKET, ...) without
+     * exposing its type, so a NativeHandle can pass through headers that must
+     * not pull in winsock or windows.h. It is a trivially copyable value with no
+     * ownership: it names a handle the caller still owns and must keep alive
+     * while registered. Build one only through the per-platform conversion
+     * headers (btl/posix/nativehandle_posix.h, btl/win32/nativehandle_win32.h).
+     */
+    class NativeHandle
+    {
+    public:
+        NativeHandle() = default;
+
+        bool valid() const noexcept
+        {
+            return valid_;
+        }
+
+    private:
+        friend struct NativeHandleAccess;
+
+        alignas(alignof(std::max_align_t)) unsigned char
+            storage_[2 * sizeof(void*)] = {};
+        bool valid_ = false;
+    };
+
+    /** @brief The one door platform conversion code uses to fill or read a
+     * NativeHandle's bytes. Not for general use.
+     */
+    struct NativeHandleAccess
+    {
+        template <typename T>
+        static NativeHandle make(T value)
+        {
+            static_assert(std::is_trivially_copyable<T>::value,
+                    "native handle payload must be trivially copyable");
+            static_assert(sizeof(T) <= sizeof(NativeHandle::storage_),
+                    "native handle payload does not fit; bump the storage size");
+
+            NativeHandle handle;
+            std::memcpy(handle.storage_, &value, sizeof(T));
+            handle.valid_ = true;
+            return handle;
+        }
+
+        template <typename T>
+        static T load(NativeHandle const& handle)
+        {
+            T value{};
+            std::memcpy(&value, handle.storage_, sizeof(T));
+            return value;
+        }
+    };
+}

--- a/src/btl/include/btl/nativehandle.h
+++ b/src/btl/include/btl/nativehandle.h
@@ -25,6 +25,7 @@ namespace btl
             Fd,     // POSIX file descriptor: select/poll.
             Socket, // Win32 SOCKET: WSAEventSelect onto an event.
             Handle, // Win32 waitable HANDLE (e.g. an overlapped-I/O event).
+            MessageQueue, // Win32 thread message queue: MsgWaitForMultipleObjects.
         };
 
         NativeHandle() = default;

--- a/src/btl/include/btl/nativehandle.h
+++ b/src/btl/include/btl/nativehandle.h
@@ -40,38 +40,39 @@ namespace btl
         }
 
     private:
-        friend struct NativeHandleAccess;
+        template <typename T>
+        friend NativeHandle makeNativeHandle(T value, Kind kind);
+        template <typename T>
+        friend T loadNativeHandle(NativeHandle const& handle);
 
         alignas(alignof(std::max_align_t)) unsigned char
             storage_[2 * sizeof(void*)] = {};
         Kind kind_ = Kind::Invalid;
     };
 
-    /** @brief The one door platform conversion code uses to fill or read a
-     * NativeHandle's bytes. Not for general use.
-     */
-    struct NativeHandleAccess
+    /** @brief Pack a value into a NativeHandle. For the conversion headers. */
+    template <typename T>
+    NativeHandle makeNativeHandle(T value, NativeHandle::Kind kind)
     {
-        template <typename T>
-        static NativeHandle make(T value, NativeHandle::Kind kind)
-        {
-            static_assert(std::is_trivially_copyable<T>::value,
-                    "native handle payload must be trivially copyable");
-            static_assert(sizeof(T) <= sizeof(NativeHandle::storage_),
-                    "native handle payload does not fit; bump the storage size");
+        static_assert(std::is_trivially_copyable<T>::value,
+                "native handle payload must be trivially copyable");
+        static_assert(sizeof(T) <= sizeof(NativeHandle::storage_),
+                "native handle payload does not fit; bump the storage size");
 
-            NativeHandle handle;
-            std::memcpy(handle.storage_, &value, sizeof(T));
-            handle.kind_ = kind;
-            return handle;
-        }
+        NativeHandle handle;
+        std::memcpy(handle.storage_, &value, sizeof(T));
+        handle.kind_ = kind;
+        return handle;
+    }
 
-        template <typename T>
-        static T load(NativeHandle const& handle)
-        {
-            T value{};
-            std::memcpy(&value, handle.storage_, sizeof(T));
-            return value;
-        }
-    };
+    /** @brief Read a value back out of a NativeHandle. For the conversion
+     * headers.
+     */
+    template <typename T>
+    T loadNativeHandle(NativeHandle const& handle)
+    {
+        T value{};
+        std::memcpy(&value, handle.storage_, sizeof(T));
+        return value;
+    }
 }

--- a/src/btl/include/btl/posix/nativehandle_posix.h
+++ b/src/btl/include/btl/posix/nativehandle_posix.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <btl/nativehandle.h>
+
+namespace btl
+{
+    /** @brief Wrap a POSIX file descriptor as a NativeHandle. */
+    inline NativeHandle fromFd(int fd)
+    {
+        return NativeHandleAccess::make(fd);
+    }
+
+    /** @brief Read the file descriptor back out. Only valid on POSIX handles. */
+    inline int toFd(NativeHandle const& handle)
+    {
+        return NativeHandleAccess::load<int>(handle);
+    }
+}

--- a/src/btl/include/btl/posix/nativehandle_posix.h
+++ b/src/btl/include/btl/posix/nativehandle_posix.h
@@ -7,12 +7,12 @@ namespace btl
     /** @brief Wrap a POSIX file descriptor as a NativeHandle. */
     inline NativeHandle fromFd(int fd)
     {
-        return NativeHandleAccess::make(fd, NativeHandle::Kind::Fd);
+        return makeNativeHandle(fd, NativeHandle::Kind::Fd);
     }
 
     /** @brief Read the file descriptor back out. Only valid on POSIX handles. */
     inline int toFd(NativeHandle const& handle)
     {
-        return NativeHandleAccess::load<int>(handle);
+        return loadNativeHandle<int>(handle);
     }
 }

--- a/src/btl/include/btl/posix/nativehandle_posix.h
+++ b/src/btl/include/btl/posix/nativehandle_posix.h
@@ -7,7 +7,7 @@ namespace btl
     /** @brief Wrap a POSIX file descriptor as a NativeHandle. */
     inline NativeHandle fromFd(int fd)
     {
-        return NativeHandleAccess::make(fd);
+        return NativeHandleAccess::make(fd, NativeHandle::Kind::Fd);
     }
 
     /** @brief Read the file descriptor back out. Only valid on POSIX handles. */

--- a/src/btl/include/btl/runloop.h
+++ b/src/btl/include/btl/runloop.h
@@ -17,22 +17,27 @@ namespace btl
     /** @brief A single-threaded reactor: a loop over readable/writable/timer
      * sources plus cross-thread posted tasks.
      *
-     * Register the sources you need, then call run() to hand it the thread. The
-     * loop dispatches each source's callback as it fires and returns when
-     * stop() is called. It knows nothing about graphics, windows, or vsync -
-     * those are sources a higher layer registers.
+     * Register the sources you need through a Controller, then call run() to hand
+     * it the thread. The loop dispatches each source's callback as it fires and
+     * returns when stop() is called. It knows nothing about graphics, windows, or
+     * vsync - those are sources a higher layer registers.
+     *
+     * Only post() and stop() are safe to call from another thread. The rest of
+     * the interface lives on Controller, which the loop hands to every callback,
+     * so it is reachable only on the loop thread.
      *
      * Contract:
      *  - Readiness is level-triggered: a readable/writable callback fires while
-     *    the handle stays ready, so drain it (or remove the source) each call.
-     *  - One thread owns a RunLoop and its sources. post() is the only method
-     *    safe to call from another thread; it wakes the loop and runs the task
-     *    on the loop thread.
-     *  - A source may remove() or cancel() itself from inside its callback.
+     *    the handle stays ready, so drain it (or drop the source) each call.
+     *  - Destroy a RunLoop on its loop thread, or after run() has returned.
      */
     class RunLoop
     {
     public:
+        class Controller;
+        class Source;
+        class Timer;
+
         RunLoop();
         ~RunLoop();
 
@@ -42,29 +47,127 @@ namespace btl
         RunLoop(RunLoop const&) = delete;
         RunLoop& operator=(RunLoop const&) = delete;
 
-        /** @brief Call onReadable while handle is readable. */
-        SourceId addReadable(NativeHandle handle, std::function<void()> onReadable);
-
-        /** @brief Call onWritable while handle is writable. */
-        SourceId addWritable(NativeHandle handle, std::function<void()> onWritable);
-
-        /** @brief Call callback once, after at least delay has elapsed. */
-        TimerId addTimer(std::chrono::microseconds delay,
-                std::function<void()> callback);
-
-        /** @brief Run task on the loop thread. Safe to call from any thread. */
-        void post(std::function<void()> task);
-
-        void remove(SourceId id);
-        void cancel(TimerId id);
-
         /** @brief Take the thread and dispatch sources until stop(). */
         void run();
+
+        /** @brief Run task on the loop thread. Safe to call from any thread. */
+        void post(std::function<void(Controller&)> task);
 
         /** @brief Ask run() to return. Safe from any thread or callback. */
         void stop();
 
     private:
-        std::unique_ptr<RunLoopImpl> impl_;
+        std::shared_ptr<RunLoopImpl> impl_;
+    };
+
+    /** @brief The loop-thread interface, handed to every callback for the length
+     * of that call. Register, remove, post, and stop through it; do not store it.
+     */
+    class RunLoop::Controller
+    {
+    public:
+        Controller(Controller const&) = delete;
+        Controller& operator=(Controller const&) = delete;
+        Controller(Controller&&) = delete;
+        Controller& operator=(Controller&&) = delete;
+
+        /** @brief Call onReadable while handle is readable. */
+        [[nodiscard]] Source addReadable(NativeHandle handle,
+                std::function<void(Controller&)> onReadable);
+
+        /** @brief Call onWritable while handle is writable. */
+        [[nodiscard]] Source addWritable(NativeHandle handle,
+                std::function<void(Controller&)> onWritable);
+
+        /** @brief Call callback once, after at least delay has elapsed. */
+        [[nodiscard]] Timer addTimer(std::chrono::microseconds delay,
+                std::function<void(Controller&)> callback);
+
+        /** @brief Run task on the loop thread. Safe to call from any thread. */
+        void post(std::function<void(Controller&)> task);
+
+        /** @brief Ask run() to return. */
+        void stop();
+
+        void remove(SourceId id);
+        void cancel(TimerId id);
+
+    private:
+        friend class RunLoopImpl;
+        explicit Controller(RunLoopImpl* impl) : impl_(impl) {}
+
+        RunLoopImpl* impl_;
+    };
+
+    /** @brief Owns a readable/writable registration and removes it when dropped.
+     * Call detach() to keep the source registered past the handle's life.
+     */
+    class RunLoop::Source
+    {
+    public:
+        Source() = default;
+        ~Source();
+
+        Source(Source&& other) noexcept;
+        Source& operator=(Source&& other) noexcept;
+
+        Source(Source const&) = delete;
+        Source& operator=(Source const&) = delete;
+
+        SourceId id() const noexcept { return id_; }
+
+        void detach() noexcept
+        {
+            weak_.reset();
+            id_ = 0;
+        }
+
+    private:
+        friend class RunLoop::Controller;
+        Source(std::weak_ptr<RunLoopImpl> impl, SourceId id) :
+            weak_(std::move(impl)), id_(id)
+        {
+        }
+
+        void reset() noexcept;
+
+        std::weak_ptr<RunLoopImpl> weak_;
+        SourceId id_ = 0;
+    };
+
+    /** @brief Owns a timer registration and cancels it when dropped. Call
+     * detach() to let a one-shot timer fire without holding the handle.
+     */
+    class RunLoop::Timer
+    {
+    public:
+        Timer() = default;
+        ~Timer();
+
+        Timer(Timer&& other) noexcept;
+        Timer& operator=(Timer&& other) noexcept;
+
+        Timer(Timer const&) = delete;
+        Timer& operator=(Timer const&) = delete;
+
+        TimerId id() const noexcept { return id_; }
+
+        void detach() noexcept
+        {
+            weak_.reset();
+            id_ = 0;
+        }
+
+    private:
+        friend class RunLoop::Controller;
+        Timer(std::weak_ptr<RunLoopImpl> impl, TimerId id) :
+            weak_(std::move(impl)), id_(id)
+        {
+        }
+
+        void reset() noexcept;
+
+        std::weak_ptr<RunLoopImpl> weak_;
+        TimerId id_ = 0;
     };
 }

--- a/src/btl/include/btl/runloop.h
+++ b/src/btl/include/btl/runloop.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "nativehandle.h"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace btl
+{
+    class RunLoopImpl;
+
+    using SourceId = std::uint64_t;
+    using TimerId = std::uint64_t;
+
+    /** @brief A single-threaded reactor: a loop over readable/writable/timer
+     * sources plus cross-thread posted tasks.
+     *
+     * Register the sources you need, then call run() to hand it the thread. The
+     * loop dispatches each source's callback as it fires and returns when
+     * stop() is called. It knows nothing about graphics, windows, or vsync -
+     * those are sources a higher layer registers.
+     *
+     * Contract:
+     *  - Readiness is level-triggered: a readable/writable callback fires while
+     *    the handle stays ready, so drain it (or remove the source) each call.
+     *  - One thread owns a RunLoop and its sources. post() is the only method
+     *    safe to call from another thread; it wakes the loop and runs the task
+     *    on the loop thread.
+     *  - A source may remove() or cancel() itself from inside its callback.
+     */
+    class RunLoop
+    {
+    public:
+        RunLoop();
+        ~RunLoop();
+
+        RunLoop(RunLoop&&) noexcept;
+        RunLoop& operator=(RunLoop&&) noexcept;
+
+        RunLoop(RunLoop const&) = delete;
+        RunLoop& operator=(RunLoop const&) = delete;
+
+        /** @brief Call onReadable while handle is readable. */
+        SourceId addReadable(NativeHandle handle, std::function<void()> onReadable);
+
+        /** @brief Call onWritable while handle is writable. */
+        SourceId addWritable(NativeHandle handle, std::function<void()> onWritable);
+
+        /** @brief Call callback once, after at least delay has elapsed. */
+        TimerId addTimer(std::chrono::microseconds delay,
+                std::function<void()> callback);
+
+        /** @brief Run task on the loop thread. Safe to call from any thread. */
+        void post(std::function<void()> task);
+
+        void remove(SourceId id);
+        void cancel(TimerId id);
+
+        /** @brief Take the thread and dispatch sources until stop(). */
+        void run();
+
+        /** @brief Ask run() to return. Safe from any thread or callback. */
+        void stop();
+
+    private:
+        std::unique_ptr<RunLoopImpl> impl_;
+    };
+}

--- a/src/btl/include/btl/win32/nativehandle_win32.h
+++ b/src/btl/include/btl/win32/nativehandle_win32.h
@@ -34,4 +34,15 @@ namespace btl
     {
         return loadNativeHandle<HANDLE>(native);
     }
+
+    /** @brief Wrap the current thread's Win32 message queue as a NativeHandle.
+     * The loop waits on it with MsgWaitForMultipleObjects and fires the source
+     * when input is available; the callback drains the queue itself.
+     */
+    inline NativeHandle fromMessageQueue()
+    {
+        // No real handle: the payload just records the thread whose queue this is.
+        return makeNativeHandle<DWORD>(GetCurrentThreadId(),
+                NativeHandle::Kind::MessageQueue);
+    }
 }

--- a/src/btl/include/btl/win32/nativehandle_win32.h
+++ b/src/btl/include/btl/win32/nativehandle_win32.h
@@ -12,13 +12,13 @@ namespace btl
     /** @brief Wrap a Win32 SOCKET as a NativeHandle. */
     inline NativeHandle fromSocket(SOCKET socket)
     {
-        return NativeHandleAccess::make(socket, NativeHandle::Kind::Socket);
+        return makeNativeHandle(socket, NativeHandle::Kind::Socket);
     }
 
     /** @brief Read the SOCKET back out. Only valid on Win32 socket handles. */
     inline SOCKET toSocket(NativeHandle const& handle)
     {
-        return NativeHandleAccess::load<SOCKET>(handle);
+        return loadNativeHandle<SOCKET>(handle);
     }
 
     /** @brief Wrap a Win32 waitable HANDLE (e.g. an overlapped-I/O event) as a
@@ -26,12 +26,12 @@ namespace btl
      */
     inline NativeHandle fromHandle(HANDLE handle)
     {
-        return NativeHandleAccess::make(handle, NativeHandle::Kind::Handle);
+        return makeNativeHandle(handle, NativeHandle::Kind::Handle);
     }
 
     /** @brief Read the HANDLE back out. Only valid on Win32 handle handles. */
     inline HANDLE toHandle(NativeHandle const& native)
     {
-        return NativeHandleAccess::load<HANDLE>(native);
+        return loadNativeHandle<HANDLE>(native);
     }
 }

--- a/src/btl/include/btl/win32/nativehandle_win32.h
+++ b/src/btl/include/btl/win32/nativehandle_win32.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <btl/nativehandle.h>
+
+// Pulls in winsock, so this header stays confined to platform .cpp files.
+#include <winsock2.h>
+
+namespace btl
+{
+    /** @brief Wrap a Win32 SOCKET as a NativeHandle. */
+    inline NativeHandle fromSocket(SOCKET socket)
+    {
+        return NativeHandleAccess::make(socket);
+    }
+
+    /** @brief Read the SOCKET back out. Only valid on Win32 socket handles. */
+    inline SOCKET toSocket(NativeHandle const& handle)
+    {
+        return NativeHandleAccess::load<SOCKET>(handle);
+    }
+}

--- a/src/btl/include/btl/win32/nativehandle_win32.h
+++ b/src/btl/include/btl/win32/nativehandle_win32.h
@@ -2,20 +2,36 @@
 
 #include <btl/nativehandle.h>
 
-// Pulls in winsock, so this header stays confined to platform .cpp files.
+// Pulls in winsock/windows, so this header stays confined to platform .cpp
+// files.
 #include <winsock2.h>
+#include <windows.h>
 
 namespace btl
 {
     /** @brief Wrap a Win32 SOCKET as a NativeHandle. */
     inline NativeHandle fromSocket(SOCKET socket)
     {
-        return NativeHandleAccess::make(socket);
+        return NativeHandleAccess::make(socket, NativeHandle::Kind::Socket);
     }
 
     /** @brief Read the SOCKET back out. Only valid on Win32 socket handles. */
     inline SOCKET toSocket(NativeHandle const& handle)
     {
         return NativeHandleAccess::load<SOCKET>(handle);
+    }
+
+    /** @brief Wrap a Win32 waitable HANDLE (e.g. an overlapped-I/O event) as a
+     * NativeHandle. The loop waits on it directly and never closes it.
+     */
+    inline NativeHandle fromHandle(HANDLE handle)
+    {
+        return NativeHandleAccess::make(handle, NativeHandle::Kind::Handle);
+    }
+
+    /** @brief Read the HANDLE back out. Only valid on Win32 handle handles. */
+    inline HANDLE toHandle(NativeHandle const& native)
+    {
+        return NativeHandleAccess::load<HANDLE>(native);
     }
 }

--- a/src/btl/meson.build
+++ b/src/btl/meson.build
@@ -3,7 +3,22 @@ if get_option('tracy_enable')
   btl_args = ['-DTRACY_ENABLE']
 endif
 
+btl_srcs = ['src/runloop.cpp']
+if host_machine.system() == 'windows'
+  btl_srcs += 'src/win32/runloopimpl.cpp'
+else
+  btl_srcs += 'src/posix/runloopimpl.cpp'
+endif
+
+libbtl = static_library('btl',
+  btl_srcs,
+  include_directories: include_directories('include'),
+  cpp_args: btl_args,
+  pic: true,
+  )
+
 libbtldep = declare_dependency(
+        link_with: libbtl,
         include_directories: include_directories('include'),
         dependencies: [],
         compile_args: btl_args,
@@ -18,6 +33,7 @@ btltest = executable('btltest',
   'test/lrucachetest.cpp',
   'test/pmrtest.cpp',
   'test/resulttest.cpp',
+  'test/runlooptest.cpp',
   'test/sharedtest.cpp',
   'test/threadpooltest.cpp',
   'test/tupletest.cpp',

--- a/src/btl/meson.build
+++ b/src/btl/meson.build
@@ -12,7 +12,7 @@ endif
 
 libbtl = static_library('btl',
   btl_srcs,
-  include_directories: include_directories('include'),
+  include_directories: include_directories('include', 'src'),
   cpp_args: btl_args,
   pic: true,
   )

--- a/src/btl/src/posix/runloopimpl.cpp
+++ b/src/btl/src/posix/runloopimpl.cpp
@@ -1,4 +1,4 @@
-#include "../runloopimpl.h"
+#include "runloopimpl.h"
 
 #include <btl/posix/nativehandle_posix.h>
 
@@ -7,9 +7,11 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <mutex>
+#include <stdexcept>
 #include <vector>
 
 namespace btl
@@ -45,26 +47,26 @@ namespace
         }
 
         SourceId addReadable(NativeHandle handle,
-                std::function<void()> onReadable) override
+                Callback onReadable) override
         {
             return addFd(handle, std::move(onReadable), /*write=*/false);
         }
 
         SourceId addWritable(NativeHandle handle,
-                std::function<void()> onWritable) override
+                Callback onWritable) override
         {
             return addFd(handle, std::move(onWritable), /*write=*/true);
         }
 
         TimerId addTimer(std::chrono::microseconds delay,
-                std::function<void()> callback) override
+                Callback callback) override
         {
             TimerId id = nextId_++;
             timers_[id] = Timer{ Clock::now() + delay, std::move(callback) };
             return id;
         }
 
-        void post(std::function<void()> task) override
+        void post(Callback task) override
         {
             {
                 std::lock_guard<std::mutex> lock(mutex_);
@@ -85,7 +87,9 @@ namespace
 
         void run() override
         {
-            running_ = true;
+            if (running_.exchange(true))
+                throw std::logic_error("btl::RunLoop::run() is already running");
+            enterLoopThread();
             while (running_)
             {
                 drainPipe();
@@ -132,16 +136,16 @@ namespace
         {
             int fd;
             bool write;
-            std::function<void()> callback;
+            Callback callback;
         };
 
         struct Timer
         {
             Clock::time_point deadline;
-            std::function<void()> callback;
+            Callback callback;
         };
 
-        SourceId addFd(NativeHandle handle, std::function<void()> callback,
+        SourceId addFd(NativeHandle handle, Callback callback,
                 bool write)
         {
             SourceId id = nextId_++;
@@ -166,14 +170,14 @@ namespace
 
         void drainPosts()
         {
-            std::vector<std::function<void()>> tasks;
+            std::vector<Callback> tasks;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
                 tasks.swap(posted_);
             }
             for (auto& task : tasks)
             {
-                task();
+                invoke(task);
                 if (!running_)
                     return;
             }
@@ -197,8 +201,8 @@ namespace
                 if (it == sources_.end())
                     continue; // removed by an earlier callback this pass.
 
-                std::function<void()> callback = it->second.callback;
-                callback();
+                Callback callback = it->second.callback;
+                invoke(callback);
                 if (!running_)
                     return;
             }
@@ -238,9 +242,9 @@ namespace
                 if (it == timers_.end())
                     continue;
 
-                std::function<void()> callback = std::move(it->second.callback);
+                Callback callback = std::move(it->second.callback);
                 timers_.erase(it); // one-shot.
-                callback();
+                invoke(callback);
                 if (!running_)
                     return;
             }
@@ -250,14 +254,14 @@ namespace
         std::map<SourceId, Source> sources_;
         std::map<TimerId, Timer> timers_;
         std::mutex mutex_;
-        std::vector<std::function<void()>> posted_;
+        std::vector<Callback> posted_;
         std::uint64_t nextId_ = 1;
-        bool running_ = false;
+        std::atomic<bool> running_{ false };
     };
 }
 
-    std::unique_ptr<RunLoopImpl> makeRunLoopImpl()
+    std::shared_ptr<RunLoopImpl> makePlatformSpecificRunLoopImpl()
     {
-        return std::make_unique<PosixRunLoop>();
+        return std::make_shared<PosixRunLoop>();
     }
 }

--- a/src/btl/src/posix/runloopimpl.cpp
+++ b/src/btl/src/posix/runloopimpl.cpp
@@ -1,0 +1,263 @@
+#include "../runloopimpl.h"
+
+#include <btl/posix/nativehandle_posix.h>
+
+#include <fcntl.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <vector>
+
+namespace btl
+{
+namespace
+{
+    using Clock = std::chrono::steady_clock;
+
+    void setNonBlocking(int fd)
+    {
+        int flags = fcntl(fd, F_GETFL, 0);
+        fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    }
+
+    class PosixRunLoop final : public RunLoopImpl
+    {
+    public:
+        PosixRunLoop()
+        {
+            if (pipe(wakeup_) == 0)
+            {
+                setNonBlocking(wakeup_[0]);
+                setNonBlocking(wakeup_[1]);
+            }
+        }
+
+        ~PosixRunLoop() override
+        {
+            if (wakeup_[0] >= 0)
+                ::close(wakeup_[0]);
+            if (wakeup_[1] >= 0)
+                ::close(wakeup_[1]);
+        }
+
+        SourceId addReadable(NativeHandle handle,
+                std::function<void()> onReadable) override
+        {
+            return addFd(handle, std::move(onReadable), /*write=*/false);
+        }
+
+        SourceId addWritable(NativeHandle handle,
+                std::function<void()> onWritable) override
+        {
+            return addFd(handle, std::move(onWritable), /*write=*/true);
+        }
+
+        TimerId addTimer(std::chrono::microseconds delay,
+                std::function<void()> callback) override
+        {
+            TimerId id = nextId_++;
+            timers_[id] = Timer{ Clock::now() + delay, std::move(callback) };
+            return id;
+        }
+
+        void post(std::function<void()> task) override
+        {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                posted_.push_back(std::move(task));
+            }
+            wake();
+        }
+
+        void remove(SourceId id) override
+        {
+            sources_.erase(id);
+        }
+
+        void cancel(TimerId id) override
+        {
+            timers_.erase(id);
+        }
+
+        void run() override
+        {
+            running_ = true;
+            while (running_)
+            {
+                drainPipe();
+                drainPosts();
+                if (!running_)
+                    break;
+
+                fd_set readSet;
+                fd_set writeSet;
+                FD_ZERO(&readSet);
+                FD_ZERO(&writeSet);
+
+                int maxFd = wakeup_[0];
+                FD_SET(wakeup_[0], &readSet);
+
+                for (auto& entry : sources_)
+                {
+                    int fd = entry.second.fd;
+                    FD_SET(fd, entry.second.write ? &writeSet : &readSet);
+                    maxFd = std::max(maxFd, fd);
+                }
+
+                timeval tv;
+                timeval* timeout = nextTimeout(tv);
+
+                int ready = ::select(maxFd + 1, &readSet, &writeSet, nullptr,
+                        timeout);
+
+                if (ready > 0)
+                    fireReady(readSet, writeSet);
+
+                fireExpiredTimers();
+            }
+        }
+
+        void stop() override
+        {
+            running_ = false;
+            wake();
+        }
+
+    private:
+        struct Source
+        {
+            int fd;
+            bool write;
+            std::function<void()> callback;
+        };
+
+        struct Timer
+        {
+            Clock::time_point deadline;
+            std::function<void()> callback;
+        };
+
+        SourceId addFd(NativeHandle handle, std::function<void()> callback,
+                bool write)
+        {
+            SourceId id = nextId_++;
+            sources_[id] = Source{ toFd(handle), write, std::move(callback) };
+            return id;
+        }
+
+        void wake()
+        {
+            char byte = 0;
+            ssize_t n = ::write(wakeup_[1], &byte, 1);
+            (void)n;
+        }
+
+        void drainPipe()
+        {
+            char buffer[64];
+            while (::read(wakeup_[0], buffer, sizeof(buffer)) > 0)
+            {
+            }
+        }
+
+        void drainPosts()
+        {
+            std::vector<std::function<void()>> tasks;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                tasks.swap(posted_);
+            }
+            for (auto& task : tasks)
+            {
+                task();
+                if (!running_)
+                    return;
+            }
+        }
+
+        void fireReady(fd_set& readSet, fd_set& writeSet)
+        {
+            // Snapshot the ids: a callback may add or remove sources.
+            std::vector<SourceId> ready;
+            for (auto& entry : sources_)
+            {
+                int fd = entry.second.fd;
+                fd_set& set = entry.second.write ? writeSet : readSet;
+                if (FD_ISSET(fd, &set))
+                    ready.push_back(entry.first);
+            }
+
+            for (SourceId id : ready)
+            {
+                auto it = sources_.find(id);
+                if (it == sources_.end())
+                    continue; // removed by an earlier callback this pass.
+
+                std::function<void()> callback = it->second.callback;
+                callback();
+                if (!running_)
+                    return;
+            }
+        }
+
+        timeval* nextTimeout(timeval& tv)
+        {
+            if (timers_.empty())
+                return nullptr; // block until a source fires.
+
+            auto soonest = timers_.begin()->second.deadline;
+            for (auto& entry : timers_)
+                soonest = std::min(soonest, entry.second.deadline);
+
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                    soonest - Clock::now()).count();
+            if (us < 0)
+                us = 0;
+
+            tv.tv_sec = (long)(us / 1000000);
+            tv.tv_usec = (long)(us % 1000000);
+            return &tv;
+        }
+
+        void fireExpiredTimers()
+        {
+            auto now = Clock::now();
+
+            std::vector<TimerId> due;
+            for (auto& entry : timers_)
+                if (entry.second.deadline <= now)
+                    due.push_back(entry.first);
+
+            for (TimerId id : due)
+            {
+                auto it = timers_.find(id);
+                if (it == timers_.end())
+                    continue;
+
+                std::function<void()> callback = std::move(it->second.callback);
+                timers_.erase(it); // one-shot.
+                callback();
+                if (!running_)
+                    return;
+            }
+        }
+
+        int wakeup_[2] = { -1, -1 };
+        std::map<SourceId, Source> sources_;
+        std::map<TimerId, Timer> timers_;
+        std::mutex mutex_;
+        std::vector<std::function<void()>> posted_;
+        std::uint64_t nextId_ = 1;
+        bool running_ = false;
+    };
+}
+
+    std::unique_ptr<RunLoopImpl> makeRunLoopImpl()
+    {
+        return std::make_unique<PosixRunLoop>();
+    }
+}

--- a/src/btl/src/runloop.cpp
+++ b/src/btl/src/runloop.cpp
@@ -1,0 +1,61 @@
+#include <btl/runloop.h>
+
+#include "runloopimpl.h"
+
+#include <utility>
+
+namespace btl
+{
+    RunLoop::RunLoop() :
+        impl_(makeRunLoopImpl())
+    {
+    }
+
+    RunLoop::~RunLoop() = default;
+
+    RunLoop::RunLoop(RunLoop&&) noexcept = default;
+    RunLoop& RunLoop::operator=(RunLoop&&) noexcept = default;
+
+    SourceId RunLoop::addReadable(NativeHandle handle,
+            std::function<void()> onReadable)
+    {
+        return impl_->addReadable(handle, std::move(onReadable));
+    }
+
+    SourceId RunLoop::addWritable(NativeHandle handle,
+            std::function<void()> onWritable)
+    {
+        return impl_->addWritable(handle, std::move(onWritable));
+    }
+
+    TimerId RunLoop::addTimer(std::chrono::microseconds delay,
+            std::function<void()> callback)
+    {
+        return impl_->addTimer(delay, std::move(callback));
+    }
+
+    void RunLoop::post(std::function<void()> task)
+    {
+        impl_->post(std::move(task));
+    }
+
+    void RunLoop::remove(SourceId id)
+    {
+        impl_->remove(id);
+    }
+
+    void RunLoop::cancel(TimerId id)
+    {
+        impl_->cancel(id);
+    }
+
+    void RunLoop::run()
+    {
+        impl_->run();
+    }
+
+    void RunLoop::stop()
+    {
+        impl_->stop();
+    }
+}

--- a/src/btl/src/runloop.cpp
+++ b/src/btl/src/runloop.cpp
@@ -7,55 +7,143 @@
 namespace btl
 {
     RunLoop::RunLoop() :
-        impl_(makeRunLoopImpl())
+        impl_(makePlatformSpecificRunLoopImpl())
     {
     }
 
-    RunLoop::~RunLoop() = default;
+    RunLoop::~RunLoop()
+    {
+        if (impl_)
+            impl_->stop();
+    }
 
     RunLoop::RunLoop(RunLoop&&) noexcept = default;
     RunLoop& RunLoop::operator=(RunLoop&&) noexcept = default;
 
-    SourceId RunLoop::addReadable(NativeHandle handle,
-            std::function<void()> onReadable)
-    {
-        return impl_->addReadable(handle, std::move(onReadable));
-    }
-
-    SourceId RunLoop::addWritable(NativeHandle handle,
-            std::function<void()> onWritable)
-    {
-        return impl_->addWritable(handle, std::move(onWritable));
-    }
-
-    TimerId RunLoop::addTimer(std::chrono::microseconds delay,
-            std::function<void()> callback)
-    {
-        return impl_->addTimer(delay, std::move(callback));
-    }
-
-    void RunLoop::post(std::function<void()> task)
-    {
-        impl_->post(std::move(task));
-    }
-
-    void RunLoop::remove(SourceId id)
-    {
-        impl_->remove(id);
-    }
-
-    void RunLoop::cancel(TimerId id)
-    {
-        impl_->cancel(id);
-    }
-
     void RunLoop::run()
     {
-        impl_->run();
+        auto impl = impl_; // Keep the loop alive if the owner is dropped mid-run.
+        impl->run();
+    }
+
+    void RunLoop::post(std::function<void(Controller&)> task)
+    {
+        impl_->post(std::move(task));
     }
 
     void RunLoop::stop()
     {
         impl_->stop();
+    }
+
+    RunLoop::Source RunLoop::Controller::addReadable(NativeHandle handle,
+            std::function<void(Controller&)> onReadable)
+    {
+        SourceId id = impl_->addReadable(handle, std::move(onReadable));
+        return Source(impl_->weak_from_this(), id);
+    }
+
+    RunLoop::Source RunLoop::Controller::addWritable(NativeHandle handle,
+            std::function<void(Controller&)> onWritable)
+    {
+        SourceId id = impl_->addWritable(handle, std::move(onWritable));
+        return Source(impl_->weak_from_this(), id);
+    }
+
+    RunLoop::Timer RunLoop::Controller::addTimer(std::chrono::microseconds delay,
+            std::function<void(Controller&)> callback)
+    {
+        TimerId id = impl_->addTimer(delay, std::move(callback));
+        return Timer(impl_->weak_from_this(), id);
+    }
+
+    void RunLoop::Controller::post(std::function<void(Controller&)> task)
+    {
+        impl_->post(std::move(task));
+    }
+
+    void RunLoop::Controller::stop()
+    {
+        impl_->stop();
+    }
+
+    void RunLoop::Controller::remove(SourceId id)
+    {
+        impl_->remove(id);
+    }
+
+    void RunLoop::Controller::cancel(TimerId id)
+    {
+        impl_->cancel(id);
+    }
+
+    RunLoop::Source::Source(Source&& other) noexcept :
+        weak_(std::move(other.weak_)), id_(other.id_)
+    {
+        other.id_ = 0;
+    }
+
+    RunLoop::Source& RunLoop::Source::operator=(Source&& other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            weak_ = std::move(other.weak_);
+            id_ = other.id_;
+            other.id_ = 0;
+        }
+        return *this;
+    }
+
+    RunLoop::Source::~Source()
+    {
+        reset();
+    }
+
+    void RunLoop::Source::reset() noexcept
+    {
+        if (id_ == 0)
+            return;
+
+        if (auto impl = weak_.lock())
+            impl->requestRemove(id_);
+
+        weak_.reset();
+        id_ = 0;
+    }
+
+    RunLoop::Timer::Timer(Timer&& other) noexcept :
+        weak_(std::move(other.weak_)), id_(other.id_)
+    {
+        other.id_ = 0;
+    }
+
+    RunLoop::Timer& RunLoop::Timer::operator=(Timer&& other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            weak_ = std::move(other.weak_);
+            id_ = other.id_;
+            other.id_ = 0;
+        }
+        return *this;
+    }
+
+    RunLoop::Timer::~Timer()
+    {
+        reset();
+    }
+
+    void RunLoop::Timer::reset() noexcept
+    {
+        if (id_ == 0)
+            return;
+
+        if (auto impl = weak_.lock())
+            impl->requestCancel(id_);
+
+        weak_.reset();
+        id_ = 0;
     }
 }

--- a/src/btl/src/runloopimpl.h
+++ b/src/btl/src/runloopimpl.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <btl/runloop.h>
+
+namespace btl
+{
+    // The platform-agnostic surface RunLoop forwards to. One concrete subclass
+    // per platform (posix/win32/...), built by makeRunLoopImpl().
+    class RunLoopImpl
+    {
+    public:
+        virtual ~RunLoopImpl() = default;
+
+        virtual SourceId addReadable(NativeHandle, std::function<void()>) = 0;
+        virtual SourceId addWritable(NativeHandle, std::function<void()>) = 0;
+        virtual TimerId addTimer(std::chrono::microseconds,
+                std::function<void()>) = 0;
+        virtual void post(std::function<void()>) = 0;
+        virtual void remove(SourceId) = 0;
+        virtual void cancel(TimerId) = 0;
+        virtual void run() = 0;
+        virtual void stop() = 0;
+    };
+
+    std::unique_ptr<RunLoopImpl> makeRunLoopImpl();
+}

--- a/src/btl/src/runloopimpl.h
+++ b/src/btl/src/runloopimpl.h
@@ -2,25 +2,65 @@
 
 #include <btl/runloop.h>
 
+#include <functional>
+#include <memory>
+#include <thread>
+
 namespace btl
 {
     // The platform-agnostic surface RunLoop forwards to. One concrete subclass
-    // per platform (posix/win32/...), built by makeRunLoopImpl().
-    class RunLoopImpl
+    // per platform (posix/win32/...), built by makePlatformSpecificRunLoopImpl().
+    class RunLoopImpl : public std::enable_shared_from_this<RunLoopImpl>
     {
     public:
+        using Callback = std::function<void(RunLoop::Controller&)>;
+
         virtual ~RunLoopImpl() = default;
 
-        virtual SourceId addReadable(NativeHandle, std::function<void()>) = 0;
-        virtual SourceId addWritable(NativeHandle, std::function<void()>) = 0;
-        virtual TimerId addTimer(std::chrono::microseconds,
-                std::function<void()>) = 0;
-        virtual void post(std::function<void()>) = 0;
+        virtual SourceId addReadable(NativeHandle, Callback) = 0;
+        virtual SourceId addWritable(NativeHandle, Callback) = 0;
+        virtual TimerId addTimer(std::chrono::microseconds, Callback) = 0;
+        virtual void post(Callback) = 0;
         virtual void remove(SourceId) = 0;
         virtual void cancel(TimerId) = 0;
         virtual void run() = 0;
         virtual void stop() = 0;
+
+        // Remove/cancel from a handle's destructor, which may run on any thread:
+        // apply now on the loop thread, otherwise post it.
+        void requestRemove(SourceId id)
+        {
+            onLoopThread([this, id] { remove(id); });
+        }
+
+        void requestCancel(TimerId id)
+        {
+            onLoopThread([this, id] { cancel(id); });
+        }
+
+    protected:
+        void invoke(Callback const& callback)
+        {
+            RunLoop::Controller controller(this);
+            callback(controller);
+        }
+
+        void enterLoopThread()
+        {
+            loopThread_ = std::this_thread::get_id();
+        }
+
+    private:
+        void onLoopThread(std::function<void()> op)
+        {
+            if (std::this_thread::get_id() == loopThread_)
+                op();
+            else
+                post([op = std::move(op)](RunLoop::Controller&) { op(); });
+        }
+
+        std::thread::id loopThread_;
     };
 
-    std::unique_ptr<RunLoopImpl> makeRunLoopImpl();
+    std::shared_ptr<RunLoopImpl> makePlatformSpecificRunLoopImpl();
 }

--- a/src/btl/src/win32/runloopimpl.cpp
+++ b/src/btl/src/win32/runloopimpl.cpp
@@ -65,6 +65,8 @@ namespace
         SourceId addReadable(NativeHandle handle,
                 Callback onReadable) override
         {
+            if (handle.kind() == NativeHandle::Kind::MessageQueue)
+                return addMessage(std::move(onReadable));
             if (handle.kind() == NativeHandle::Kind::Handle)
                 return addHandle(handle, std::move(onReadable));
             return addSocket(handle, std::move(onReadable),
@@ -127,8 +129,18 @@ namespace
                 std::vector<HANDLE> handles;
                 std::vector<SourceId> ids;
                 handles.push_back(wakeup_);
+
+                bool hasMessages = false;
+                SourceId messageId = 0;
                 for (auto& entry : sources_)
                 {
+                    if (entry.second.isMessage)
+                    {
+                        // Waited on via the message queue, not a HANDLE.
+                        hasMessages = true;
+                        messageId = entry.first;
+                        continue;
+                    }
                     if (handles.size() >= MAXIMUM_WAIT_OBJECTS)
                         break; // 64-handle WFMO cap; see the design doc.
                     handles.push_back(entry.second.event);
@@ -136,11 +148,26 @@ namespace
                 }
 
                 DWORD timeout = nextTimeout();
-                DWORD result = WaitForMultipleObjects(
-                        (DWORD)handles.size(), handles.data(), FALSE, timeout);
+                DWORD result;
+                if (hasMessages)
+                    result = MsgWaitForMultipleObjectsEx(
+                            (DWORD)handles.size(), handles.data(), timeout,
+                            QS_ALLINPUT, MWMO_INPUTAVAILABLE);
+                else
+                    result = WaitForMultipleObjects(
+                            (DWORD)handles.size(), handles.data(), FALSE,
+                            timeout);
 
                 if (result == WAIT_TIMEOUT)
                 {
+                    fireExpiredTimers();
+                }
+                else if (hasMessages
+                        && result == WAIT_OBJECT_0 + handles.size())
+                {
+                    // MsgWaitForMultipleObjectsEx reports the message queue as
+                    // the object just past the waited handles.
+                    fireMessage(messageId);
                     fireExpiredTimers();
                 }
                 else if (result >= WAIT_OBJECT_0
@@ -167,6 +194,7 @@ namespace
             SOCKET socket;  // INVALID_SOCKET for a handle source.
             bool ownsEvent; // true: we created the event and must close it.
             Callback callback;
+            bool isMessage = false; // true: the thread message queue, no event.
         };
 
         struct Timer
@@ -198,6 +226,19 @@ namespace
             return id;
         }
 
+        // A message source has no waitable event; run() waits on the thread
+        // message queue via MsgWaitForMultipleObjectsEx and fires this source
+        // when input is available. Its callback drains the queue itself.
+        SourceId addMessage(Callback callback)
+        {
+            SourceId id = nextId_++;
+            Source source{ nullptr, INVALID_SOCKET, false,
+                    std::move(callback) };
+            source.isMessage = true;
+            sources_[id] = std::move(source);
+            return id;
+        }
+
         void fireSocket(SourceId id)
         {
             auto it = sources_.find(id);
@@ -212,6 +253,20 @@ namespace
                 WSAEnumNetworkEvents(
                         it->second.socket, it->second.event, &network);
             }
+
+            // The callback may remove this or other sources, so copy it out.
+            Callback callback = it->second.callback;
+            invoke(callback);
+        }
+
+        // A message source has no event to drain or reset; the callback pulls
+        // messages off the thread queue itself. Level-triggered: anything the
+        // callback leaves behind fires the wait again next pass.
+        void fireMessage(SourceId id)
+        {
+            auto it = sources_.find(id);
+            if (it == sources_.end())
+                return;
 
             // The callback may remove this or other sources, so copy it out.
             Callback callback = it->second.callback;

--- a/src/btl/src/win32/runloopimpl.cpp
+++ b/src/btl/src/win32/runloopimpl.cpp
@@ -1,0 +1,262 @@
+// These must precede any header that pulls in winsock2/windows (below).
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include "../runloopimpl.h"
+
+#include <btl/win32/nativehandle_win32.h>
+
+#include <winsock2.h>
+#include <windows.h>
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#pragma comment(lib, "ws2_32.lib")
+
+namespace btl
+{
+namespace
+{
+    using Clock = std::chrono::steady_clock;
+
+    // WSAStartup is refcounted; one guard per RunLoop keeps winsock up for its
+    // lifetime without caring who else started it.
+    struct WinsockGuard
+    {
+        WinsockGuard()
+        {
+            WSADATA data;
+            WSAStartup(MAKEWORD(2, 2), &data);
+        }
+
+        ~WinsockGuard()
+        {
+            WSACleanup();
+        }
+    };
+
+    class Win32RunLoop final : public RunLoopImpl
+    {
+    public:
+        Win32RunLoop()
+        {
+            wakeup_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        }
+
+        ~Win32RunLoop() override
+        {
+            for (auto& entry : sources_)
+                WSACloseEvent(entry.second.event);
+            if (wakeup_)
+                CloseHandle(wakeup_);
+        }
+
+        SourceId addReadable(NativeHandle handle,
+                std::function<void()> onReadable) override
+        {
+            return addSocket(handle, std::move(onReadable),
+                    FD_READ | FD_ACCEPT | FD_CLOSE);
+        }
+
+        SourceId addWritable(NativeHandle handle,
+                std::function<void()> onWritable) override
+        {
+            return addSocket(handle, std::move(onWritable), FD_WRITE | FD_CLOSE);
+        }
+
+        TimerId addTimer(std::chrono::microseconds delay,
+                std::function<void()> callback) override
+        {
+            TimerId id = nextId_++;
+            timers_[id] = Timer{ Clock::now() + delay, std::move(callback) };
+            return id;
+        }
+
+        void post(std::function<void()> task) override
+        {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                posted_.push_back(std::move(task));
+            }
+            SetEvent(wakeup_);
+        }
+
+        void remove(SourceId id) override
+        {
+            auto it = sources_.find(id);
+            if (it != sources_.end())
+            {
+                WSACloseEvent(it->second.event);
+                sources_.erase(it);
+            }
+        }
+
+        void cancel(TimerId id) override
+        {
+            timers_.erase(id);
+        }
+
+        void run() override
+        {
+            running_ = true;
+            while (running_)
+            {
+                ResetEvent(wakeup_);
+                drainPosts();
+                if (!running_)
+                    break;
+
+                std::vector<HANDLE> handles;
+                std::vector<SourceId> ids;
+                handles.push_back(wakeup_);
+                for (auto& entry : sources_)
+                {
+                    if (handles.size() >= MAXIMUM_WAIT_OBJECTS)
+                        break; // 64-handle WFMO cap; see the design doc.
+                    handles.push_back(entry.second.event);
+                    ids.push_back(entry.first);
+                }
+
+                DWORD timeout = nextTimeout();
+                DWORD result = WaitForMultipleObjects(
+                        (DWORD)handles.size(), handles.data(), FALSE, timeout);
+
+                if (result == WAIT_TIMEOUT)
+                {
+                    fireExpiredTimers();
+                }
+                else if (result >= WAIT_OBJECT_0
+                        && result < WAIT_OBJECT_0 + handles.size())
+                {
+                    DWORD index = result - WAIT_OBJECT_0;
+                    if (index != 0) // 0 is the wakeup event.
+                        fireSocket(ids[index - 1]);
+                    fireExpiredTimers();
+                }
+            }
+        }
+
+        void stop() override
+        {
+            running_ = false;
+            SetEvent(wakeup_);
+        }
+
+    private:
+        struct Source
+        {
+            WSAEVENT event;
+            SOCKET socket;
+            std::function<void()> callback;
+        };
+
+        struct Timer
+        {
+            Clock::time_point deadline;
+            std::function<void()> callback;
+        };
+
+        SourceId addSocket(NativeHandle handle, std::function<void()> callback,
+                long events)
+        {
+            SOCKET socket = toSocket(handle);
+            WSAEVENT event = WSACreateEvent();
+            WSAEventSelect(socket, event, events);
+
+            SourceId id = nextId_++;
+            sources_[id] = Source{ event, socket, std::move(callback) };
+            return id;
+        }
+
+        void fireSocket(SourceId id)
+        {
+            auto it = sources_.find(id);
+            if (it == sources_.end())
+                return;
+
+            WSANETWORKEVENTS network;
+            WSAEnumNetworkEvents(it->second.socket, it->second.event, &network);
+
+            // The callback may remove this or other sources, so copy it out.
+            std::function<void()> callback = it->second.callback;
+            callback();
+        }
+
+        void drainPosts()
+        {
+            std::vector<std::function<void()>> tasks;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                tasks.swap(posted_);
+            }
+            for (auto& task : tasks)
+            {
+                task();
+                if (!running_)
+                    return;
+            }
+        }
+
+        DWORD nextTimeout()
+        {
+            if (timers_.empty())
+                return INFINITE;
+
+            auto soonest = timers_.begin()->second.deadline;
+            for (auto& entry : timers_)
+                soonest = std::min(soonest, entry.second.deadline);
+
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    soonest - Clock::now()).count();
+            if (ms < 0)
+                return 0;
+            return (DWORD)ms;
+        }
+
+        void fireExpiredTimers()
+        {
+            auto now = Clock::now();
+
+            std::vector<TimerId> due;
+            for (auto& entry : timers_)
+                if (entry.second.deadline <= now)
+                    due.push_back(entry.first);
+
+            for (TimerId id : due)
+            {
+                auto it = timers_.find(id);
+                if (it == timers_.end())
+                    continue; // cancelled by an earlier callback this pass.
+
+                std::function<void()> callback = std::move(it->second.callback);
+                timers_.erase(it); // one-shot.
+                callback();
+                if (!running_)
+                    return;
+            }
+        }
+
+        WinsockGuard winsock_;
+        HANDLE wakeup_ = nullptr;
+        std::map<SourceId, Source> sources_;
+        std::map<TimerId, Timer> timers_;
+        std::mutex mutex_;
+        std::vector<std::function<void()>> posted_;
+        std::uint64_t nextId_ = 1;
+        bool running_ = false;
+    };
+}
+
+    std::unique_ptr<RunLoopImpl> makeRunLoopImpl()
+    {
+        return std::make_unique<Win32RunLoop>();
+    }
+}

--- a/src/btl/src/win32/runloopimpl.cpp
+++ b/src/btl/src/win32/runloopimpl.cpp
@@ -6,7 +6,7 @@
 #define NOMINMAX
 #endif
 
-#include "../runloopimpl.h"
+#include "runloopimpl.h"
 
 #include <btl/win32/nativehandle_win32.h>
 
@@ -14,9 +14,11 @@
 #include <windows.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <mutex>
+#include <stdexcept>
 #include <vector>
 
 #pragma comment(lib, "ws2_32.lib")
@@ -61,7 +63,7 @@ namespace
         }
 
         SourceId addReadable(NativeHandle handle,
-                std::function<void()> onReadable) override
+                Callback onReadable) override
         {
             if (handle.kind() == NativeHandle::Kind::Handle)
                 return addHandle(handle, std::move(onReadable));
@@ -70,7 +72,7 @@ namespace
         }
 
         SourceId addWritable(NativeHandle handle,
-                std::function<void()> onWritable) override
+                Callback onWritable) override
         {
             if (handle.kind() == NativeHandle::Kind::Handle)
                 return addHandle(handle, std::move(onWritable));
@@ -78,14 +80,14 @@ namespace
         }
 
         TimerId addTimer(std::chrono::microseconds delay,
-                std::function<void()> callback) override
+                Callback callback) override
         {
             TimerId id = nextId_++;
             timers_[id] = Timer{ Clock::now() + delay, std::move(callback) };
             return id;
         }
 
-        void post(std::function<void()> task) override
+        void post(Callback task) override
         {
             {
                 std::lock_guard<std::mutex> lock(mutex_);
@@ -112,7 +114,9 @@ namespace
 
         void run() override
         {
-            running_ = true;
+            if (running_.exchange(true))
+                throw std::logic_error("btl::RunLoop::run() is already running");
+            enterLoopThread();
             while (running_)
             {
                 ResetEvent(wakeup_);
@@ -162,16 +166,16 @@ namespace
             HANDLE event;   // a WSAEVENT we own (socket), or a caller HANDLE.
             SOCKET socket;  // INVALID_SOCKET for a handle source.
             bool ownsEvent; // true: we created the event and must close it.
-            std::function<void()> callback;
+            Callback callback;
         };
 
         struct Timer
         {
             Clock::time_point deadline;
-            std::function<void()> callback;
+            Callback callback;
         };
 
-        SourceId addSocket(NativeHandle handle, std::function<void()> callback,
+        SourceId addSocket(NativeHandle handle, Callback callback,
                 long events)
         {
             SOCKET socket = toSocket(handle);
@@ -186,7 +190,7 @@ namespace
         // A handle source waits on a caller-owned waitable HANDLE directly (an
         // overlapped-I/O event, a manual-reset event): no WSAEventSelect, no
         // network-event enumeration, and we never close it.
-        SourceId addHandle(NativeHandle handle, std::function<void()> callback)
+        SourceId addHandle(NativeHandle handle, Callback callback)
         {
             SourceId id = nextId_++;
             sources_[id] = Source{ toHandle(handle), INVALID_SOCKET, false,
@@ -210,20 +214,20 @@ namespace
             }
 
             // The callback may remove this or other sources, so copy it out.
-            std::function<void()> callback = it->second.callback;
-            callback();
+            Callback callback = it->second.callback;
+            invoke(callback);
         }
 
         void drainPosts()
         {
-            std::vector<std::function<void()>> tasks;
+            std::vector<Callback> tasks;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
                 tasks.swap(posted_);
             }
             for (auto& task : tasks)
             {
-                task();
+                invoke(task);
                 if (!running_)
                     return;
             }
@@ -260,9 +264,9 @@ namespace
                 if (it == timers_.end())
                     continue; // cancelled by an earlier callback this pass.
 
-                std::function<void()> callback = std::move(it->second.callback);
+                Callback callback = std::move(it->second.callback);
                 timers_.erase(it); // one-shot.
-                callback();
+                invoke(callback);
                 if (!running_)
                     return;
             }
@@ -273,14 +277,14 @@ namespace
         std::map<SourceId, Source> sources_;
         std::map<TimerId, Timer> timers_;
         std::mutex mutex_;
-        std::vector<std::function<void()>> posted_;
+        std::vector<Callback> posted_;
         std::uint64_t nextId_ = 1;
-        bool running_ = false;
+        std::atomic<bool> running_{ false };
     };
 }
 
-    std::unique_ptr<RunLoopImpl> makeRunLoopImpl()
+    std::shared_ptr<RunLoopImpl> makePlatformSpecificRunLoopImpl()
     {
-        return std::make_unique<Win32RunLoop>();
+        return std::make_shared<Win32RunLoop>();
     }
 }

--- a/src/btl/src/win32/runloopimpl.cpp
+++ b/src/btl/src/win32/runloopimpl.cpp
@@ -54,7 +54,8 @@ namespace
         ~Win32RunLoop() override
         {
             for (auto& entry : sources_)
-                WSACloseEvent(entry.second.event);
+                if (entry.second.ownsEvent)
+                    WSACloseEvent(entry.second.event);
             if (wakeup_)
                 CloseHandle(wakeup_);
         }
@@ -62,6 +63,8 @@ namespace
         SourceId addReadable(NativeHandle handle,
                 std::function<void()> onReadable) override
         {
+            if (handle.kind() == NativeHandle::Kind::Handle)
+                return addHandle(handle, std::move(onReadable));
             return addSocket(handle, std::move(onReadable),
                     FD_READ | FD_ACCEPT | FD_CLOSE);
         }
@@ -69,6 +72,8 @@ namespace
         SourceId addWritable(NativeHandle handle,
                 std::function<void()> onWritable) override
         {
+            if (handle.kind() == NativeHandle::Kind::Handle)
+                return addHandle(handle, std::move(onWritable));
             return addSocket(handle, std::move(onWritable), FD_WRITE | FD_CLOSE);
         }
 
@@ -94,7 +99,8 @@ namespace
             auto it = sources_.find(id);
             if (it != sources_.end())
             {
-                WSACloseEvent(it->second.event);
+                if (it->second.ownsEvent)
+                    WSACloseEvent(it->second.event);
                 sources_.erase(it);
             }
         }
@@ -153,8 +159,9 @@ namespace
     private:
         struct Source
         {
-            WSAEVENT event;
-            SOCKET socket;
+            HANDLE event;   // a WSAEVENT we own (socket), or a caller HANDLE.
+            SOCKET socket;  // INVALID_SOCKET for a handle source.
+            bool ownsEvent; // true: we created the event and must close it.
             std::function<void()> callback;
         };
 
@@ -172,7 +179,18 @@ namespace
             WSAEventSelect(socket, event, events);
 
             SourceId id = nextId_++;
-            sources_[id] = Source{ event, socket, std::move(callback) };
+            sources_[id] = Source{ event, socket, true, std::move(callback) };
+            return id;
+        }
+
+        // A handle source waits on a caller-owned waitable HANDLE directly (an
+        // overlapped-I/O event, a manual-reset event): no WSAEventSelect, no
+        // network-event enumeration, and we never close it.
+        SourceId addHandle(NativeHandle handle, std::function<void()> callback)
+        {
+            SourceId id = nextId_++;
+            sources_[id] = Source{ toHandle(handle), INVALID_SOCKET, false,
+                    std::move(callback) };
             return id;
         }
 
@@ -182,8 +200,14 @@ namespace
             if (it == sources_.end())
                 return;
 
-            WSANETWORKEVENTS network;
-            WSAEnumNetworkEvents(it->second.socket, it->second.event, &network);
+            // Sockets need their pending network events drained; a handle source
+            // has none, its callback drains the I/O (and resets the event).
+            if (it->second.socket != INVALID_SOCKET)
+            {
+                WSANETWORKEVENTS network;
+                WSAEnumNetworkEvents(
+                        it->second.socket, it->second.event, &network);
+            }
 
             // The callback may remove this or other sources, so copy it out.
             std::function<void()> callback = it->second.callback;

--- a/src/btl/test/runlooptest.cpp
+++ b/src/btl/test/runlooptest.cpp
@@ -19,6 +19,7 @@ using Sock = int;
 #endif
 
 using namespace std::chrono_literals;
+using Controller = btl::RunLoop::Controller;
 
 namespace
 {
@@ -85,10 +86,13 @@ TEST(RunLoop, timerFiresThenStops)
     btl::RunLoop loop;
 
     bool fired = false;
-    loop.addTimer(5ms, [&]
+    loop.post([&](Controller& c)
         {
-            fired = true;
-            loop.stop();
+            c.addTimer(5ms, [&](Controller& cc)
+                {
+                    fired = true;
+                    cc.stop();
+                }).detach();
         });
 
     loop.run(); // returns once stop() runs from the timer.
@@ -107,11 +111,11 @@ TEST(RunLoop, postRunsOnTheLoopThread)
     std::thread poster([&]
         {
             std::this_thread::sleep_for(10ms);
-            loop.post([&]
+            loop.post([&](Controller& c)
                 {
                     taskThread = std::this_thread::get_id();
                     ran = true;
-                    loop.stop();
+                    c.stop();
                 });
         });
 
@@ -129,18 +133,51 @@ TEST(RunLoop, readableFiresWhenPeerWrites)
     auto pair = makePair();
 
     bool readable = false;
-    loop.addReadable(wrap(pair.first), [&]
+    loop.post([&](Controller& c)
         {
-            readable = true;
-            loop.stop();
+            c.addReadable(wrap(pair.first), [&](Controller& cc)
+                {
+                    readable = true;
+                    cc.stop();
+                }).detach();
         });
 
-    // Peer writes, so pair.first is readable when the loop starts.
+    // Peer writes, so pair.first is readable when the source is registered.
     writeByte(pair.second);
 
     loop.run();
 
     EXPECT_TRUE(readable);
+
+    closeSock(pair.first);
+    closeSock(pair.second);
+}
+
+TEST(RunLoop, droppingSourceHandleRemovesIt)
+{
+    btl::RunLoop loop;
+
+    auto pair = makePair();
+
+    int fires = 0;
+    loop.post([&](Controller& c)
+        {
+            {
+                auto source = c.addReadable(wrap(pair.first), [&](Controller&)
+                    {
+                        ++fires;
+                    });
+                // source drops here, on the loop thread, so it is removed before
+                // the loop waits - the pending write must not fire it.
+            }
+            c.addTimer(20ms, [](Controller& t) { t.stop(); }).detach();
+        });
+
+    writeByte(pair.second);
+
+    loop.run();
+
+    EXPECT_EQ(fires, 0);
 
     closeSock(pair.first);
     closeSock(pair.second);
@@ -156,13 +193,17 @@ TEST(RunLoop, readableFiresOnSignaledHandleThenStopsAfterRemove)
     HANDLE event = ::CreateEventW(nullptr, TRUE, FALSE, nullptr); // manual-reset
 
     int fires = 0;
-    btl::SourceId id = loop.addReadable(btl::fromHandle(event), [&]
+    btl::RunLoop::Source source;
+    loop.post([&](Controller& c)
         {
-            ++fires;
-            loop.remove(id); // stop watching; the event stays signaled.
-            // If remove() failed, the still-signaled (level-triggered) event
-            // would fire again before this timer stops the loop.
-            loop.addTimer(20ms, [&] { loop.stop(); });
+            source = c.addReadable(btl::fromHandle(event), [&](Controller& cc)
+                {
+                    ++fires;
+                    cc.remove(source.id()); // stop watching; event stays signaled.
+                    // If remove() failed, the still-signaled (level-triggered)
+                    // event would fire again before this timer stops the loop.
+                    cc.addTimer(20ms, [](Controller& t) { t.stop(); }).detach();
+                });
         });
 
     ::SetEvent(event); // signaled before run(): readable from the start.

--- a/src/btl/test/runlooptest.cpp
+++ b/src/btl/test/runlooptest.cpp
@@ -145,3 +145,32 @@ TEST(RunLoop, readableFiresWhenPeerWrites)
     closeSock(pair.first);
     closeSock(pair.second);
 }
+
+#ifdef _WIN32
+// A waitable HANDLE (here a manual-reset event, as a named pipe's overlapped
+// event would be) is a first-class readable source on Windows.
+TEST(RunLoop, readableFiresOnSignaledHandleThenStopsAfterRemove)
+{
+    btl::RunLoop loop;
+
+    HANDLE event = ::CreateEventW(nullptr, TRUE, FALSE, nullptr); // manual-reset
+
+    int fires = 0;
+    btl::SourceId id = loop.addReadable(btl::fromHandle(event), [&]
+        {
+            ++fires;
+            loop.remove(id); // stop watching; the event stays signaled.
+            // If remove() failed, the still-signaled (level-triggered) event
+            // would fire again before this timer stops the loop.
+            loop.addTimer(20ms, [&] { loop.stop(); });
+        });
+
+    ::SetEvent(event); // signaled before run(): readable from the start.
+
+    loop.run();
+
+    EXPECT_EQ(fires, 1); // fired once, and remove() kept it from re-firing.
+
+    ::CloseHandle(event);
+}
+#endif

--- a/src/btl/test/runlooptest.cpp
+++ b/src/btl/test/runlooptest.cpp
@@ -1,0 +1,147 @@
+#include <btl/runloop.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <utility>
+
+#ifdef _WIN32
+#include <btl/win32/nativehandle_win32.h>
+#include <ws2tcpip.h>
+using Sock = SOCKET;
+#else
+#include <btl/posix/nativehandle_posix.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using Sock = int;
+#endif
+
+using namespace std::chrono_literals;
+
+namespace
+{
+    btl::NativeHandle wrap(Sock s)
+    {
+#ifdef _WIN32
+        return btl::fromSocket(s);
+#else
+        return btl::fromFd(s);
+#endif
+    }
+
+    void writeByte(Sock s)
+    {
+        char byte = 'x';
+#ifdef _WIN32
+        ::send(s, &byte, 1, 0);
+#else
+        ssize_t n = ::write(s, &byte, 1);
+        (void)n;
+#endif
+    }
+
+    void closeSock(Sock s)
+    {
+#ifdef _WIN32
+        ::closesocket(s);
+#else
+        ::close(s);
+#endif
+    }
+
+    // A connected pair of sockets. On POSIX a socketpair; on Windows a loopback
+    // TCP connect (which has no socketpair()).
+    std::pair<Sock, Sock> makePair()
+    {
+#ifdef _WIN32
+        SOCKET listener = ::socket(AF_INET, SOCK_STREAM, 0);
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+        ::bind(listener, (sockaddr*)&addr, sizeof(addr));
+        ::listen(listener, 1);
+
+        int len = sizeof(addr);
+        ::getsockname(listener, (sockaddr*)&addr, &len);
+
+        SOCKET client = ::socket(AF_INET, SOCK_STREAM, 0);
+        ::connect(client, (sockaddr*)&addr, sizeof(addr));
+        SOCKET server = ::accept(listener, nullptr, nullptr);
+        ::closesocket(listener);
+        return { client, server };
+#else
+        int fds[2] = { -1, -1 };
+        ::socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+        return { fds[0], fds[1] };
+#endif
+    }
+}
+
+TEST(RunLoop, timerFiresThenStops)
+{
+    btl::RunLoop loop;
+
+    bool fired = false;
+    loop.addTimer(5ms, [&]
+        {
+            fired = true;
+            loop.stop();
+        });
+
+    loop.run(); // returns once stop() runs from the timer.
+
+    EXPECT_TRUE(fired);
+}
+
+TEST(RunLoop, postRunsOnTheLoopThread)
+{
+    btl::RunLoop loop;
+
+    std::atomic<bool> ran{ false };
+    std::thread::id taskThread;
+    std::thread::id runThread = std::this_thread::get_id();
+
+    std::thread poster([&]
+        {
+            std::this_thread::sleep_for(10ms);
+            loop.post([&]
+                {
+                    taskThread = std::this_thread::get_id();
+                    ran = true;
+                    loop.stop();
+                });
+        });
+
+    loop.run(); // the posted task wakes it and runs here.
+    poster.join();
+
+    EXPECT_TRUE(ran.load());
+    EXPECT_EQ(taskThread, runThread);
+}
+
+TEST(RunLoop, readableFiresWhenPeerWrites)
+{
+    btl::RunLoop loop; // constructing it starts winsock, which makePair needs.
+
+    auto pair = makePair();
+
+    bool readable = false;
+    loop.addReadable(wrap(pair.first), [&]
+        {
+            readable = true;
+            loop.stop();
+        });
+
+    // Peer writes, so pair.first is readable when the loop starts.
+    writeByte(pair.second);
+
+    loop.run();
+
+    EXPECT_TRUE(readable);
+
+    closeSock(pair.first);
+    closeSock(pair.second);
+}

--- a/src/btl/test/runlooptest.cpp
+++ b/src/btl/test/runlooptest.cpp
@@ -214,4 +214,53 @@ TEST(RunLoop, readableFiresOnSignaledHandleThenStopsAfterRemove)
 
     ::CloseHandle(event);
 }
+
+// The thread message queue is a readable source: a message posted to the loop
+// thread wakes the loop (MsgWaitForMultipleObjectsEx) and fires the source,
+// whose callback drains the queue with PeekMessage.
+TEST(RunLoop, messageQueueFiresOnPostedThreadMessage)
+{
+    btl::RunLoop loop;
+
+    std::atomic<DWORD> loopThreadId{ 0 };
+    std::atomic<bool> ready{ false };
+    bool fired = false; // written on the loop thread, read after join.
+
+    std::thread worker([&]
+        {
+            loopThreadId = ::GetCurrentThreadId();
+
+            // Force the thread message queue to exist so PostThreadMessage can
+            // target it, then let the main thread post.
+            MSG msg;
+            ::PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+            ready = true;
+
+            loop.post([&](Controller& c)
+                {
+                    c.addReadable(btl::fromMessageQueue(), [&](Controller& cc)
+                        {
+                            MSG m;
+                            while (::PeekMessageW(&m, nullptr, 0, 0, PM_REMOVE))
+                                if (m.message == WM_USER)
+                                    fired = true;
+                            cc.stop();
+                        }).detach();
+                });
+
+            loop.run();
+        });
+
+    while (!ready.load())
+        std::this_thread::sleep_for(1ms);
+
+    // Retry until the queue is up (PostThreadMessage can briefly fail with
+    // ERROR_INVALID_THREAD_ID before the target thread has a queue).
+    while (!::PostThreadMessageW(loopThreadId.load(), WM_USER, 0, 0))
+        std::this_thread::sleep_for(1ms);
+
+    worker.join();
+
+    EXPECT_TRUE(fired);
+}
 #endif


### PR DESCRIPTION
Add `btl::RunLoop` and render the platforms on demand (the frame-model rework).

- `btl::RunLoop`: a single-threaded reactor (readable/writable/timer/post) with an opaque non-owning `NativeHandle`, split into a thread-safe owner + a loop-thread `Controller`. POSIX select + Win32 WSAEventSelect / message-queue / HANDLE sources.
- WGL/GLX/dummy drive their frame loop through it: block when idle, wake on `requestFrame()` (gated by the #127 observe mechanism), re-evaluate the signal graph only on external change; the desktop frame fence completes asynchronously instead of blocking.
- The dummy platform becomes a real headless backend: a time-advancing `Frame` plus an optional `setMaxFps()` cap.
- Also carries the runloop + frame-model design docs and the review-comment cleanups (explicit lambda captures, style fixes).

Green across the full CI matrix (Linux gcc/clang incl. Sanitize, macOS, Windows msvc + clang-cl). Base: #127.
