### PR TITLE
Fix signal::input observe and expose SignalContext::observe

### DIFF
--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -228,11 +228,10 @@ namespace bq::signal
                 return r;
             }
 
-            btl::connection observe(DataContext& context, DataType& data,
-                    std::function<void()> callback)
+            void observe(DataContext& context, DataType& data,
+                    ObserveCallback callback)
             {
-                return sig_.observe(context, data.innerData,
-                        std::move(callback));
+                sig_.observe(context, data.innerData, std::move(callback));
             }
 
         private:
@@ -355,8 +354,8 @@ namespace bq::signal
          *
          * observe() connects the elements that are there when it is called and
          * is **not** rewired by a later membership change: an element that
-         * arrives afterwards is not observed, and one that leaves stays in the
-         * returned connection. Nothing in the toolkit observes a signal today.
+         * arrives afterwards is not observed, and one that leaves stays
+         * registered on its now-detached leaf until the observer's guard drops.
          *
          * @throws std::runtime_error if one identity appears twice, which means
          *         an array was concatenated with itself.
@@ -446,19 +445,16 @@ namespace bq::signal
                 return r;
             }
 
-            btl::connection observe(DataContext& context, DataType& data,
-                    std::function<void()> callback)
+            void observe(DataContext& context, DataType& data,
+                    ObserveCallback callback)
             {
-                btl::connection c = sig_.observe(context, data.innerData,
-                        callback);
+                sig_.observe(context, data.innerData, callback);
 
                 for (auto& element : data.elements)
                 {
-                    c += element.value.unwrap().observe(context,
+                    element.value.unwrap().observe(context,
                             data.datas.at(element.id), callback);
                 }
-
-                return c;
             }
 
         private:

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -425,12 +425,6 @@ namespace bq::signal
                             data.datas.at(element.id), frame);
                 }
 
-                // Nothing collected an arrival's own request to be driven
-                // again, so ask for the next frame on its behalf rather than
-                // let a newly built animation sit still.
-                if (!arrived.empty())
-                    r.nextUpdate = min(r.nextUpdate, signal_time_t(0));
-
                 return r;
             }
 

--- a/src/bq/include/bq/signal/arraysignal.h
+++ b/src/bq/include/bq/signal/arraysignal.h
@@ -228,12 +228,6 @@ namespace bq::signal
                 return r;
             }
 
-            void observe(DataContext& context, DataType& data,
-                    ObserveCallback callback)
-            {
-                sig_.observe(context, data.innerData, std::move(callback));
-            }
-
         private:
             // Returns whether the membership changed, which is the whole of
             // what an update can change: a value is built once per identity.
@@ -352,11 +346,6 @@ namespace bq::signal
          * neighbours, and it is a property of the node rather than of anything
          * the elements do — nothing here needs the elements to be shared.
          *
-         * observe() connects the elements that are there when it is called and
-         * is **not** rewired by a later membership change: an element that
-         * arrives afterwards is not observed, and one that leaves stays
-         * registered on its now-detached leaf until the observer's guard drops.
-         *
          * @throws std::runtime_error if one identity appears twice, which means
          *         an array was concatenated with itself.
          */
@@ -443,18 +432,6 @@ namespace bq::signal
                     r.nextUpdate = min(r.nextUpdate, signal_time_t(0));
 
                 return r;
-            }
-
-            void observe(DataContext& context, DataType& data,
-                    ObserveCallback callback)
-            {
-                sig_.observe(context, data.innerData, callback);
-
-                for (auto& element : data.elements)
-                {
-                    element.value.unwrap().observe(context,
-                            data.datas.at(element.id), callback);
-                }
             }
 
         private:

--- a/src/bq/include/bq/signal/cache.h
+++ b/src/bq/include/bq/signal/cache.h
@@ -52,12 +52,6 @@ namespace bq::signal
             return r;
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_.observe(context, data.innerData, std::move(callback));
-        }
-
     private:
         TSignal sig_;
     };

--- a/src/bq/include/bq/signal/cache.h
+++ b/src/bq/include/bq/signal/cache.h
@@ -52,12 +52,10 @@ namespace bq::signal
             return r;
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return sig_.observe(context, data.innerData,
-                    std::forward<TCallback>(callback));
+            sig_.observe(context, data.innerData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/check.h
+++ b/src/bq/include/bq/signal/check.h
@@ -55,7 +55,7 @@ namespace bq::signal
                     data.value = std::move(value);
             }
 
-            return { r.nextUpdate, didReallyChange };
+            return { didReallyChange };
         }
 
     private:

--- a/src/bq/include/bq/signal/check.h
+++ b/src/bq/include/bq/signal/check.h
@@ -58,12 +58,10 @@ namespace bq::signal
             return { r.nextUpdate, didReallyChange };
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return sig_.observe(context, data.innerData,
-                    std::forward<TCallback>(callback));
+            sig_.observe(context, data.innerData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/check.h
+++ b/src/bq/include/bq/signal/check.h
@@ -58,12 +58,6 @@ namespace bq::signal
             return { r.nextUpdate, didReallyChange };
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_.observe(context, data.innerData, std::move(callback));
-        }
-
     private:
         TSignal sig_;
     };

--- a/src/bq/include/bq/signal/combine.h
+++ b/src/bq/include/bq/signal/combine.h
@@ -51,13 +51,6 @@ namespace bq::signal
             return r;
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            for (size_t i = 0; i < sigs_.size(); ++i)
-                sigs_[i].unwrap().observe(context, data.datas[i], callback);
-        }
-
     private:
         std::vector<AnySignal<T>> sigs_;
     };

--- a/src/bq/include/bq/signal/combine.h
+++ b/src/bq/include/bq/signal/combine.h
@@ -51,15 +51,11 @@ namespace bq::signal
             return r;
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            btl::connection c;
-
             for (size_t i = 0; i < sigs_.size(); ++i)
-                c += sigs_[i].unwrap().observe(context, data.datas[i], callback);
-
-            return c;
+                sigs_[i].unwrap().observe(context, data.datas[i], callback);
         }
 
     private:

--- a/src/bq/include/bq/signal/conditional.h
+++ b/src/bq/include/bq/signal/conditional.h
@@ -95,19 +95,14 @@ namespace bq::signal
             return r;
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> const& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback const& callback)
         {
-            auto c = conditionSignal_.observe(context, data.conditionData,
-                    callback);
+            conditionSignal_.observe(context, data.conditionData, callback);
             if (data.condition)
-                c += trueSignal_.unwrap().observe(context, data.signalData,
-                        callback);
+                trueSignal_.unwrap().observe(context, data.signalData, callback);
             else
-                c += falseSignal_.unwrap().observe(context, data.signalData,
-                        callback);
-
-            return c;
+                falseSignal_.unwrap().observe(context, data.signalData, callback);
         }
 
     private:

--- a/src/bq/include/bq/signal/conditional.h
+++ b/src/bq/include/bq/signal/conditional.h
@@ -95,16 +95,6 @@ namespace bq::signal
             return r;
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback const& callback)
-        {
-            conditionSignal_.observe(context, data.conditionData, callback);
-            if (data.condition)
-                trueSignal_.unwrap().observe(context, data.signalData, callback);
-            else
-                falseSignal_.unwrap().observe(context, data.signalData, callback);
-        }
-
     private:
         TCondition conditionSignal_;
         AnySignal<Ts...> trueSignal_;

--- a/src/bq/include/bq/signal/constant.h
+++ b/src/bq/include/bq/signal/constant.h
@@ -47,7 +47,7 @@ namespace bq::signal
 
         UpdateResult update(DataContext&, DataType&, FrameInfo const&)
         {
-            return { std::nullopt, false };
+            return { false };
         }
 
     private:

--- a/src/bq/include/bq/signal/constant.h
+++ b/src/bq/include/bq/signal/constant.h
@@ -50,11 +50,9 @@ namespace bq::signal
             return { std::nullopt, false };
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext&, DataType&, TCallback&&)
+        void observe(DataContext&, DataType&, ObserveCallback)
         {
             // nothing to observe
-            return btl::connection();
         }
 
     private:

--- a/src/bq/include/bq/signal/constant.h
+++ b/src/bq/include/bq/signal/constant.h
@@ -50,11 +50,6 @@ namespace bq::signal
             return { std::nullopt, false };
         }
 
-        void observe(DataContext&, DataType&, ObserveCallback)
-        {
-            // nothing to observe
-        }
-
     private:
         btl::CopyWrapper<T> constant_;
     };

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -159,7 +159,7 @@ namespace bq::signal
         }
 
         /** The wakeup an external leaf registers itself with at init. */
-        std::weak_ptr<ObserveControl> observeControl() const
+        std::shared_ptr<ObserveControl> observeControl() const
         {
             return observeControl_;
         }

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -8,11 +8,57 @@
 #include <typeindex>
 #include <memory>
 #include <unordered_map>
+#include <functional>
 #include <cassert>
 
 namespace bq::signal
 {
     BQ_EXPORT btl::UniqueId makeUniqueId();
+
+    /** Lifetime token for an observation. observe() ties every wakeup it
+     * registers to one of these; the wakeups fire while it is alive and drop
+     * when it does. */
+    using ObserveGuard = std::shared_ptr<void>;
+
+    /** Creates a fresh guard for a caller about to observe. */
+    inline ObserveGuard makeObserveGuard()
+    {
+        return std::make_shared<char>();
+    }
+
+    /** A wake callback paired with the guard that scopes it.
+     *
+     * observe() stores these on the external leaves it reaches rather than
+     * returning an unregistration handle: the callback fires only while its
+     * guard is alive, so an observer disarms by dropping the guard. A leaf drops
+     * a dead registration the next time it is observed or fires. */
+    class ObserveCallback
+    {
+    public:
+        ObserveCallback() = default;
+
+        ObserveCallback(ObserveGuard const& guard, std::function<void()> callback) :
+            guard_(guard),
+            callback_(std::move(callback))
+        {
+        }
+
+        /** True while the owning observer is still armed. */
+        explicit operator bool() const
+        {
+            return !guard_.expired();
+        }
+
+        void operator()() const
+        {
+            if (auto alive = guard_.lock())
+                callback_();
+        }
+
+    private:
+        std::weak_ptr<void> guard_;
+        std::function<void()> callback_;
+    };
 
     class BQ_EXPORT DataContext
     {

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -9,54 +9,37 @@
 #include <memory>
 #include <unordered_map>
 #include <functional>
+#include <mutex>
 #include <cassert>
 
 namespace bq::signal
 {
     BQ_EXPORT btl::UniqueId makeUniqueId();
 
-    /** Lifetime token for an observation. observe() ties every wakeup it
-     * registers to one of these; the wakeups fire while it is alive and drop
-     * when it does. */
-    using ObserveGuard = std::shared_ptr<void>;
-
-    /** Creates a fresh guard for a caller about to observe. */
-    inline ObserveGuard makeObserveGuard()
-    {
-        return std::make_shared<char>();
-    }
-
-    /** A wake callback paired with the guard that scopes it.
-     *
-     * observe() stores these on the external leaves it reaches rather than
-     * returning an unregistration handle: the callback fires only while its
-     * guard is alive, so an observer disarms by dropping the guard. A leaf drops
-     * a dead registration the next time it is observed or fires. */
-    class ObserveCallback
+    /** Per-context wakeup for external leaf changes. observe() arms it with a
+     * callback; external leaves (input, collect) fire it when they change,
+     * without evaluating the graph. It stays armed for the context's lifetime;
+     * coalescing of repeated fires is the caller's concern (the frame loop
+     * throttles requestFrame). */
+    class ObserveControl
     {
     public:
-        ObserveCallback() = default;
-
-        ObserveCallback(ObserveGuard const& guard, std::function<void()> callback) :
-            guard_(guard),
-            callback_(std::move(callback))
+        void arm(std::function<void()> callback)
         {
+            std::lock_guard<std::mutex> lock(mutex_);
+            callback_ = std::move(callback);
         }
 
-        /** True while the owning observer is still armed. */
-        explicit operator bool() const
+        void fire()
         {
-            return !guard_.expired();
-        }
-
-        void operator()() const
-        {
-            if (auto alive = guard_.lock())
-                callback_();
+            std::function<void()> callback;
+            { std::lock_guard<std::mutex> lock(mutex_); callback = callback_; }
+            if (callback)
+                callback();
         }
 
     private:
-        std::weak_ptr<void> guard_;
+        std::mutex mutex_;
         std::function<void()> callback_;
     };
 
@@ -164,11 +147,26 @@ namespace bq::signal
             frameData_.clear();
         }
 
+        /** Arms this context's wakeup; the callback fires on the next external
+         * change to any leaf reached by this context. */
+        void observe(std::function<void()> callback)
+        {
+            observeControl_->arm(std::move(callback));
+        }
+
+        /** The wakeup an external leaf registers itself with at init. */
+        std::weak_ptr<ObserveControl> observeControl() const
+        {
+            return observeControl_;
+        }
+
     private:
         btl::UniqueId id_;
         std::unordered_map<DataId, std::weak_ptr<Base>> data_;
         std::vector<std::shared_ptr<Base>> frameData_;
         std::vector<std::shared_ptr<Base>> prevFrameData_;
+        std::shared_ptr<ObserveControl> observeControl_ =
+            std::make_shared<ObserveControl>();
     };
 } // namespace bq::signal
 

--- a/src/bq/include/bq/signal/datacontext.h
+++ b/src/bq/include/bq/signal/datacontext.h
@@ -33,7 +33,10 @@ namespace bq::signal
         void fire()
         {
             std::function<void()> callback;
-            { std::lock_guard<std::mutex> lock(mutex_); callback = callback_; }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                callback = callback_;
+            }
             if (callback)
                 callback();
         }
@@ -147,9 +150,10 @@ namespace bq::signal
             frameData_.clear();
         }
 
-        /** Arms this context's wakeup; the callback fires on the next external
-         * change to any leaf reached by this context. */
-        void observe(std::function<void()> callback)
+        /** Sets this context's wakeup callback, replacing any previous one. It
+         * fires on the next external change to any leaf this context reaches.
+         * There is one callback -- the owning SignalContext's. */
+        void setObserveCallback(std::function<void()> callback)
         {
             observeControl_->arm(std::move(callback));
         }

--- a/src/bq/include/bq/signal/evaluateoninit.h
+++ b/src/bq/include/bq/signal/evaluateoninit.h
@@ -39,10 +39,6 @@ namespace bq::signal
             return {};
         }
 
-        void observe(DataContext&, DataType&, ObserveCallback)
-        {
-        }
-
     private:
         TFunc func_;
     };

--- a/src/bq/include/bq/signal/evaluateoninit.h
+++ b/src/bq/include/bq/signal/evaluateoninit.h
@@ -39,9 +39,8 @@ namespace bq::signal
             return {};
         }
 
-        btl::connection observe(DataContext&, DataType&, std::function<void()>)
+        void observe(DataContext&, DataType&, ObserveCallback)
         {
-            return {};
         }
 
     private:

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -4,8 +4,7 @@
 #include "signalresult.h"
 #include "datacontext.h"
 
-#include <btl/connection.h>
-
+#include <algorithm>
 #include <mutex>
 #include <memory>
 #include <cstdint>
@@ -33,8 +32,7 @@ namespace bq::signal
         std::optional<Weak<Ts...>> sig;
         uint64_t valueIndex = 0;
         uint64_t signalIndex = 0;
-        std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
-        uint64_t nextId = 1;
+        std::vector<ObserveCallback> callbacks;
     };
 
     template <typename... Ts>
@@ -71,7 +69,7 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
+            std::vector<ObserveCallback> callbacks;
             {
                 std::unique_lock lock(control->mutex);
                 control->value = SignalResult<Ts...>(std::forward<Us>(us)...);
@@ -81,7 +79,7 @@ namespace bq::signal
             }
 
             for (auto&& cb : callbacks)
-                std::move(cb.second)();
+                cb();
         }
 
         void set(Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> sig)
@@ -90,7 +88,7 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
+            std::vector<ObserveCallback> callbacks;
             {
                 std::unique_lock lock(control->mutex);
                 control->sig = std::move(sig).unwrap();
@@ -100,7 +98,7 @@ namespace bq::signal
             }
 
             for (auto&& cb : callbacks)
-                std::move(cb.second)();
+                cb();
         }
 
     private:
@@ -251,45 +249,26 @@ namespace bq::signal
             return { std::nullopt, didChange };
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data, TCallback&& callback)
+        void observe(DataContext& context, DataType& data, ObserveCallback callback)
         {
             std::unique_lock lock(control_->mutex);
 
             ContextDataType& contextData = *data.contextData;
 
-            auto id = control_->nextId++;
-            control_->callbacks.emplace_back(id, callback);
-
-            std::weak_ptr<InputControl<Ts...>> weakControl = control_;
-            btl::connection connection = btl::connection::on_disconnect(
-                    [id, weakControl]()
-                    {
-                        if (auto control = weakControl.lock())
-                        {
-                            std::unique_lock lock(control->mutex);
-                            for (auto i = control->callbacks.begin();
-                                    i != control->callbacks.end(); ++i)
-                            {
-                                if (id == i->first)
-                                {
-                                    control->callbacks.erase(i);
-                                    break;
-                                }
-                            }
-                        }
-                    });
+            auto& cbs = control_->callbacks;
+            cbs.erase(std::remove_if(cbs.begin(), cbs.end(),
+                    [](ObserveCallback const& cb) { return !cb; }), cbs.end());
 
             if (control_->sig && contextData.sigData)
             {
-                connection += control_->sig->observe(
+                control_->sig->observe(
                         context,
                         *contextData.sigData,
                         callback
                         );
             }
 
-            return connection;
+            cbs.push_back(std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -118,8 +118,6 @@ namespace bq::signal
 
             std::optional<SignalDataTypeT<Weak<Ts...>>> sigData;
             SignalResult<Ts...> value;
-            std::optional<signal_time_t> updateTime;
-            signal_time_t time = signal_time_t(0);
             uint64_t frameId = 0;
             uint64_t index = 0;
             bool didChange = false;
@@ -197,19 +195,10 @@ namespace bq::signal
 
             if (!newFrame)
             {
-                if (contextData.updateTime)
-                {
-                    return {
-                        *contextData.updateTime - contextData.time,
-                            contextData.didChange
-                    };
-                }
-
-                return { std::nullopt, contextData.didChange };
+                return { contextData.didChange };
             }
 
             contextData.frameId = frame.getFrameId();
-            contextData.time += frame.getDeltaTime();
 
             bool didChange = false;
             bool const newSignal = contextData.index < control_->signalIndex;
@@ -239,10 +228,6 @@ namespace bq::signal
                 }
 
                 didChange = didChange || r.didChange;
-
-                contextData.updateTime.reset();
-                if (r.nextUpdate)
-                    contextData.updateTime = contextData.time + *r.nextUpdate;
             }
 
             bool const newValue = (contextData.index < control_->valueIndex);
@@ -255,15 +240,7 @@ namespace bq::signal
 
             contextData.didChange = didChange;
 
-            if (contextData.updateTime)
-            {
-                return {
-                    *contextData.updateTime - contextData.time,
-                    didChange
-                };
-            }
-
-            return { std::nullopt, didChange };
+            return { didChange };
         }
 
     private:

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -17,15 +17,6 @@ namespace bq::signal
     template <typename TStorage, typename... Ts>
     class Signal;
 
-    /** A single (input, context) observation. It is owned by the input's
-     * per-context data and held weakly by the shared control, so it lapses
-     * exactly when that data is released -- the context is torn down, or the
-     * input leaves the graph -- and set() drops the lapsed ones. */
-    struct ObserveRegistration
-    {
-        std::weak_ptr<ObserveControl> control;
-    };
-
     template <typename... Ts>
     struct InputControl
     {
@@ -41,7 +32,7 @@ namespace bq::signal
         std::optional<Weak<Ts...>> sig;
         uint64_t valueIndex = 0;
         uint64_t signalIndex = 0;
-        std::vector<std::weak_ptr<ObserveRegistration>> observers;
+        std::vector<std::shared_ptr<ObserveControl>> observers;
     };
 
     template <typename... Ts>
@@ -78,28 +69,17 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::shared_ptr<ObserveRegistration>> toFire;
+            std::vector<std::shared_ptr<ObserveControl>> toFire;
             {
                 std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->value = SignalResult<Ts...>(std::forward<Us>(us)...);
                 control->valueIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
-                for (auto it = control->observers.begin();
-                        it != control->observers.end(); )
-                {
-                    if (auto registration = it->lock())
-                    {
-                        toFire.push_back(std::move(registration));
-                        ++it;
-                    }
-                    else
-                        it = control->observers.erase(it);
-                }
+                toFire = control->observers;
             }
 
-            for (auto& registration : toFire)
-                if (auto c = registration->control.lock())
-                    c->fire();
+            for (auto& c : toFire)
+                c->fire();
         }
 
         void set(Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> sig)
@@ -108,28 +88,17 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::shared_ptr<ObserveRegistration>> toFire;
+            std::vector<std::shared_ptr<ObserveControl>> toFire;
             {
                 std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->sig = std::move(sig).unwrap();
                 control->signalIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
-                for (auto it = control->observers.begin();
-                        it != control->observers.end(); )
-                {
-                    if (auto registration = it->lock())
-                    {
-                        toFire.push_back(std::move(registration));
-                        ++it;
-                    }
-                    else
-                        it = control->observers.erase(it);
-                }
+                toFire = control->observers;
             }
 
-            for (auto& registration : toFire)
-                if (auto c = registration->control.lock())
-                    c->fire();
+            for (auto& c : toFire)
+                c->fire();
         }
 
     private:
@@ -154,7 +123,19 @@ namespace bq::signal
             uint64_t frameId = 0;
             uint64_t index = 0;
             bool didChange = false;
-            std::shared_ptr<ObserveRegistration> observeRegistration;
+            std::shared_ptr<InputControl<Ts...>> inputControl;
+            std::shared_ptr<ObserveControl> observeControl;
+
+            ~ContextDataType()
+            {
+                if (inputControl)
+                {
+                    std::unique_lock<std::recursive_mutex> lock(inputControl->mutex);
+                    auto& obs = inputControl->observers;
+                    obs.erase(std::remove(obs.begin(), obs.end(), observeControl),
+                            obs.end());
+                }
+            }
         };
 
         struct DataType
@@ -180,10 +161,9 @@ namespace bq::signal
 
                 contextData->index = control_->valueIndex;
 
-                auto registration = std::make_shared<ObserveRegistration>();
-                registration->control = context.observeControl();
-                contextData->observeRegistration = registration;
-                control_->observers.push_back(registration);
+                contextData->inputControl = control_;
+                contextData->observeControl = context.observeControl();
+                control_->observers.push_back(contextData->observeControl);
 
                 if (control_->sig)
                 {

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -32,7 +32,8 @@ namespace bq::signal
         std::optional<Weak<Ts...>> sig;
         uint64_t valueIndex = 0;
         uint64_t signalIndex = 0;
-        std::vector<ObserveCallback> callbacks;
+        std::vector<std::pair<uint64_t, std::weak_ptr<ObserveControl>>> observers;
+        uint64_t nextObserverId = 1;
     };
 
     template <typename... Ts>
@@ -69,17 +70,28 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<ObserveCallback> callbacks;
+            std::vector<std::weak_ptr<ObserveControl>> toFire;
             {
-                std::unique_lock lock(control->mutex);
+                std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->value = SignalResult<Ts...>(std::forward<Us>(us)...);
                 control->valueIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
-                std::swap(callbacks, control->callbacks);
+                for (auto it = control->observers.begin();
+                        it != control->observers.end(); )
+                {
+                    if (it->second.expired())
+                        it = control->observers.erase(it);
+                    else
+                    {
+                        toFire.push_back(it->second);
+                        ++it;
+                    }
+                }
             }
 
-            for (auto&& cb : callbacks)
-                cb();
+            for (auto& w : toFire)
+                if (auto c = w.lock())
+                    c->fire();
         }
 
         void set(Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> sig)
@@ -88,17 +100,28 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<ObserveCallback> callbacks;
+            std::vector<std::weak_ptr<ObserveControl>> toFire;
             {
-                std::unique_lock lock(control->mutex);
+                std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->sig = std::move(sig).unwrap();
                 control->signalIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
-                std::swap(callbacks, control->callbacks);
+                for (auto it = control->observers.begin();
+                        it != control->observers.end(); )
+                {
+                    if (it->second.expired())
+                        it = control->observers.erase(it);
+                    else
+                    {
+                        toFire.push_back(it->second);
+                        ++it;
+                    }
+                }
             }
 
-            for (auto&& cb : callbacks)
-                cb();
+            for (auto& w : toFire)
+                if (auto c = w.lock())
+                    c->fire();
         }
 
     private:
@@ -116,6 +139,21 @@ namespace bq::signal
             {
             }
 
+            ~ContextDataType()
+            {
+                if (auto control = inputControl.lock())
+                {
+                    std::unique_lock<std::recursive_mutex> lock(control->mutex);
+                    auto& obs = control->observers;
+                    for (auto it = obs.begin(); it != obs.end(); ++it)
+                        if (it->first == observerId)
+                        {
+                            obs.erase(it);
+                            break;
+                        }
+                }
+            }
+
             std::optional<SignalDataTypeT<Weak<Ts...>>> sigData;
             SignalResult<Ts...> value;
             std::optional<signal_time_t> updateTime;
@@ -123,6 +161,8 @@ namespace bq::signal
             uint64_t frameId = 0;
             uint64_t index = 0;
             bool didChange = false;
+            std::weak_ptr<InputControl<Ts...>> inputControl;
+            uint64_t observerId = 0;
         };
 
         struct DataType
@@ -147,6 +187,11 @@ namespace bq::signal
                         control_->id_, control_->value);
 
                 contextData->index = control_->valueIndex;
+
+                auto id = control_->nextObserverId++;
+                control_->observers.emplace_back(id, context.observeControl());
+                contextData->inputControl = control_;
+                contextData->observerId = id;
 
                 if (control_->sig)
                 {
@@ -247,28 +292,6 @@ namespace bq::signal
             }
 
             return { std::nullopt, didChange };
-        }
-
-        void observe(DataContext& context, DataType& data, ObserveCallback callback)
-        {
-            std::unique_lock lock(control_->mutex);
-
-            ContextDataType& contextData = *data.contextData;
-
-            auto& cbs = control_->callbacks;
-            cbs.erase(std::remove_if(cbs.begin(), cbs.end(),
-                    [](ObserveCallback const& cb) { return !cb; }), cbs.end());
-
-            if (control_->sig && contextData.sigData)
-            {
-                control_->sig->observe(
-                        context,
-                        *contextData.sigData,
-                        callback
-                        );
-            }
-
-            cbs.push_back(std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -4,9 +4,14 @@
 #include "signalresult.h"
 #include "datacontext.h"
 
+#include <btl/connection.h>
+
 #include <mutex>
 #include <memory>
 #include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
 
 namespace bq::signal
 {
@@ -28,6 +33,8 @@ namespace bq::signal
         std::optional<Weak<Ts...>> sig;
         uint64_t valueIndex = 0;
         uint64_t signalIndex = 0;
+        std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
+        uint64_t nextId = 1;
     };
 
     template <typename... Ts>
@@ -60,30 +67,40 @@ namespace bq::signal
             >>
         void set(Us&&... us)
         {
-            if (auto control = control_.lock())
+            auto control = control_.lock();
+            if (!control)
+                return;
+
+            std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
             {
                 std::unique_lock lock(control->mutex);
                 control->value = SignalResult<Ts...>(std::forward<Us>(us)...);
                 control->valueIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
+                std::swap(callbacks, control->callbacks);
             }
+
+            for (auto&& cb : callbacks)
+                std::move(cb.second)();
         }
 
         void set(Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> sig)
         {
-            if (auto control = control_.lock())
+            auto control = control_.lock();
+            if (!control)
+                return;
+
+            std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
             {
                 std::unique_lock lock(control->mutex);
                 control->sig = std::move(sig).unwrap();
                 control->signalIndex = std::max(control->valueIndex,
                         control->signalIndex) + 1;
-                /*
-                control->sigData = control->sig->initialize(control->context);
-                control->value = control->sig->evaluate(control->context,
-                        *control->sigData);
-                ++control->index;
-                */
+                std::swap(callbacks, control->callbacks);
             }
+
+            for (auto&& cb : callbacks)
+                std::move(cb.second)();
         }
 
     private:
@@ -241,16 +258,38 @@ namespace bq::signal
 
             ContextDataType& contextData = *data.contextData;
 
+            auto id = control_->nextId++;
+            control_->callbacks.emplace_back(id, callback);
+
+            std::weak_ptr<InputControl<Ts...>> weakControl = control_;
+            btl::connection connection = btl::connection::on_disconnect(
+                    [id, weakControl]()
+                    {
+                        if (auto control = weakControl.lock())
+                        {
+                            std::unique_lock lock(control->mutex);
+                            for (auto i = control->callbacks.begin();
+                                    i != control->callbacks.end(); ++i)
+                            {
+                                if (id == i->first)
+                                {
+                                    control->callbacks.erase(i);
+                                    break;
+                                }
+                            }
+                        }
+                    });
+
             if (control_->sig && contextData.sigData)
             {
-                return control_->sig->observe(
+                connection += control_->sig->observe(
                         context,
                         *contextData.sigData,
-                        std::forward<TCallback>(callback)
+                        callback
                         );
             }
 
-            return {};
+            return connection;
         }
 
     private:

--- a/src/bq/include/bq/signal/input.h
+++ b/src/bq/include/bq/signal/input.h
@@ -17,6 +17,15 @@ namespace bq::signal
     template <typename TStorage, typename... Ts>
     class Signal;
 
+    /** A single (input, context) observation. It is owned by the input's
+     * per-context data and held weakly by the shared control, so it lapses
+     * exactly when that data is released -- the context is torn down, or the
+     * input leaves the graph -- and set() drops the lapsed ones. */
+    struct ObserveRegistration
+    {
+        std::weak_ptr<ObserveControl> control;
+    };
+
     template <typename... Ts>
     struct InputControl
     {
@@ -32,8 +41,7 @@ namespace bq::signal
         std::optional<Weak<Ts...>> sig;
         uint64_t valueIndex = 0;
         uint64_t signalIndex = 0;
-        std::vector<std::pair<uint64_t, std::weak_ptr<ObserveControl>>> observers;
-        uint64_t nextObserverId = 1;
+        std::vector<std::weak_ptr<ObserveRegistration>> observers;
     };
 
     template <typename... Ts>
@@ -70,7 +78,7 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::weak_ptr<ObserveControl>> toFire;
+            std::vector<std::shared_ptr<ObserveRegistration>> toFire;
             {
                 std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->value = SignalResult<Ts...>(std::forward<Us>(us)...);
@@ -79,18 +87,18 @@ namespace bq::signal
                 for (auto it = control->observers.begin();
                         it != control->observers.end(); )
                 {
-                    if (it->second.expired())
-                        it = control->observers.erase(it);
-                    else
+                    if (auto registration = it->lock())
                     {
-                        toFire.push_back(it->second);
+                        toFire.push_back(std::move(registration));
                         ++it;
                     }
+                    else
+                        it = control->observers.erase(it);
                 }
             }
 
-            for (auto& w : toFire)
-                if (auto c = w.lock())
+            for (auto& registration : toFire)
+                if (auto c = registration->control.lock())
                     c->fire();
         }
 
@@ -100,7 +108,7 @@ namespace bq::signal
             if (!control)
                 return;
 
-            std::vector<std::weak_ptr<ObserveControl>> toFire;
+            std::vector<std::shared_ptr<ObserveRegistration>> toFire;
             {
                 std::unique_lock<std::recursive_mutex> lock(control->mutex);
                 control->sig = std::move(sig).unwrap();
@@ -109,18 +117,18 @@ namespace bq::signal
                 for (auto it = control->observers.begin();
                         it != control->observers.end(); )
                 {
-                    if (it->second.expired())
-                        it = control->observers.erase(it);
-                    else
+                    if (auto registration = it->lock())
                     {
-                        toFire.push_back(it->second);
+                        toFire.push_back(std::move(registration));
                         ++it;
                     }
+                    else
+                        it = control->observers.erase(it);
                 }
             }
 
-            for (auto& w : toFire)
-                if (auto c = w.lock())
+            for (auto& registration : toFire)
+                if (auto c = registration->control.lock())
                     c->fire();
         }
 
@@ -139,21 +147,6 @@ namespace bq::signal
             {
             }
 
-            ~ContextDataType()
-            {
-                if (auto control = inputControl.lock())
-                {
-                    std::unique_lock<std::recursive_mutex> lock(control->mutex);
-                    auto& obs = control->observers;
-                    for (auto it = obs.begin(); it != obs.end(); ++it)
-                        if (it->first == observerId)
-                        {
-                            obs.erase(it);
-                            break;
-                        }
-                }
-            }
-
             std::optional<SignalDataTypeT<Weak<Ts...>>> sigData;
             SignalResult<Ts...> value;
             std::optional<signal_time_t> updateTime;
@@ -161,8 +154,7 @@ namespace bq::signal
             uint64_t frameId = 0;
             uint64_t index = 0;
             bool didChange = false;
-            std::weak_ptr<InputControl<Ts...>> inputControl;
-            uint64_t observerId = 0;
+            std::shared_ptr<ObserveRegistration> observeRegistration;
         };
 
         struct DataType
@@ -188,10 +180,10 @@ namespace bq::signal
 
                 contextData->index = control_->valueIndex;
 
-                auto id = control_->nextObserverId++;
-                control_->observers.emplace_back(id, context.observeControl());
-                contextData->inputControl = control_;
-                contextData->observerId = id;
+                auto registration = std::make_shared<ObserveRegistration>();
+                registration->control = context.observeControl();
+                contextData->observeRegistration = registration;
+                control_->observers.push_back(registration);
 
                 if (control_->sig)
                 {

--- a/src/bq/include/bq/signal/join.h
+++ b/src/bq/include/bq/signal/join.h
@@ -125,13 +125,11 @@ namespace bq::signal
             return r;
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            auto c = sig_.observe(context, data.outerData, callback);
-            c += data.innerSignal.observe(context, data.innerData, std::move(callback));
-
-            return c;
+            sig_.observe(context, data.outerData, callback);
+            data.innerSignal.observe(context, data.innerData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/join.h
+++ b/src/bq/include/bq/signal/join.h
@@ -125,13 +125,6 @@ namespace bq::signal
             return r;
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_.observe(context, data.outerData, callback);
-            data.innerSignal.observe(context, data.innerData, std::move(callback));
-        }
-
     private:
         T sig_;
     };

--- a/src/bq/include/bq/signal/map.h
+++ b/src/bq/include/bq/signal/map.h
@@ -89,11 +89,6 @@ namespace bq::signal
             return sig_.update(context, data.signalData, frame);
         }
 
-        void observe(DataContext& context, DataType& data, ObserveCallback callback)
-        {
-            sig_.observe(context, data.signalData, std::move(callback));
-        }
-
     private:
         mutable btl::CopyWrapper<TFunc> func_;
         TSignal sig_;

--- a/src/bq/include/bq/signal/map.h
+++ b/src/bq/include/bq/signal/map.h
@@ -89,11 +89,9 @@ namespace bq::signal
             return sig_.update(context, data.signalData, frame);
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data, TCallback&& callback)
+        void observe(DataContext& context, DataType& data, ObserveCallback callback)
         {
-            return sig_.observe(context, data.signalData, std::forward<TCallback>(
-                        callback));
+            sig_.observe(context, data.signalData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/merge.h
+++ b/src/bq/include/bq/signal/merge.h
@@ -46,11 +46,10 @@ namespace bq::signal
                     std::make_index_sequence<sizeof...(Ts)>());
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return doObserve(context, data, std::forward<TCallback>(callback),
+            doObserve(context, data, std::move(callback),
                     std::make_index_sequence<sizeof...(Ts)>());
         }
 
@@ -86,12 +85,12 @@ namespace bq::signal
                         context, std::get<S>(data.sigData), frame));
         }
 
-        template <typename TCallback, size_t... S>
-        auto doObserve(DataContext& context, DataType& data,
-                TCallback&& callback, std::index_sequence<S...>)
+        template <size_t... S>
+        void doObserve(DataContext& context, DataType& data,
+                ObserveCallback const& callback, std::index_sequence<S...>)
         {
-            return (btl::connection() + ... + std::get<S>(sigs_).observe(
-                        context, std::get<S>(data.sigData), callback));
+            (std::get<S>(sigs_).observe(
+                        context, std::get<S>(data.sigData), callback), ...);
         }
 
     private:

--- a/src/bq/include/bq/signal/merge.h
+++ b/src/bq/include/bq/signal/merge.h
@@ -46,13 +46,6 @@ namespace bq::signal
                     std::make_index_sequence<sizeof...(Ts)>());
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            doObserve(context, data, std::move(callback),
-                    std::make_index_sequence<sizeof...(Ts)>());
-        }
-
     private:
         template <size_t... S>
         DataType doInitialize(DataContext& context, FrameInfo const& frame,
@@ -83,14 +76,6 @@ namespace bq::signal
         {
             return (UpdateResult {} + ... + std::get<S>(sigs_).update(
                         context, std::get<S>(data.sigData), frame));
-        }
-
-        template <size_t... S>
-        void doObserve(DataContext& context, DataType& data,
-                ObserveCallback const& callback, std::index_sequence<S...>)
-        {
-            (std::get<S>(sigs_).observe(
-                        context, std::get<S>(data.sigData), callback), ...);
         }
 
     private:

--- a/src/bq/include/bq/signal/shared.h
+++ b/src/bq/include/bq/signal/shared.h
@@ -56,11 +56,10 @@ namespace bq::signal
             return impl_->update(context, data, frame);
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return impl_->observe(context, data, callback);
+            impl_->observe(context, data, std::move(callback));
         }
 
         Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> weak() const

--- a/src/bq/include/bq/signal/shared.h
+++ b/src/bq/include/bq/signal/shared.h
@@ -56,12 +56,6 @@ namespace bq::signal
             return impl_->update(context, data, frame);
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            impl_->observe(context, data, std::move(callback));
-        }
-
         Signal<Weak<Ts...>, std::optional<SignalResult<Ts const&...>>> weak() const
         {
             /*

--- a/src/bq/include/bq/signal/sharedcontrol.h
+++ b/src/bq/include/bq/signal/sharedcontrol.h
@@ -26,8 +26,6 @@ namespace bq::signal
                 BaseDataType const& data) = 0;
         virtual UpdateResult baseUpdate(DataContext& context, BaseDataType& data,
                 FrameInfo const& frame) = 0;
-        virtual void baseObserve(DataContext& context, BaseDataType& data,
-                ObserveCallback callback) = 0;
     };
 
     template <typename TStorage, typename... Ts>
@@ -128,14 +126,6 @@ namespace bq::signal
             return update(context, static_cast<DataType&>(data), frame);
         }
 
-        void baseObserve(DataContext& context,
-                typename Super::BaseDataType& data,
-                ObserveCallback callback) override
-        {
-            observe(context, static_cast<DataType&>(data),
-                    std::move(callback));
-        }
-
         SharedControl(StorageType sig) :
             id_(makeUniqueId()),
             sig_(std::move(sig))
@@ -197,15 +187,6 @@ namespace bq::signal
                 data.value = contextData->currentValue;
 
             return contextData->updateResult;
-        }
-
-        void observe(DataContext& context, DataType& data, ObserveCallback callback)
-        {
-            if (ContextDataType* contextData = data.lock())
-            {
-                std::unique_lock lock(contextData->mutex_);
-                sig_.observe(context, contextData->innerData, std::move(callback));
-            }
         }
 
     private:

--- a/src/bq/include/bq/signal/sharedcontrol.h
+++ b/src/bq/include/bq/signal/sharedcontrol.h
@@ -5,8 +5,6 @@
 #include "frameinfo.h"
 #include "datacontext.h"
 
-#include <btl/connection.h>
-
 #include <cstdint>
 #include <mutex>
 
@@ -28,8 +26,8 @@ namespace bq::signal
                 BaseDataType const& data) = 0;
         virtual UpdateResult baseUpdate(DataContext& context, BaseDataType& data,
                 FrameInfo const& frame) = 0;
-        virtual btl::connection baseObserve(DataContext& context, BaseDataType& data,
-                std::function<void()> callback) = 0;
+        virtual void baseObserve(DataContext& context, BaseDataType& data,
+                ObserveCallback callback) = 0;
     };
 
     template <typename TStorage, typename... Ts>
@@ -130,11 +128,11 @@ namespace bq::signal
             return update(context, static_cast<DataType&>(data), frame);
         }
 
-        btl::connection baseObserve(DataContext& context,
+        void baseObserve(DataContext& context,
                 typename Super::BaseDataType& data,
-                std::function<void()> callback) override
+                ObserveCallback callback) override
         {
-            return observe(context, static_cast<DataType&>(data),
+            observe(context, static_cast<DataType&>(data),
                     std::move(callback));
         }
 
@@ -201,16 +199,13 @@ namespace bq::signal
             return contextData->updateResult;
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data, TCallback&& callback)
+        void observe(DataContext& context, DataType& data, ObserveCallback callback)
         {
             if (ContextDataType* contextData = data.lock())
             {
                 std::unique_lock lock(contextData->mutex_);
-                return sig_.observe(context, contextData->innerData, callback);
+                sig_.observe(context, contextData->innerData, std::move(callback));
             }
-
-            return {};
         }
 
     private:

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -83,7 +83,7 @@ namespace bq::signal
          * it must be safe to call from any thread. */
         void observe(std::function<void()> callback)
         {
-            dataContext_.observe(std::move(callback));
+            dataContext_.setObserveCallback(std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -72,8 +72,15 @@ namespace bq::signal
         }
 
         /** Arms a wakeup for external changes to any leaf this context reaches.
-         * The callback fires without the graph being evaluated. It stays armed
-         * for the context's lifetime. */
+         *
+         * The callback fires without the graph being evaluated. It is a wakeup,
+         * not a change count: it may be called more than once per update cycle
+         * -- once per external change, and more than once for a single change
+         * that reaches the context through separate routes (an unshared
+         * diamond). So it must be cheap and safe to run repeatedly; the intended
+         * use is to schedule an already-throttled repaint. It stays armed for
+         * the context's lifetime and runs on the thread that made the change, so
+         * it must be safe to call from any thread. */
         void observe(std::function<void()> callback)
         {
             dataContext_.observe(std::move(callback));

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -71,25 +71,12 @@ namespace bq::signal
             return false;
         }
 
-        /** Registers a wakeup for an external change to any of the context's
-         * signals. The callback fires when a source outside the graph changes a
-         * leaf, without the graph being evaluated. The returned guard scopes the
-         * registration: drop it to unregister. */
-        template <typename TCallback>
-        ObserveGuard observe(TCallback&& callback)
+        /** Arms a wakeup for external changes to any leaf this context reaches.
+         * The callback fires without the graph being evaluated. It stays armed
+         * for the context's lifetime. */
+        void observe(std::function<void()> callback)
         {
-            auto guard = makeObserveGuard();
-            observe(guard, std::forward<TCallback>(callback));
-            return guard;
-        }
-
-        /** Registers a wakeup under a caller-owned guard, so several observes
-         * can share one lifetime. The registration lives while the guard does. */
-        template <typename TCallback>
-        void observe(ObserveGuard const& guard, TCallback&& callback)
-        {
-            observeImpl(ObserveCallback(guard, std::forward<TCallback>(callback)),
-                    std::index_sequence_for<TSignals...>{});
+            dataContext_.observe(std::move(callback));
         }
 
     private:
@@ -134,14 +121,6 @@ namespace bq::signal
             UpdateResult result = (UpdateResult{} + ... + updateEntry<Is>(frame));
             dataContext_.swapFrameData();
             return result;
-        }
-
-        // The callback is copied into each leaf.
-        template <size_t... Is>
-        void observeImpl(ObserveCallback const& callback, std::index_sequence<Is...>)
-        {
-            (std::get<Is>(signals_).unwrap().observe(
-                    dataContext_, std::get<Is>(data_), callback), ...);
         }
 
         // evaluate() must be usable on a const SignalContext, but the signal

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -4,8 +4,6 @@
 #include "datacontext.h"
 #include "signaltraits.h"
 
-#include <btl/connection.h>
-
 #include <tuple>
 #include <array>
 #include <cstddef>
@@ -75,12 +73,22 @@ namespace bq::signal
 
         /** Registers a wakeup for an external change to any of the context's
          * signals. The callback fires when a source outside the graph changes a
-         * leaf, without the graph being evaluated; the returned connection
-         * unregisters it. */
+         * leaf, without the graph being evaluated. The returned guard scopes the
+         * registration: drop it to unregister. */
         template <typename TCallback>
-        btl::connection observe(TCallback&& callback)
+        ObserveGuard observe(TCallback&& callback)
         {
-            return observeImpl(std::forward<TCallback>(callback),
+            auto guard = makeObserveGuard();
+            observe(guard, std::forward<TCallback>(callback));
+            return guard;
+        }
+
+        /** Registers a wakeup under a caller-owned guard, so several observes
+         * can share one lifetime. The registration lives while the guard does. */
+        template <typename TCallback>
+        void observe(ObserveGuard const& guard, TCallback&& callback)
+        {
+            observeImpl(ObserveCallback(guard, std::forward<TCallback>(callback)),
                     std::index_sequence_for<TSignals...>{});
         }
 
@@ -128,15 +136,12 @@ namespace bq::signal
             return result;
         }
 
-        // The callback is copied into each leaf, so it is passed as an lvalue
-        // rather than moved into the fold.
-        template <typename TCallback, size_t... Is>
-        btl::connection observeImpl(TCallback&& callback, std::index_sequence<Is...>)
+        // The callback is copied into each leaf.
+        template <size_t... Is>
+        void observeImpl(ObserveCallback const& callback, std::index_sequence<Is...>)
         {
-            btl::connection c;
-            ((c += std::get<Is>(signals_).unwrap().observe(
-                    dataContext_, std::get<Is>(data_), callback)), ...);
-            return c;
+            (std::get<Is>(signals_).unwrap().observe(
+                    dataContext_, std::get<Is>(data_), callback), ...);
         }
 
         // evaluate() must be usable on a const SignalContext, but the signal

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -4,6 +4,8 @@
 #include "datacontext.h"
 #include "signaltraits.h"
 
+#include <btl/connection.h>
+
 #include <tuple>
 #include <array>
 #include <cstddef>
@@ -71,6 +73,17 @@ namespace bq::signal
             return false;
         }
 
+        /** Registers a wakeup for an external change to any of the context's
+         * signals. The callback fires when a source outside the graph changes a
+         * leaf, without the graph being evaluated; the returned connection
+         * unregisters it. */
+        template <typename TCallback>
+        btl::connection observe(TCallback&& callback)
+        {
+            return observeImpl(std::forward<TCallback>(callback),
+                    std::index_sequence_for<TSignals...>{});
+        }
+
     private:
         template <size_t... Is>
         std::tuple<SignalDataTypeT<TSignals>...> initializeData(
@@ -113,6 +126,17 @@ namespace bq::signal
             UpdateResult result = (UpdateResult{} + ... + updateEntry<Is>(frame));
             dataContext_.swapFrameData();
             return result;
+        }
+
+        // The callback is copied into each leaf, so it is passed as an lvalue
+        // rather than moved into the fold.
+        template <typename TCallback, size_t... Is>
+        btl::connection observeImpl(TCallback&& callback, std::index_sequence<Is...>)
+        {
+            btl::connection c;
+            ((c += std::get<Is>(signals_).unwrap().observe(
+                    dataContext_, std::get<Is>(data_), callback)), ...);
+            return c;
         }
 
         // evaluate() must be usable on a const SignalContext, but the signal

--- a/src/bq/include/bq/signal/signalcontext.h
+++ b/src/bq/include/bq/signal/signalcontext.h
@@ -78,9 +78,11 @@ namespace bq::signal
          * -- once per external change, and more than once for a single change
          * that reaches the context through separate routes (an unshared
          * diamond). So it must be cheap and safe to run repeatedly; the intended
-         * use is to schedule an already-throttled repaint. It stays armed for
-         * the context's lifetime and runs on the thread that made the change, so
-         * it must be safe to call from any thread. */
+         * use is to schedule an already-throttled repaint. The callback must not
+         * retain a strong reference back into this context's signal graph, since
+         * the graph holds the wakeup. It stays armed for the context's lifetime
+         * and runs on the thread that made the change, so it must be safe to call
+         * from any thread. */
         void observe(std::function<void()> callback)
         {
             dataContext_.setObserveCallback(std::move(callback));

--- a/src/bq/include/bq/signal/signaltraits.h
+++ b/src/bq/include/bq/signal/signaltraits.h
@@ -5,7 +5,6 @@
 #include "signalresult.h"
 #include "datacontext.h"
 
-#include <btl/connection.h>
 #include <btl/cloneoncopy.h>
 #include <btl/all.h>
 #include <btl/typetraits.h>
@@ -40,7 +39,7 @@ namespace bq::signal
             std::declval<std::decay_t<T>>().observe(
                 std::declval<DataContext&>(),
                 std::declval<std::decay_t<initialize_t<T>>&>(),
-                std::function<void()>()
+                ObserveCallback()
                 )
             );
 
@@ -55,7 +54,7 @@ namespace bq::signal
         observe_t<T>
         >> : btl::All<
             std::is_same<UpdateResult, update_t<T>>,
-            std::is_same<btl::connection, observe_t<T>>,
+            std::is_same<void, observe_t<T>>,
             std::is_nothrow_move_constructible<std::decay_t<T>>,
             std::is_copy_constructible<std::decay_t<T>>,
             std::is_copy_assignable<std::decay_t<T>>
@@ -66,7 +65,7 @@ namespace bq::signal
     {
         static_assert(IsSignalResult<std::decay_t<evaluate_t<T>>>::value);
         static_assert(std::is_same_v<UpdateResult, update_t<T>>);
-        static_assert(std::is_same_v<btl::connection, observe_t<T>>);
+        static_assert(std::is_same_v<void, observe_t<T>>);
         static_assert(std::is_nothrow_move_constructible_v<std::decay_t<T>>);
         static_assert(std::is_copy_constructible_v<std::decay_t<T>>);
         static_assert(std::is_copy_assignable_v<std::decay_t<T>>);

--- a/src/bq/include/bq/signal/signaltraits.h
+++ b/src/bq/include/bq/signal/signaltraits.h
@@ -34,15 +34,6 @@ namespace bq::signal
                 std::declval<FrameInfo const>())
             );
 
-    template <typename T>
-    using observe_t = decltype(
-            std::declval<std::decay_t<T>>().observe(
-                std::declval<DataContext&>(),
-                std::declval<std::decay_t<initialize_t<T>>&>(),
-                ObserveCallback()
-                )
-            );
-
     template <typename T, typename = void>
     struct CheckSignal : std::false_type {};
 
@@ -50,11 +41,9 @@ namespace bq::signal
     struct CheckSignal<T, btl::void_t<
         initialize_t<T>,
         evaluate_t<T>,
-        update_t<T>,
-        observe_t<T>
+        update_t<T>
         >> : btl::All<
             std::is_same<UpdateResult, update_t<T>>,
-            std::is_same<void, observe_t<T>>,
             std::is_nothrow_move_constructible<std::decay_t<T>>,
             std::is_copy_constructible<std::decay_t<T>>,
             std::is_copy_assignable<std::decay_t<T>>
@@ -65,7 +54,6 @@ namespace bq::signal
     {
         static_assert(IsSignalResult<std::decay_t<evaluate_t<T>>>::value);
         static_assert(std::is_same_v<UpdateResult, update_t<T>>);
-        static_assert(std::is_same_v<void, observe_t<T>>);
         static_assert(std::is_nothrow_move_constructible_v<std::decay_t<T>>);
         static_assert(std::is_copy_constructible_v<std::decay_t<T>>);
         static_assert(std::is_copy_assignable_v<std::decay_t<T>>);

--- a/src/bq/include/bq/signal/typed.h
+++ b/src/bq/include/bq/signal/typed.h
@@ -32,8 +32,6 @@ namespace bq::signal
                 DataBase const& data) const = 0;
         virtual UpdateResult update(DataContext& context, DataBase& data,
                 FrameInfo const& frame) = 0;
-        virtual void observe(DataContext& context, DataBase& data,
-                ObserveCallback callback) = 0;
     };
 
     template <typename TStorage, typename... Ts>
@@ -74,12 +72,6 @@ namespace bq::signal
                 FrameInfo const& frame) override
         {
             return sig_.update(context, getStorageData(baseData), frame);
-        }
-
-        void observe(DataContext& context, BaseDataType& data,
-                ObserveCallback callback) override
-        {
-            sig_.observe(context, getStorageData(data), std::move(callback));
         }
 
     private:
@@ -128,12 +120,6 @@ namespace bq::signal
                 FrameInfo const& frame)
         {
             return sig_->update(context, *data.data, frame);
-        }
-
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_->observe(context, *data.data, std::move(callback));
         }
 
         template <typename... Us, typename = std::enable_if_t<

--- a/src/bq/include/bq/signal/typed.h
+++ b/src/bq/include/bq/signal/typed.h
@@ -6,8 +6,6 @@
 #include "signaltraits.h"
 #include "datacontext.h"
 
-#include <btl/connection.h>
-
 #include <memory>
 
 namespace bq::signal
@@ -34,8 +32,8 @@ namespace bq::signal
                 DataBase const& data) const = 0;
         virtual UpdateResult update(DataContext& context, DataBase& data,
                 FrameInfo const& frame) = 0;
-        virtual btl::connection observe(DataContext& context, DataBase& data,
-                std::function<void()> callback) = 0;
+        virtual void observe(DataContext& context, DataBase& data,
+                ObserveCallback callback) = 0;
     };
 
     template <typename TStorage, typename... Ts>
@@ -78,10 +76,10 @@ namespace bq::signal
             return sig_.update(context, getStorageData(baseData), frame);
         }
 
-        btl::connection observe(DataContext& context, BaseDataType& data,
-                std::function<void()> callback) override
+        void observe(DataContext& context, BaseDataType& data,
+                ObserveCallback callback) override
         {
-            return sig_.observe(context, getStorageData(data), std::move(callback));
+            sig_.observe(context, getStorageData(data), std::move(callback));
         }
 
     private:
@@ -132,11 +130,10 @@ namespace bq::signal
             return sig_->update(context, *data.data, frame);
         }
 
-        template <typename TCallback>
-        btl::connection observe(DataContext& context, DataType& data,
-                TCallback&& callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return sig_->observe(context, *data.data, std::forward<TCallback>(callback));
+            sig_->observe(context, *data.data, std::move(callback));
         }
 
         template <typename... Us, typename = std::enable_if_t<

--- a/src/bq/include/bq/signal/updateresult.h
+++ b/src/bq/include/bq/signal/updateresult.h
@@ -9,25 +9,12 @@ namespace bq::signal
     using signal_time_t = std::chrono::microseconds;
     struct UpdateResult
     {
-        std::optional<signal_time_t> nextUpdate;
         bool didChange = false;
     };
-
-    inline std::optional<signal_time_t> min(std::optional<signal_time_t> const& l,
-            std::optional<signal_time_t> const& r)
-    {
-        if (l.has_value() && r.has_value())
-            return std::min(*l, *r);
-        else if (r.has_value())
-            return r;
-        else
-            return l;
-    }
 
     inline UpdateResult operator+(UpdateResult const& a, UpdateResult const& b)
     {
         return {
-            min(a.nextUpdate, b.nextUpdate),
             a.didChange || b.didChange
         };
     }

--- a/src/bq/include/bq/signal/weak.h
+++ b/src/bq/include/bq/signal/weak.h
@@ -96,14 +96,6 @@ namespace bq::signal
             return { data.contextData->nextUpdate, data.contextData->didChange };
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            if (auto control = control_.lock())
-                control->baseObserve(context,
-                        *data.contextData->innerData, std::move(callback));
-        }
-
     private:
         btl::UniqueId id_;
         std::weak_ptr<SharedControlBase<Ts...>> control_;

--- a/src/bq/include/bq/signal/weak.h
+++ b/src/bq/include/bq/signal/weak.h
@@ -96,14 +96,12 @@ namespace bq::signal
             return { data.contextData->nextUpdate, data.contextData->didChange };
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
             if (auto control = control_.lock())
-                return control->baseObserve(context,
+                control->baseObserve(context,
                         *data.contextData->innerData, std::move(callback));
-
-            return {};
         }
 
     private:

--- a/src/bq/include/bq/signal/weak.h
+++ b/src/bq/include/bq/signal/weak.h
@@ -28,7 +28,6 @@ namespace bq::signal
             SignalResult<Ts...> value;
             uint64_t frameId = 0;
             bool didChange = false;
-            std::optional<signal_time_t> nextUpdate;
         };
 
         struct DataType
@@ -80,20 +79,18 @@ namespace bq::signal
                             *data.contextData->innerData, frame);
                     data.contextData->value = control->baseEvaluate(context,
                             *data.contextData->innerData);
-                    data.contextData->nextUpdate = result.nextUpdate;
                     data.contextData->didChange = result.didChange;
                     return result;
                 }
                 else
                 {
-                    data.contextData->nextUpdate = std::nullopt;
                     data.contextData->didChange = false;
                 }
 
                 data.contextData->frameId = frame.getFrameId();
             }
 
-            return { data.contextData->nextUpdate, data.contextData->didChange };
+            return { data.contextData->didChange };
         }
 
     private:

--- a/src/bq/include/bq/signal/withchanged.h
+++ b/src/bq/include/bq/signal/withchanged.h
@@ -67,12 +67,6 @@ namespace bq::signal
             };
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_.observe(context, data.innerData, std::move(callback));
-        }
-
     private:
         TStorage sig_;
         bool ignoreChange_ = false;

--- a/src/bq/include/bq/signal/withchanged.h
+++ b/src/bq/include/bq/signal/withchanged.h
@@ -62,7 +62,6 @@ namespace bq::signal
             data.innerDidChange = r.didChange;
 
             return {
-                r.nextUpdate,
                 didChange
             };
         }

--- a/src/bq/include/bq/signal/withchanged.h
+++ b/src/bq/include/bq/signal/withchanged.h
@@ -67,10 +67,10 @@ namespace bq::signal
             };
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return sig_.observe(context, data.innerData, std::move(callback));
+            sig_.observe(context, data.innerData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/signal/withprevious.h
+++ b/src/bq/include/bq/signal/withprevious.h
@@ -110,12 +110,6 @@ namespace bq::signal
             return r;
         }
 
-        void observe(DataContext& context, DataType& data,
-                ObserveCallback callback)
-        {
-            sig_.observe(context, data.innerData, std::move(callback));
-        }
-
     private:
         btl::CopyWrapper<TFunc> func_;
         std::shared_ptr<FuncReturnType> initial_;

--- a/src/bq/include/bq/signal/withprevious.h
+++ b/src/bq/include/bq/signal/withprevious.h
@@ -110,10 +110,10 @@ namespace bq::signal
             return r;
         }
 
-        btl::connection observe(DataContext& context, DataType& data,
-                std::function<void()> callback)
+        void observe(DataContext& context, DataType& data,
+                ObserveCallback callback)
         {
-            return sig_.observe(context, data.innerData, std::move(callback));
+            sig_.observe(context, data.innerData, std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/stream/collect.h
+++ b/src/bq/include/bq/stream/collect.h
@@ -79,7 +79,7 @@ namespace bq::stream
             data.control->values.clear();
             std::swap(data.control->values, data.control->newValues);
 
-            return { {}, !data.control->values.empty() };
+            return { !data.control->values.empty() };
         }
 
     private:

--- a/src/bq/include/bq/stream/collect.h
+++ b/src/bq/include/bq/stream/collect.h
@@ -13,7 +13,6 @@
 #include <btl/spinlock.h>
 #include <btl/shared.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <mutex>
 
@@ -28,7 +27,7 @@ namespace bq::stream
             std::mutex mutex;
             std::vector<T> newValues;
             std::vector<T> values;
-            std::vector<signal::ObserveCallback> callbacks;
+            std::weak_ptr<signal::ObserveControl> observe;
         };
 
         struct DataType
@@ -42,24 +41,23 @@ namespace bq::stream
         {
         }
 
-        DataType initialize(signal::DataContext&, signal::FrameInfo const&) const
+        DataType initialize(signal::DataContext& context,
+                signal::FrameInfo const&) const
         {
             auto control = std::make_shared<Control>();
+            control->observe = context.observeControl();
             return {
                 control,
                 stream_.fmap([control](auto value)
                     {
-                        decltype(control->callbacks) callbacks;
-
+                        std::weak_ptr<signal::ObserveControl> observe;
                         {
-                            std::unique_lock lock(control->mutex);
+                            std::unique_lock<std::mutex> lock(control->mutex);
                             control->newValues.push_back(std::move(value));
-                            std::swap(callbacks, control->callbacks);
+                            observe = control->observe;
                         }
-
-                        for (auto&& cb : callbacks)
-                            cb();
-
+                        if (auto c = observe.lock())
+                            c->fire();
                         return true;
                     })
             };
@@ -82,18 +80,6 @@ namespace bq::stream
             std::swap(data.control->values, data.control->newValues);
 
             return { {}, !data.control->values.empty() };
-        }
-
-        void observe(signal::DataContext&, DataType& data,
-                signal::ObserveCallback callback)
-        {
-            std::unique_lock lock(data.control->mutex);
-
-            auto& cbs = data.control->callbacks;
-            cbs.erase(std::remove_if(cbs.begin(), cbs.end(),
-                    [](signal::ObserveCallback const& cb) { return !cb; }),
-                    cbs.end());
-            cbs.push_back(std::move(callback));
         }
 
     private:

--- a/src/bq/include/bq/stream/collect.h
+++ b/src/bq/include/bq/stream/collect.h
@@ -27,7 +27,7 @@ namespace bq::stream
             std::mutex mutex;
             std::vector<T> newValues;
             std::vector<T> values;
-            std::weak_ptr<signal::ObserveControl> observe;
+            std::shared_ptr<signal::ObserveControl> observe;
         };
 
         struct DataType
@@ -50,14 +50,14 @@ namespace bq::stream
                 control,
                 stream_.fmap([control](auto value)
                     {
-                        std::weak_ptr<signal::ObserveControl> observe;
+                        std::shared_ptr<signal::ObserveControl> observe;
                         {
                             std::unique_lock<std::mutex> lock(control->mutex);
                             control->newValues.push_back(std::move(value));
                             observe = control->observe;
                         }
-                        if (auto c = observe.lock())
-                            c->fire();
+                        if (observe)
+                            observe->fire();
                         return true;
                     })
             };

--- a/src/bq/include/bq/stream/collect.h
+++ b/src/bq/include/bq/stream/collect.h
@@ -13,6 +13,7 @@
 #include <btl/spinlock.h>
 #include <btl/shared.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <mutex>
 
@@ -27,8 +28,7 @@ namespace bq::stream
             std::mutex mutex;
             std::vector<T> newValues;
             std::vector<T> values;
-            std::vector<std::pair<uint64_t, std::function<void()>>> callbacks;
-            uint64_t nextId = 1;
+            std::vector<signal::ObserveCallback> callbacks;
         };
 
         struct DataType
@@ -58,7 +58,7 @@ namespace bq::stream
                         }
 
                         for (auto&& cb : callbacks)
-                            std::move(cb.second)();
+                            cb();
 
                         return true;
                     })
@@ -84,31 +84,16 @@ namespace bq::stream
             return { {}, !data.control->values.empty() };
         }
 
-        btl::connection observe(signal::DataContext&, DataType& data,
-                std::function<void()> callback)
+        void observe(signal::DataContext&, DataType& data,
+                signal::ObserveCallback callback)
         {
             std::unique_lock lock(data.control->mutex);
-            auto id = data.control->nextId++;
 
-            data.control->callbacks.emplace_back(id, callback);
-
-            std::weak_ptr<Control> weakControl = data.control;
-
-            return btl::connection::on_disconnect([id, weakControl]()
-                {
-                    if (auto control = weakControl.lock())
-                    {
-                        for (auto i = control->callbacks.begin();
-                                i != control->callbacks.end(); ++i)
-                        {
-                            if (id == i->first)
-                            {
-                                control->callbacks.erase(i);
-                                break;
-                            }
-                        }
-                    }
-                });
+            auto& cbs = data.control->callbacks;
+            cbs.erase(std::remove_if(cbs.begin(), cbs.end(),
+                    [](signal::ObserveCallback const& cb) { return !cb; }),
+                    cbs.end());
+            cbs.push_back(std::move(callback));
         }
 
     private:

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -19,6 +19,7 @@ libbqdep = declare_dependency(
 bqtest = executable('bqtest',
   'test/arraysignaltest.cpp',
   'test/datacontexttest.cpp',
+  'test/observetest.cpp',
   'test/picktest.cpp',
   'test/sharedvectortest.cpp',
   'test/signaltest.cpp',

--- a/src/bq/test/observetest.cpp
+++ b/src/bq/test/observetest.cpp
@@ -1,0 +1,463 @@
+#include <bq/stream/collect.h>
+#include <bq/stream/pipe.h>
+
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+#include <bq/signal/datacontext.h>
+#include <bq/signal/constant.h>
+#include <bq/signal/merge.h>
+#include <bq/signal/combine.h>
+#include <bq/signal/input.h>
+#include <bq/signal/arraysignal.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace bq;
+using namespace bq::signal;
+using namespace bq::stream;
+
+// observe() registers a callback on every leaf that an external source can wake,
+// so that the wake fires immediately without evaluating the graph. Nothing in
+// the toolkit drives observe today; these tests pin the mechanism down by
+// driving the signal impls directly, exactly as SignalContext does internally.
+
+namespace
+{
+    // Initializes a signal impl into a context and returns its DataType, with
+    // the frame data swapped once as a live context does after construction.
+    // The signal is passed by lvalue because observe() needs the non-const
+    // unwrap().
+    template <typename TSignal>
+    auto initialize(DataContext& ctx, TSignal& sig)
+    {
+        auto data = sig.unwrap().initialize(ctx, FrameInfo(0, {}));
+        ctx.swapFrameData();
+        return data;
+    }
+} // namespace
+
+// A collect leaf fires its observer exactly once, synchronously, when the
+// stream emits.
+TEST(Observe, collectLeafFires)
+{
+    auto p = pipe<int>();
+    auto sig = collect(std::move(p.stream));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    EXPECT_FALSE(fired);
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
+}
+
+// The wake does not evaluate the graph: the pushed value is not visible through
+// evaluate() until an update() swaps it into the current values.
+TEST(Observe, wakeDoesNotEvaluate)
+{
+    auto p = pipe<int>();
+    auto sig = collect(std::move(p.stream));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
+
+    // The observer fired, but the value is still only pending: evaluate() sees
+    // nothing until update() moves it across.
+    EXPECT_TRUE(sig.unwrap().evaluate(ctx, data).get<0>().empty());
+
+    sig.unwrap().update(ctx, data, FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 42 }), sig.unwrap().evaluate(ctx, data).get<0>());
+}
+
+// observe is one-shot: firing consumes the callback, so a second emission wakes
+// nothing until the observer is re-armed by observing again.
+TEST(Observe, collectIsOneShot)
+{
+    auto p = pipe<int>();
+    auto sig = collect(std::move(p.stream));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    int count = 0;
+    auto c1 = sig.unwrap().observe(ctx, data, [&] { ++count; });
+
+    p.handle.push(1);
+    EXPECT_EQ(1, count);
+
+    // Not re-armed: the callback list was cleared as it fired.
+    p.handle.push(2);
+    EXPECT_EQ(1, count);
+
+    // Re-arming makes it fire again.
+    auto c2 = sig.unwrap().observe(ctx, data, [&] { ++count; });
+    p.handle.push(3);
+    EXPECT_EQ(2, count);
+}
+
+// Disconnecting the returned connection unregisters the callback before it can
+// fire.
+TEST(Observe, disconnectStopsFiring)
+{
+    auto p = pipe<int>();
+    auto sig = collect(std::move(p.stream));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    conn.disconnect();
+
+    p.handle.push(42);
+    EXPECT_FALSE(fired);
+}
+
+// map forwards observe to its single upstream, so an external change at the leaf
+// still wakes the observer through the mapped node.
+TEST(Observe, throughMap)
+{
+    auto p = pipe<int>();
+    auto sig = collect(std::move(p.stream)).map(
+            [](std::vector<int> const& v) { return v.size(); });
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    p.handle.push(7);
+    EXPECT_TRUE(fired);
+}
+
+// merge observes all of its children: a change in either leaf wakes the
+// observer, once per external change.
+TEST(Observe, throughMerge)
+{
+    auto pa = pipe<int>();
+    auto pb = pipe<int>();
+    auto sig = merge(collect(std::move(pa.stream)), collect(std::move(pb.stream)));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    // A single observe connects both children. Each child is an independent
+    // one-shot: pushing the first fires and disarms only its own leaf, leaving
+    // the second still armed to fire on its push. So each external change fires
+    // exactly once.
+    int count = 0;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { ++count; });
+
+    pa.handle.push(1);
+    EXPECT_EQ(1, count);
+
+    pb.handle.push(2);
+    EXPECT_EQ(2, count);
+}
+
+// combine observes every child leaf.
+TEST(Observe, throughCombine)
+{
+    auto pa = pipe<int>();
+    auto pb = pipe<int>();
+
+    std::vector<AnySignal<std::vector<int>>> children;
+    children.push_back(collect(std::move(pa.stream)).eraseType());
+    children.push_back(collect(std::move(pb.stream)).eraseType());
+    auto sig = combine(std::move(children));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool firedA = false;
+    auto connA = sig.unwrap().observe(ctx, data, [&] { firedA = true; });
+    pa.handle.push(1);
+    EXPECT_TRUE(firedA);
+
+    bool firedB = false;
+    auto connB = sig.unwrap().observe(ctx, data, [&] { firedB = true; });
+    pb.handle.push(2);
+    EXPECT_TRUE(firedB);
+}
+
+// A conditional observes its condition and only the currently active branch;
+// the inactive branch's leaf is not connected. Switching the condition and
+// re-observing rewires onto the newly active branch.
+TEST(Observe, throughConditional)
+{
+    auto pt = pipe<int>();
+    auto pf = pipe<int>();
+    auto cond = makeInput<bool>(true);
+
+    auto sig = cond.signal.conditional(
+            collect(std::move(pt.stream)),
+            collect(std::move(pf.stream)));
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    // Active branch is the true branch: it fires, the inactive false branch
+    // does not (it is neither initialized nor observed).
+    bool firedTrue = false;
+    bool firedFalse = false;
+    auto conn = sig.unwrap().observe(ctx, data,
+            [&] { firedTrue = true; });
+    pt.handle.push(1);
+    pf.handle.push(2);
+    EXPECT_TRUE(firedTrue);
+    EXPECT_FALSE(firedFalse);
+
+    // Switch the active branch and drive an update so the conditional swaps in
+    // the false branch's data.
+    conn.disconnect();
+    cond.handle.set(false);
+    sig.unwrap().update(ctx, data, FrameInfo(1, {}));
+
+    // Re-observing now registers on the false branch.
+    auto conn2 = sig.unwrap().observe(ctx, data,
+            [&] { firedFalse = true; });
+    pf.handle.push(3);
+    EXPECT_TRUE(firedFalse);
+}
+
+// join observes both the outer signal and the current inner signal, so an
+// external change reachable through the inner signal wakes the observer.
+TEST(Observe, throughJoin)
+{
+    auto p = pipe<int>();
+    auto inner = collect(std::move(p.stream));
+    auto sig = constant(inner).join();
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
+}
+
+// join(ArraySignal) observes each element that is present when observe is
+// called, so an external change at an element's leaf wakes the observer.
+TEST(Observe, throughArrayJoin)
+{
+    auto p = pipe<int>();
+    auto element = collect(std::move(p.stream)).eraseType();
+
+    ArraySignal<AnySignal<std::vector<int>>> array(std::move(element));
+    auto sig = join(array);
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
+}
+
+// A plain value input is an external leaf: observing it and then set()ting a new
+// value wakes the observer immediately, without evaluating the graph (the new
+// value is only visible through evaluate() after an update()).
+TEST(Observe, inputLeafFires)
+{
+    auto input = makeInput<int>(5);
+
+    DataContext ctx;
+    auto data = initialize(ctx, input.signal);
+
+    bool fired = false;
+    auto conn = input.signal.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    EXPECT_FALSE(fired);
+    input.handle.set(10);
+    EXPECT_TRUE(fired);
+
+    // The wake did not evaluate: the value is still the old one until update().
+    EXPECT_EQ(5, input.signal.unwrap().evaluate(ctx, data).get<0>());
+    input.signal.unwrap().update(ctx, data, FrameInfo(1, {}));
+    EXPECT_EQ(10, input.signal.unwrap().evaluate(ctx, data).get<0>());
+}
+
+// Input observe is one-shot too: a second set() wakes nothing until re-armed.
+TEST(Observe, inputIsOneShot)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx;
+    auto data = initialize(ctx, input.signal);
+
+    int count = 0;
+    auto c1 = input.signal.unwrap().observe(ctx, data, [&] { ++count; });
+
+    input.handle.set(1);
+    EXPECT_EQ(1, count);
+
+    input.handle.set(2);
+    EXPECT_EQ(1, count);
+
+    auto c2 = input.signal.unwrap().observe(ctx, data, [&] { ++count; });
+    input.handle.set(3);
+    EXPECT_EQ(2, count);
+}
+
+// Disconnecting an input observer unregisters it before set() can wake it.
+TEST(Observe, inputDisconnectStops)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx;
+    auto data = initialize(ctx, input.signal);
+
+    bool fired = false;
+    auto conn = input.signal.unwrap().observe(ctx, data, [&] { fired = true; });
+    conn.disconnect();
+
+    input.handle.set(1);
+    EXPECT_FALSE(fired);
+}
+
+// The input leaf wakes through a combinator as well: a set() at the input wakes
+// an observer registered on the mapped node.
+TEST(Observe, inputThroughMap)
+{
+    auto input = makeInput<int>(1);
+    auto sig = input.signal.map([](int n) { return n * 2; });
+
+    DataContext ctx;
+    auto data = initialize(ctx, sig);
+
+    bool fired = false;
+    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+
+    input.handle.set(4);
+    EXPECT_TRUE(fired);
+}
+
+// ---------------------------------------------------------------------------
+// SignalContext::observe -- the public entry point, registering a wakeup
+// across every signal the context holds.
+// ---------------------------------------------------------------------------
+
+// A context over a collect leaf: observe() wakes on a stream emission, and the
+// wake does not evaluate -- the value is not visible via evaluate<0>() until an
+// update() applies it.
+TEST(SignalContextObserve, collectWakesWithoutEvaluating)
+{
+    auto p = pipe<int>();
+    auto c = makeSignalContext(collect(std::move(p.stream)));
+
+    bool fired = false;
+    auto conn = c.observe([&] { fired = true; });
+
+    EXPECT_FALSE(fired);
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
+
+    // The wake did not evaluate the graph: the value is still pending.
+    EXPECT_TRUE(c.evaluate<0>().get<0>().empty());
+
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ((std::vector<int>{ 42 }), c.evaluate<0>().get<0>());
+}
+
+// A context over a plain input leaf: observe() wakes on set(), exercising the
+// input observe fix through the public API.
+TEST(SignalContextObserve, inputWakesOnSet)
+{
+    auto input = makeInput<int>(5);
+    auto c = makeSignalContext(input.signal);
+
+    bool fired = false;
+    auto conn = c.observe([&] { fired = true; });
+
+    EXPECT_FALSE(fired);
+    input.handle.set(10);
+    EXPECT_TRUE(fired);
+}
+
+// The wakeup reaches leaves through combinators: a mapped input still wakes the
+// context observer on set().
+TEST(SignalContextObserve, throughMap)
+{
+    auto input = makeInput<int>(1);
+    auto c = makeSignalContext(input.signal.map([](int n) { return n * 2; }));
+
+    bool fired = false;
+    auto conn = c.observe([&] { fired = true; });
+
+    input.handle.set(4);
+    EXPECT_TRUE(fired);
+}
+
+// observe() registers across every signal the context holds, so a change in
+// either of two independent leaves wakes the observer.
+TEST(SignalContextObserve, acrossAllSignals)
+{
+    auto pa = pipe<int>();
+    auto pb = pipe<int>();
+    auto c = makeSignalContext(
+            collect(std::move(pa.stream)),
+            collect(std::move(pb.stream)));
+
+    int count = 0;
+    auto conn = c.observe([&] { ++count; });
+
+    pa.handle.push(1);
+    EXPECT_EQ(1, count);
+
+    pb.handle.push(2);
+    EXPECT_EQ(2, count);
+}
+
+// The wakeup is one-shot: after firing, a second change does nothing until the
+// context is observed again.
+TEST(SignalContextObserve, isOneShot)
+{
+    auto input = makeInput<int>(0);
+    auto c = makeSignalContext(input.signal);
+
+    int count = 0;
+    auto conn = c.observe([&] { ++count; });
+
+    input.handle.set(1);
+    EXPECT_EQ(1, count);
+
+    // Not re-armed.
+    input.handle.set(2);
+    EXPECT_EQ(1, count);
+
+    // Re-arming makes it fire again.
+    auto conn2 = c.observe([&] { ++count; });
+    input.handle.set(3);
+    EXPECT_EQ(2, count);
+}
+
+// Dropping the returned connection unregisters the wakeup before the change.
+TEST(SignalContextObserve, disconnectStopsFiring)
+{
+    auto p = pipe<int>();
+    auto c = makeSignalContext(collect(std::move(p.stream)));
+
+    bool fired = false;
+    {
+        auto conn = c.observe([&] { fired = true; });
+    }
+
+    p.handle.push(42);
+    EXPECT_FALSE(fired);
+}

--- a/src/bq/test/observetest.cpp
+++ b/src/bq/test/observetest.cpp
@@ -18,10 +18,11 @@ using namespace bq;
 using namespace bq::signal;
 using namespace bq::stream;
 
-// observe() registers a callback on every leaf that an external source can wake,
-// so that the wake fires immediately without evaluating the graph. Nothing in
-// the toolkit drives observe today; these tests pin the mechanism down by
-// driving the signal impls directly, exactly as SignalContext does internally.
+// observe() registers a wakeup on every leaf that an external source can wake,
+// so the wake fires immediately without evaluating the graph. The registration
+// is scoped by a guard: it fires while the guard is alive and stops once the
+// guard drops. These tests drive the signal impls directly, exactly as
+// SignalContext does internally, pairing each callback with a guard by hand.
 
 namespace
 {
@@ -49,7 +50,8 @@ TEST(Observe, collectLeafFires)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     EXPECT_FALSE(fired);
     p.handle.push(42);
@@ -67,7 +69,8 @@ TEST(Observe, wakeDoesNotEvaluate)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     p.handle.push(42);
     EXPECT_TRUE(fired);
@@ -91,7 +94,8 @@ TEST(Observe, collectIsOneShot)
     auto data = initialize(ctx, sig);
 
     int count = 0;
-    auto c1 = sig.unwrap().observe(ctx, data, [&] { ++count; });
+    auto g1 = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(g1, [&] { ++count; }));
 
     p.handle.push(1);
     EXPECT_EQ(1, count);
@@ -101,14 +105,14 @@ TEST(Observe, collectIsOneShot)
     EXPECT_EQ(1, count);
 
     // Re-arming makes it fire again.
-    auto c2 = sig.unwrap().observe(ctx, data, [&] { ++count; });
+    auto g2 = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(g2, [&] { ++count; }));
     p.handle.push(3);
     EXPECT_EQ(2, count);
 }
 
-// Disconnecting the returned connection unregisters the callback before it can
-// fire.
-TEST(Observe, disconnectStopsFiring)
+// Dropping the guard unregisters the callback before it can fire.
+TEST(Observe, guardDropStopsFiring)
 {
     auto p = pipe<int>();
     auto sig = collect(std::move(p.stream));
@@ -117,8 +121,9 @@ TEST(Observe, disconnectStopsFiring)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
-    conn.disconnect();
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    guard.reset();
 
     p.handle.push(42);
     EXPECT_FALSE(fired);
@@ -136,7 +141,8 @@ TEST(Observe, throughMap)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     p.handle.push(7);
     EXPECT_TRUE(fired);
@@ -158,7 +164,8 @@ TEST(Observe, throughMerge)
     // the second still armed to fire on its push. So each external change fires
     // exactly once.
     int count = 0;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { ++count; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { ++count; }));
 
     pa.handle.push(1);
     EXPECT_EQ(1, count);
@@ -182,12 +189,14 @@ TEST(Observe, throughCombine)
     auto data = initialize(ctx, sig);
 
     bool firedA = false;
-    auto connA = sig.unwrap().observe(ctx, data, [&] { firedA = true; });
+    auto guardA = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guardA, [&] { firedA = true; }));
     pa.handle.push(1);
     EXPECT_TRUE(firedA);
 
     bool firedB = false;
-    auto connB = sig.unwrap().observe(ctx, data, [&] { firedB = true; });
+    auto guardB = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guardB, [&] { firedB = true; }));
     pb.handle.push(2);
     EXPECT_TRUE(firedB);
 }
@@ -212,8 +221,9 @@ TEST(Observe, throughConditional)
     // does not (it is neither initialized nor observed).
     bool firedTrue = false;
     bool firedFalse = false;
-    auto conn = sig.unwrap().observe(ctx, data,
-            [&] { firedTrue = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data,
+            ObserveCallback(guard, [&] { firedTrue = true; }));
     pt.handle.push(1);
     pf.handle.push(2);
     EXPECT_TRUE(firedTrue);
@@ -221,13 +231,14 @@ TEST(Observe, throughConditional)
 
     // Switch the active branch and drive an update so the conditional swaps in
     // the false branch's data.
-    conn.disconnect();
+    guard.reset();
     cond.handle.set(false);
     sig.unwrap().update(ctx, data, FrameInfo(1, {}));
 
     // Re-observing now registers on the false branch.
-    auto conn2 = sig.unwrap().observe(ctx, data,
-            [&] { firedFalse = true; });
+    auto guard2 = makeObserveGuard();
+    sig.unwrap().observe(ctx, data,
+            ObserveCallback(guard2, [&] { firedFalse = true; }));
     pf.handle.push(3);
     EXPECT_TRUE(firedFalse);
 }
@@ -244,7 +255,8 @@ TEST(Observe, throughJoin)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     p.handle.push(42);
     EXPECT_TRUE(fired);
@@ -264,7 +276,8 @@ TEST(Observe, throughArrayJoin)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     p.handle.push(42);
     EXPECT_TRUE(fired);
@@ -281,7 +294,9 @@ TEST(Observe, inputLeafFires)
     auto data = initialize(ctx, input.signal);
 
     bool fired = false;
-    auto conn = input.signal.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    input.signal.unwrap().observe(ctx, data,
+            ObserveCallback(guard, [&] { fired = true; }));
 
     EXPECT_FALSE(fired);
     input.handle.set(10);
@@ -302,7 +317,9 @@ TEST(Observe, inputIsOneShot)
     auto data = initialize(ctx, input.signal);
 
     int count = 0;
-    auto c1 = input.signal.unwrap().observe(ctx, data, [&] { ++count; });
+    auto g1 = makeObserveGuard();
+    input.signal.unwrap().observe(ctx, data,
+            ObserveCallback(g1, [&] { ++count; }));
 
     input.handle.set(1);
     EXPECT_EQ(1, count);
@@ -310,13 +327,15 @@ TEST(Observe, inputIsOneShot)
     input.handle.set(2);
     EXPECT_EQ(1, count);
 
-    auto c2 = input.signal.unwrap().observe(ctx, data, [&] { ++count; });
+    auto g2 = makeObserveGuard();
+    input.signal.unwrap().observe(ctx, data,
+            ObserveCallback(g2, [&] { ++count; }));
     input.handle.set(3);
     EXPECT_EQ(2, count);
 }
 
-// Disconnecting an input observer unregisters it before set() can wake it.
-TEST(Observe, inputDisconnectStops)
+// Dropping an input observer's guard unregisters it before set() can wake it.
+TEST(Observe, inputGuardDropStops)
 {
     auto input = makeInput<int>(0);
 
@@ -324,8 +343,10 @@ TEST(Observe, inputDisconnectStops)
     auto data = initialize(ctx, input.signal);
 
     bool fired = false;
-    auto conn = input.signal.unwrap().observe(ctx, data, [&] { fired = true; });
-    conn.disconnect();
+    auto guard = makeObserveGuard();
+    input.signal.unwrap().observe(ctx, data,
+            ObserveCallback(guard, [&] { fired = true; }));
+    guard.reset();
 
     input.handle.set(1);
     EXPECT_FALSE(fired);
@@ -342,7 +363,8 @@ TEST(Observe, inputThroughMap)
     auto data = initialize(ctx, sig);
 
     bool fired = false;
-    auto conn = sig.unwrap().observe(ctx, data, [&] { fired = true; });
+    auto guard = makeObserveGuard();
+    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
 
     input.handle.set(4);
     EXPECT_TRUE(fired);
@@ -350,7 +372,7 @@ TEST(Observe, inputThroughMap)
 
 // ---------------------------------------------------------------------------
 // SignalContext::observe -- the public entry point, registering a wakeup
-// across every signal the context holds.
+// across every signal the context holds and returning a guard that scopes it.
 // ---------------------------------------------------------------------------
 
 // A context over a collect leaf: observe() wakes on a stream emission, and the
@@ -362,7 +384,7 @@ TEST(SignalContextObserve, collectWakesWithoutEvaluating)
     auto c = makeSignalContext(collect(std::move(p.stream)));
 
     bool fired = false;
-    auto conn = c.observe([&] { fired = true; });
+    auto guard = c.observe([&] { fired = true; });
 
     EXPECT_FALSE(fired);
     p.handle.push(42);
@@ -383,7 +405,7 @@ TEST(SignalContextObserve, inputWakesOnSet)
     auto c = makeSignalContext(input.signal);
 
     bool fired = false;
-    auto conn = c.observe([&] { fired = true; });
+    auto guard = c.observe([&] { fired = true; });
 
     EXPECT_FALSE(fired);
     input.handle.set(10);
@@ -398,7 +420,7 @@ TEST(SignalContextObserve, throughMap)
     auto c = makeSignalContext(input.signal.map([](int n) { return n * 2; }));
 
     bool fired = false;
-    auto conn = c.observe([&] { fired = true; });
+    auto guard = c.observe([&] { fired = true; });
 
     input.handle.set(4);
     EXPECT_TRUE(fired);
@@ -415,7 +437,7 @@ TEST(SignalContextObserve, acrossAllSignals)
             collect(std::move(pb.stream)));
 
     int count = 0;
-    auto conn = c.observe([&] { ++count; });
+    auto guard = c.observe([&] { ++count; });
 
     pa.handle.push(1);
     EXPECT_EQ(1, count);
@@ -432,7 +454,7 @@ TEST(SignalContextObserve, isOneShot)
     auto c = makeSignalContext(input.signal);
 
     int count = 0;
-    auto conn = c.observe([&] { ++count; });
+    auto guard = c.observe([&] { ++count; });
 
     input.handle.set(1);
     EXPECT_EQ(1, count);
@@ -442,20 +464,20 @@ TEST(SignalContextObserve, isOneShot)
     EXPECT_EQ(1, count);
 
     // Re-arming makes it fire again.
-    auto conn2 = c.observe([&] { ++count; });
+    auto guard2 = c.observe([&] { ++count; });
     input.handle.set(3);
     EXPECT_EQ(2, count);
 }
 
-// Dropping the returned connection unregisters the wakeup before the change.
-TEST(SignalContextObserve, disconnectStopsFiring)
+// Dropping the returned guard unregisters the wakeup before the change.
+TEST(SignalContextObserve, guardDropStopsFiring)
 {
     auto p = pipe<int>();
     auto c = makeSignalContext(collect(std::move(p.stream)));
 
     bool fired = false;
     {
-        auto conn = c.observe([&] { fired = true; });
+        auto guard = c.observe([&] { fired = true; });
     }
 
     p.handle.push(42);

--- a/src/bq/test/observetest.cpp
+++ b/src/bq/test/observetest.cpp
@@ -5,6 +5,7 @@
 #include <bq/signal/signalcontext.h>
 #include <bq/signal/datacontext.h>
 #include <bq/signal/constant.h>
+#include <bq/signal/conditional.h>
 #include <bq/signal/merge.h>
 #include <bq/signal/combine.h>
 #include <bq/signal/input.h>
@@ -18,18 +19,25 @@ using namespace bq;
 using namespace bq::signal;
 using namespace bq::stream;
 
-// observe() registers a wakeup on every leaf that an external source can wake,
-// so the wake fires immediately without evaluating the graph. The registration
-// is scoped by a guard: it fires while the guard is alive and stops once the
-// guard drops. These tests drive the signal impls directly, exactly as
-// SignalContext does internally, pairing each callback with a guard by hand.
+// Design B: the wakeup lives on the DataContext, not on the signals. A caller
+// arms the context with observe(); external leaves (input, collect) bind a weak
+// reference to that context's control when their per-context data is created at
+// init, and fire it on set()/emit without evaluating the graph. There is no
+// per-signal observe() traversal.
+//
+// The control is always armed: it stays armed for the context's lifetime and
+// fires on every external change (coalescing is left to the frame loop). A
+// leaf's registration is dropped when its per-context data is destroyed, so a
+// branch swapped out of a conditional or join stops waking the context.
+//
+// These tests arm a context, initialize a graph into it (which wires the
+// leaves), then drive a leaf and assert the callback fired.
 
 namespace
 {
     // Initializes a signal impl into a context and returns its DataType, with
     // the frame data swapped once as a live context does after construction.
-    // The signal is passed by lvalue because observe() needs the non-const
-    // unwrap().
+    // Initialization is what wires the context's leaves to its wakeup.
     template <typename TSignal>
     auto initialize(DataContext& ctx, TSignal& sig)
     {
@@ -39,98 +47,80 @@ namespace
     }
 } // namespace
 
-// A collect leaf fires its observer exactly once, synchronously, when the
-// stream emits.
-TEST(Observe, collectLeafFires)
+// A plain value input is an external leaf: arming the context and then set()ting
+// a new value wakes it.
+TEST(Observe, inputFiresOnSet)
 {
-    auto p = pipe<int>();
-    auto sig = collect(std::move(p.stream));
+    auto input = makeInput<int>(5);
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
     bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    ctx.observe([&] { fired = true; });
+
+    auto data = initialize(ctx, input.signal);
 
     EXPECT_FALSE(fired);
-    p.handle.push(42);
+    input.handle.set(10);
     EXPECT_TRUE(fired);
 }
 
-// The wake does not evaluate the graph: the pushed value is not visible through
-// evaluate() until an update() swaps it into the current values.
-TEST(Observe, wakeDoesNotEvaluate)
+// Always armed: every set() fires the wakeup, not just the first.
+TEST(Observe, firesOnEachSet)
 {
-    auto p = pipe<int>();
-    auto sig = collect(std::move(p.stream));
+    auto input = makeInput<int>(0);
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
-    bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
-
-    p.handle.push(42);
-    EXPECT_TRUE(fired);
-
-    // The observer fired, but the value is still only pending: evaluate() sees
-    // nothing until update() moves it across.
-    EXPECT_TRUE(sig.unwrap().evaluate(ctx, data).get<0>().empty());
-
-    sig.unwrap().update(ctx, data, FrameInfo(1, {}));
-    EXPECT_EQ((std::vector<int>{ 42 }), sig.unwrap().evaluate(ctx, data).get<0>());
-}
-
-// observe is one-shot: firing consumes the callback, so a second emission wakes
-// nothing until the observer is re-armed by observing again.
-TEST(Observe, collectIsOneShot)
-{
-    auto p = pipe<int>();
-    auto sig = collect(std::move(p.stream));
-
-    DataContext ctx;
-    auto data = initialize(ctx, sig);
-
     int count = 0;
-    auto g1 = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(g1, [&] { ++count; }));
+    ctx.observe([&] { ++count; });
 
-    p.handle.push(1);
+    auto data = initialize(ctx, input.signal);
+
+    input.handle.set(1);
     EXPECT_EQ(1, count);
 
-    // Not re-armed: the callback list was cleared as it fired.
-    p.handle.push(2);
-    EXPECT_EQ(1, count);
-
-    // Re-arming makes it fire again.
-    auto g2 = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(g2, [&] { ++count; }));
-    p.handle.push(3);
+    input.handle.set(2);
     EXPECT_EQ(2, count);
 }
 
-// Dropping the guard unregisters the callback before it can fire.
-TEST(Observe, guardDropStopsFiring)
+// The wake does not evaluate the graph: the new value is not visible through
+// evaluate() until an update() swaps it into the current value.
+TEST(Observe, wakeDoesNotEvaluate)
+{
+    auto input = makeInput<int>(5);
+
+    DataContext ctx;
+    bool fired = false;
+    ctx.observe([&] { fired = true; });
+
+    auto data = initialize(ctx, input.signal);
+
+    input.handle.set(10);
+    EXPECT_TRUE(fired);
+
+    // The wake fired, but evaluate() still sees the old value until update().
+    EXPECT_EQ(5, input.signal.unwrap().evaluate(ctx, data).get<0>());
+    input.signal.unwrap().update(ctx, data, FrameInfo(1, {}));
+    EXPECT_EQ(10, input.signal.unwrap().evaluate(ctx, data).get<0>());
+}
+
+// A collect leaf fires the context wakeup when its stream emits.
+TEST(Observe, collectFiresOnEmit)
 {
     auto p = pipe<int>();
     auto sig = collect(std::move(p.stream));
 
     DataContext ctx;
+    bool fired = false;
+    ctx.observe([&] { fired = true; });
+
     auto data = initialize(ctx, sig);
 
-    bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
-    guard.reset();
-
-    p.handle.push(42);
     EXPECT_FALSE(fired);
+    p.handle.push(42);
+    EXPECT_TRUE(fired);
 }
 
-// map forwards observe to its single upstream, so an external change at the leaf
-// still wakes the observer through the mapped node.
+// A mapped node wires the same leaf: a push at the collect wakes the context.
 TEST(Observe, throughMap)
 {
     auto p = pipe<int>();
@@ -138,18 +128,16 @@ TEST(Observe, throughMap)
             [](std::vector<int> const& v) { return v.size(); });
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
     bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    ctx.observe([&] { fired = true; });
+
+    auto data = initialize(ctx, sig);
 
     p.handle.push(7);
     EXPECT_TRUE(fired);
 }
 
-// merge observes all of its children: a change in either leaf wakes the
-// observer, once per external change.
+// merge wires all of its children: a change in either leaf wakes the context.
 TEST(Observe, throughMerge)
 {
     auto pa = pipe<int>();
@@ -157,15 +145,10 @@ TEST(Observe, throughMerge)
     auto sig = merge(collect(std::move(pa.stream)), collect(std::move(pb.stream)));
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
-    // A single observe connects both children. Each child is an independent
-    // one-shot: pushing the first fires and disarms only its own leaf, leaving
-    // the second still armed to fire on its push. So each external change fires
-    // exactly once.
     int count = 0;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { ++count; }));
+    ctx.observe([&] { ++count; });
+
+    auto data = initialize(ctx, sig);
 
     pa.handle.push(1);
     EXPECT_EQ(1, count);
@@ -174,7 +157,7 @@ TEST(Observe, throughMerge)
     EXPECT_EQ(2, count);
 }
 
-// combine observes every child leaf.
+// combine wires every child leaf.
 TEST(Observe, throughCombine)
 {
     auto pa = pipe<int>();
@@ -186,65 +169,19 @@ TEST(Observe, throughCombine)
     auto sig = combine(std::move(children));
 
     DataContext ctx;
+    int count = 0;
+    ctx.observe([&] { ++count; });
+
     auto data = initialize(ctx, sig);
 
-    bool firedA = false;
-    auto guardA = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guardA, [&] { firedA = true; }));
     pa.handle.push(1);
-    EXPECT_TRUE(firedA);
+    EXPECT_EQ(1, count);
 
-    bool firedB = false;
-    auto guardB = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guardB, [&] { firedB = true; }));
     pb.handle.push(2);
-    EXPECT_TRUE(firedB);
+    EXPECT_EQ(2, count);
 }
 
-// A conditional observes its condition and only the currently active branch;
-// the inactive branch's leaf is not connected. Switching the condition and
-// re-observing rewires onto the newly active branch.
-TEST(Observe, throughConditional)
-{
-    auto pt = pipe<int>();
-    auto pf = pipe<int>();
-    auto cond = makeInput<bool>(true);
-
-    auto sig = cond.signal.conditional(
-            collect(std::move(pt.stream)),
-            collect(std::move(pf.stream)));
-
-    DataContext ctx;
-    auto data = initialize(ctx, sig);
-
-    // Active branch is the true branch: it fires, the inactive false branch
-    // does not (it is neither initialized nor observed).
-    bool firedTrue = false;
-    bool firedFalse = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data,
-            ObserveCallback(guard, [&] { firedTrue = true; }));
-    pt.handle.push(1);
-    pf.handle.push(2);
-    EXPECT_TRUE(firedTrue);
-    EXPECT_FALSE(firedFalse);
-
-    // Switch the active branch and drive an update so the conditional swaps in
-    // the false branch's data.
-    guard.reset();
-    cond.handle.set(false);
-    sig.unwrap().update(ctx, data, FrameInfo(1, {}));
-
-    // Re-observing now registers on the false branch.
-    auto guard2 = makeObserveGuard();
-    sig.unwrap().observe(ctx, data,
-            ObserveCallback(guard2, [&] { firedFalse = true; }));
-    pf.handle.push(3);
-    EXPECT_TRUE(firedFalse);
-}
-
-// join observes both the outer signal and the current inner signal, so an
-// external change reachable through the inner signal wakes the observer.
+// join wires the leaf reachable through the current inner signal.
 TEST(Observe, throughJoin)
 {
     auto p = pipe<int>();
@@ -252,18 +189,16 @@ TEST(Observe, throughJoin)
     auto sig = constant(inner).join();
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
     bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    ctx.observe([&] { fired = true; });
+
+    auto data = initialize(ctx, sig);
 
     p.handle.push(42);
     EXPECT_TRUE(fired);
 }
 
-// join(ArraySignal) observes each element that is present when observe is
-// called, so an external change at an element's leaf wakes the observer.
+// join(ArraySignal) wires each element present at init.
 TEST(Observe, throughArrayJoin)
 {
     auto p = pipe<int>();
@@ -273,161 +208,159 @@ TEST(Observe, throughArrayJoin)
     auto sig = join(array);
 
     DataContext ctx;
-    auto data = initialize(ctx, sig);
-
     bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    ctx.observe([&] { fired = true; });
+
+    auto data = initialize(ctx, sig);
 
     p.handle.push(42);
     EXPECT_TRUE(fired);
 }
 
-// A plain value input is an external leaf: observing it and then set()ting a new
-// value wakes the observer immediately, without evaluating the graph (the new
-// value is only visible through evaluate() after an update()).
-TEST(Observe, inputLeafFires)
+// A conditional wires only the currently active branch; the inactive branch is
+// never initialized, so its leaf is not wired.
+TEST(Observe, conditionalActiveBranchOnly)
 {
-    auto input = makeInput<int>(5);
+    auto pt = pipe<int>();
+    auto pf = pipe<int>();
+    auto cond = makeInput<bool>(true);
+
+    auto sig = conditional(cond.signal,
+            collect(std::move(pt.stream)),
+            collect(std::move(pf.stream)));
 
     DataContext ctx;
-    auto data = initialize(ctx, input.signal);
+    bool firedTrue = false;
+    ctx.observe([&] { firedTrue = true; });
 
-    bool fired = false;
-    auto guard = makeObserveGuard();
-    input.signal.unwrap().observe(ctx, data,
-            ObserveCallback(guard, [&] { fired = true; }));
-
-    EXPECT_FALSE(fired);
-    input.handle.set(10);
-    EXPECT_TRUE(fired);
-
-    // The wake did not evaluate: the value is still the old one until update().
-    EXPECT_EQ(5, input.signal.unwrap().evaluate(ctx, data).get<0>());
-    input.signal.unwrap().update(ctx, data, FrameInfo(1, {}));
-    EXPECT_EQ(10, input.signal.unwrap().evaluate(ctx, data).get<0>());
-}
-
-// Input observe is one-shot too: a second set() wakes nothing until re-armed.
-TEST(Observe, inputIsOneShot)
-{
-    auto input = makeInput<int>(0);
-
-    DataContext ctx;
-    auto data = initialize(ctx, input.signal);
-
-    int count = 0;
-    auto g1 = makeObserveGuard();
-    input.signal.unwrap().observe(ctx, data,
-            ObserveCallback(g1, [&] { ++count; }));
-
-    input.handle.set(1);
-    EXPECT_EQ(1, count);
-
-    input.handle.set(2);
-    EXPECT_EQ(1, count);
-
-    auto g2 = makeObserveGuard();
-    input.signal.unwrap().observe(ctx, data,
-            ObserveCallback(g2, [&] { ++count; }));
-    input.handle.set(3);
-    EXPECT_EQ(2, count);
-}
-
-// Dropping an input observer's guard unregisters it before set() can wake it.
-TEST(Observe, inputGuardDropStops)
-{
-    auto input = makeInput<int>(0);
-
-    DataContext ctx;
-    auto data = initialize(ctx, input.signal);
-
-    bool fired = false;
-    auto guard = makeObserveGuard();
-    input.signal.unwrap().observe(ctx, data,
-            ObserveCallback(guard, [&] { fired = true; }));
-    guard.reset();
-
-    input.handle.set(1);
-    EXPECT_FALSE(fired);
-}
-
-// The input leaf wakes through a combinator as well: a set() at the input wakes
-// an observer registered on the mapped node.
-TEST(Observe, inputThroughMap)
-{
-    auto input = makeInput<int>(1);
-    auto sig = input.signal.map([](int n) { return n * 2; });
-
-    DataContext ctx;
     auto data = initialize(ctx, sig);
 
-    bool fired = false;
-    auto guard = makeObserveGuard();
-    sig.unwrap().observe(ctx, data, ObserveCallback(guard, [&] { fired = true; }));
+    pt.handle.push(1);
+    EXPECT_TRUE(firedTrue);
 
-    input.handle.set(4);
-    EXPECT_TRUE(fired);
+    // The false branch was never initialized, so pushing it wakes nothing.
+    bool firedFalse = false;
+    ctx.observe([&] { firedFalse = true; });
+    pf.handle.push(2);
+    EXPECT_FALSE(firedFalse);
 }
 
-// ---------------------------------------------------------------------------
-// SignalContext::observe -- the public entry point, registering a wakeup
-// across every signal the context holds and returning a guard that scopes it.
-// ---------------------------------------------------------------------------
-
-// A context over a collect leaf: observe() wakes on a stream emission, and the
-// wake does not evaluate -- the value is not visible via evaluate<0>() until an
-// update() applies it.
-TEST(SignalContextObserve, collectWakesWithoutEvaluating)
+// Flipping the condition destroys the old branch's data (unregistering its leaf)
+// and initializes the new one (wiring its leaf), so the wakeup follows the swap.
+TEST(Observe, conditionalRewiresOnFlip)
 {
-    auto p = pipe<int>();
-    auto c = makeSignalContext(collect(std::move(p.stream)));
+    auto pt = pipe<int>();
+    auto pf = pipe<int>();
+    auto cond = makeInput<bool>(true);
 
+    auto sig = conditional(cond.signal,
+            collect(std::move(pt.stream)),
+            collect(std::move(pf.stream)));
+
+    DataContext ctx;
     bool fired = false;
-    auto guard = c.observe([&] { fired = true; });
+    ctx.observe([&] { fired = true; });
 
-    EXPECT_FALSE(fired);
-    p.handle.push(42);
+    auto data = initialize(ctx, sig);
+
+    pt.handle.push(1);
     EXPECT_TRUE(fired);
 
-    // The wake did not evaluate the graph: the value is still pending.
-    EXPECT_TRUE(c.evaluate<0>().get<0>().empty());
+    // Switch to the false branch and update so the conditional swaps its data.
+    cond.handle.set(false);
+    sig.unwrap().update(ctx, data, FrameInfo(1, {}));
 
-    c.update(FrameInfo(1, {}));
-    EXPECT_EQ((std::vector<int>{ 42 }), c.evaluate<0>().get<0>());
+    fired = false;
+
+    // The true branch's data was destroyed, so pushing it no longer fires.
+    pt.handle.push(2);
+    EXPECT_FALSE(fired);
+
+    // The false branch is now wired.
+    pf.handle.push(3);
+    EXPECT_TRUE(fired);
 }
 
-// A context over a plain input leaf: observe() wakes on set(), exercising the
-// input observe fix through the public API.
-TEST(SignalContextObserve, inputWakesOnSet)
+// A leaf's registration is tied to its per-context data: once that data is
+// destroyed, the leaf no longer wakes the context.
+TEST(Observe, cleanupOnDataDestruction)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx;
+    bool fired = false;
+    ctx.observe([&] { fired = true; });
+
+    {
+        auto data = initialize(ctx, input.signal);
+    }
+
+    input.handle.set(1);
+    EXPECT_FALSE(fired);
+}
+
+// A single input feeds two contexts; each registers its own wakeup, so one
+// set() fires both.
+TEST(Observe, multipleContextsFire)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx1;
+    bool fired1 = false;
+    ctx1.observe([&] { fired1 = true; });
+    auto data1 = initialize(ctx1, input.signal);
+
+    DataContext ctx2;
+    bool fired2 = false;
+    ctx2.observe([&] { fired2 = true; });
+    auto data2 = initialize(ctx2, input.signal);
+
+    input.handle.set(1);
+    EXPECT_TRUE(fired1);
+    EXPECT_TRUE(fired2);
+}
+
+// ---------------------------------------------------------------------------
+// SignalContext::observe -- the public entry point. It arms the context's
+// wakeup, which the graph's leaves are already wired to.
+// ---------------------------------------------------------------------------
+
+// Arming a context over an input leaf wakes on set(), and the wake does not
+// evaluate: the value is pending until update() applies it.
+TEST(SignalContextObserve, firesOnSet)
 {
     auto input = makeInput<int>(5);
     auto c = makeSignalContext(input.signal);
 
     bool fired = false;
-    auto guard = c.observe([&] { fired = true; });
+    c.observe([&] { fired = true; });
 
     EXPECT_FALSE(fired);
     input.handle.set(10);
     EXPECT_TRUE(fired);
+
+    // The wake did not evaluate: the value is pending until update().
+    EXPECT_EQ(5, c.evaluate<0>().get<0>());
+    c.update(FrameInfo(1, {}));
+    EXPECT_EQ(10, c.evaluate<0>().get<0>());
 }
 
 // The wakeup reaches leaves through combinators: a mapped input still wakes the
-// context observer on set().
+// context on set().
 TEST(SignalContextObserve, throughMap)
 {
     auto input = makeInput<int>(1);
     auto c = makeSignalContext(input.signal.map([](int n) { return n * 2; }));
 
     bool fired = false;
-    auto guard = c.observe([&] { fired = true; });
+    c.observe([&] { fired = true; });
 
     input.handle.set(4);
     EXPECT_TRUE(fired);
 }
 
-// observe() registers across every signal the context holds, so a change in
-// either of two independent leaves wakes the observer.
+// The wakeup covers every signal the context holds, so a change in either of two
+// independent leaves wakes it.
 TEST(SignalContextObserve, acrossAllSignals)
 {
     auto pa = pipe<int>();
@@ -437,7 +370,7 @@ TEST(SignalContextObserve, acrossAllSignals)
             collect(std::move(pb.stream)));
 
     int count = 0;
-    auto guard = c.observe([&] { ++count; });
+    c.observe([&] { ++count; });
 
     pa.handle.push(1);
     EXPECT_EQ(1, count);
@@ -446,40 +379,18 @@ TEST(SignalContextObserve, acrossAllSignals)
     EXPECT_EQ(2, count);
 }
 
-// The wakeup is one-shot: after firing, a second change does nothing until the
-// context is observed again.
-TEST(SignalContextObserve, isOneShot)
+// Always armed: each external change fires, not just the first.
+TEST(SignalContextObserve, firesOnEachChange)
 {
     auto input = makeInput<int>(0);
     auto c = makeSignalContext(input.signal);
 
     int count = 0;
-    auto guard = c.observe([&] { ++count; });
+    c.observe([&] { ++count; });
 
     input.handle.set(1);
     EXPECT_EQ(1, count);
 
-    // Not re-armed.
     input.handle.set(2);
-    EXPECT_EQ(1, count);
-
-    // Re-arming makes it fire again.
-    auto guard2 = c.observe([&] { ++count; });
-    input.handle.set(3);
     EXPECT_EQ(2, count);
-}
-
-// Dropping the returned guard unregisters the wakeup before the change.
-TEST(SignalContextObserve, guardDropStopsFiring)
-{
-    auto p = pipe<int>();
-    auto c = makeSignalContext(collect(std::move(p.stream)));
-
-    bool fired = false;
-    {
-        auto guard = c.observe([&] { fired = true; });
-    }
-
-    p.handle.push(42);
-    EXPECT_FALSE(fired);
 }

--- a/src/bq/test/observetest.cpp
+++ b/src/bq/test/observetest.cpp
@@ -56,7 +56,7 @@ TEST(Observe, inputFiresOnSet)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, input.signal);
 
@@ -72,7 +72,7 @@ TEST(Observe, firesOnEachSet)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto data = initialize(ctx, input.signal);
 
@@ -91,7 +91,7 @@ TEST(Observe, wakeDoesNotEvaluate)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, input.signal);
 
@@ -112,7 +112,7 @@ TEST(Observe, collectFiresOnEmit)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -130,7 +130,7 @@ TEST(Observe, throughMap)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -147,7 +147,7 @@ TEST(Observe, throughMerge)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto data = initialize(ctx, sig);
 
@@ -171,7 +171,7 @@ TEST(Observe, throughCombine)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto data = initialize(ctx, sig);
 
@@ -191,7 +191,7 @@ TEST(Observe, throughJoin)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -210,7 +210,7 @@ TEST(Observe, throughArrayJoin)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -232,7 +232,7 @@ TEST(Observe, conditionalActiveBranchOnly)
 
     DataContext ctx;
     bool firedTrue = false;
-    ctx.observe([&] { firedTrue = true; });
+    ctx.setObserveCallback([&] { firedTrue = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -241,7 +241,7 @@ TEST(Observe, conditionalActiveBranchOnly)
 
     // The false branch was never initialized, so pushing it wakes nothing.
     bool firedFalse = false;
-    ctx.observe([&] { firedFalse = true; });
+    ctx.setObserveCallback([&] { firedFalse = true; });
     pf.handle.push(2);
     EXPECT_FALSE(firedFalse);
 }
@@ -260,7 +260,7 @@ TEST(Observe, conditionalRewiresOnFlip)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     auto data = initialize(ctx, sig);
 
@@ -290,7 +290,7 @@ TEST(Observe, cleanupOnDataDestruction)
 
     DataContext ctx;
     bool fired = false;
-    ctx.observe([&] { fired = true; });
+    ctx.setObserveCallback([&] { fired = true; });
 
     {
         auto data = initialize(ctx, input.signal);
@@ -308,12 +308,12 @@ TEST(Observe, multipleContextsFire)
 
     DataContext ctx1;
     bool fired1 = false;
-    ctx1.observe([&] { fired1 = true; });
+    ctx1.setObserveCallback([&] { fired1 = true; });
     auto data1 = initialize(ctx1, input.signal);
 
     DataContext ctx2;
     bool fired2 = false;
-    ctx2.observe([&] { fired2 = true; });
+    ctx2.setObserveCallback([&] { fired2 = true; });
     auto data2 = initialize(ctx2, input.signal);
 
     input.handle.set(1);
@@ -474,7 +474,7 @@ TEST(ObserveDiamond, inputTeardownRebuild)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto sig = merge(input.signal.map([](int x) { return x; }),
                      input.signal.map([](int x) { return x; }));
@@ -503,7 +503,7 @@ TEST(ObserveDiamond, collectTeardownRebuild)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto col = collect(std::move(p.stream));
     auto sig = merge(col.map([](std::vector<int> const& v) { return v.size(); }),
@@ -536,7 +536,7 @@ TEST(ObserveDiamond, sharedSubgraphTeardown)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto sig = merge(shared.map([](int x) { return x; }),
                      shared.map([](int x) { return x; }));
@@ -561,7 +561,7 @@ TEST(ObserveDiamond, inputPartialTeardown)
 
     DataContext ctx;
     int count = 0;
-    ctx.observe([&] { ++count; });
+    ctx.setObserveCallback([&] { ++count; });
 
     auto s1 = input.signal.map([](int x) { return x; });
     auto s2 = input.signal.map([](int x) { return x; });

--- a/src/bq/test/observetest.cpp
+++ b/src/bq/test/observetest.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <vector>
 
 using namespace bq;
@@ -393,4 +394,193 @@ TEST(SignalContextObserve, firesOnEachChange)
 
     input.handle.set(2);
     EXPECT_EQ(2, count);
+}
+
+// An input reached through two routes registers once (its per-context data is
+// deduped by control id at init), so a set() fires the wakeup once.
+TEST(SignalContextObserve, diamondInputFiresOnce)
+{
+    auto input = makeInput<int>(0);
+    auto c = makeSignalContext(merge(
+                input.signal.map([](int x) { return x; }),
+                input.signal.map([](int x) { return x; })));
+
+    int count = 0;
+    c.observe([&] { ++count; });
+
+    input.handle.set(1);
+    EXPECT_EQ(1, count);
+}
+
+// An unshared collect reached through two routes builds one Control per route,
+// so an emit fires the wakeup once per route. This is allowed: the wakeup may
+// fire more than once, and the frame loop coalesces.
+TEST(SignalContextObserve, diamondCollectFiresPerRoute)
+{
+    auto p = pipe<int>();
+    auto col = collect(std::move(p.stream));
+    auto c = makeSignalContext(merge(
+                col.map([](std::vector<int> const& v) { return v.size(); }),
+                col.map([](std::vector<int> const& v) { return v.size(); })));
+
+    int count = 0;
+    c.observe([&] { ++count; });
+
+    p.handle.push(1);
+    EXPECT_EQ(2, count);
+}
+
+// Sharing collapses the diamond back to one Control, so one emit fires once.
+TEST(SignalContextObserve, diamondCollectSharedFiresOnce)
+{
+    auto p = pipe<int>();
+    auto col = collect(std::move(p.stream)).share();
+    auto c = makeSignalContext(merge(
+                col.map([](std::vector<int> const& v) { return v.size(); }),
+                col.map([](std::vector<int> const& v) { return v.size(); })));
+
+    int count = 0;
+    c.observe([&] { ++count; });
+
+    p.handle.push(1);
+    EXPECT_EQ(1, count);
+}
+
+// Two distinct changes each fire: the wakeup is not coalesced within a cycle.
+TEST(SignalContextObserve, distinctInputsEachFire)
+{
+    auto a = makeInput<int>(0);
+    auto b = makeInput<int>(0);
+    auto c = makeSignalContext(a.signal, b.signal);
+
+    int count = 0;
+    c.observe([&] { ++count; });
+
+    a.handle.set(1);
+    b.handle.set(2);
+    EXPECT_EQ(2, count);
+}
+
+// ---------------------------------------------------------------------------
+// Init/deinit balance under a diamond. The context (and its callback) outlives
+// the graph data: after tearing the data down, a set() that still fired would
+// mean a registration leaked past its per-context data, so count staying at 0
+// proves the unregister was balanced against the register.
+// ---------------------------------------------------------------------------
+
+TEST(ObserveDiamond, inputTeardownRebuild)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx;
+    int count = 0;
+    ctx.observe([&] { ++count; });
+
+    auto sig = merge(input.signal.map([](int x) { return x; }),
+                     input.signal.map([](int x) { return x; }));
+
+    {
+        auto data = initialize(ctx, sig);
+        input.handle.set(1);
+        EXPECT_EQ(1, count); // one registration despite two routes
+    } // data destroyed once -> ContextDataType destroyed once -> unregister once
+
+    count = 0;
+    input.handle.set(2);
+    EXPECT_EQ(0, count); // context still alive; nothing fired -> balanced
+
+    {
+        auto data = initialize(ctx, sig);
+        count = 0;
+        input.handle.set(3);
+        EXPECT_EQ(1, count); // re-init re-registers cleanly
+    }
+}
+
+TEST(ObserveDiamond, collectTeardownRebuild)
+{
+    auto p = pipe<int>();
+
+    DataContext ctx;
+    int count = 0;
+    ctx.observe([&] { ++count; });
+
+    auto col = collect(std::move(p.stream));
+    auto sig = merge(col.map([](std::vector<int> const& v) { return v.size(); }),
+                     col.map([](std::vector<int> const& v) { return v.size(); }));
+
+    {
+        auto data = initialize(ctx, sig);
+        p.handle.push(1);
+        EXPECT_EQ(2, count); // two Controls
+    } // both Controls destroyed -> both fmap subscriptions detach
+
+    count = 0;
+    p.handle.push(2);
+    EXPECT_EQ(0, count); // no dangling subscription fired
+
+    {
+        auto data = initialize(ctx, sig);
+        count = 0;
+        p.handle.push(3);
+        EXPECT_EQ(2, count); // rebuilt cleanly
+    }
+}
+
+// A shared subgraph (not just a leaf) reached twice: the input inside it inits
+// once, and tearing the shared node down releases it once.
+TEST(ObserveDiamond, sharedSubgraphTeardown)
+{
+    auto input = makeInput<int>(0);
+    auto shared = input.signal.map([](int x) { return x * 2; }).share();
+
+    DataContext ctx;
+    int count = 0;
+    ctx.observe([&] { ++count; });
+
+    auto sig = merge(shared.map([](int x) { return x; }),
+                     shared.map([](int x) { return x; }));
+
+    {
+        auto data = initialize(ctx, sig);
+        input.handle.set(1);
+        EXPECT_EQ(1, count); // shared subgraph -> input inits once
+    }
+
+    count = 0;
+    input.handle.set(2);
+    EXPECT_EQ(0, count); // shared node released -> input released -> unregister
+}
+
+// Refcount-driven release: two routes share the input's per-context data.
+// Dropping one route must not unregister while the other still holds it; the
+// last route out unregisters exactly once (no early or double deinit).
+TEST(ObserveDiamond, inputPartialTeardown)
+{
+    auto input = makeInput<int>(0);
+
+    DataContext ctx;
+    int count = 0;
+    ctx.observe([&] { ++count; });
+
+    auto s1 = input.signal.map([](int x) { return x; });
+    auto s2 = input.signal.map([](int x) { return x; });
+
+    auto d1 = initialize(ctx, s1);
+    auto d2 = initialize(ctx, s2);
+    std::optional<decltype(d1)> route1{ std::move(d1) };
+    std::optional<decltype(d2)> route2{ std::move(d2) };
+
+    input.handle.set(1);
+    EXPECT_EQ(1, count); // one registration shared by both routes
+
+    route1.reset(); // one route leaves; the other still holds the data
+    count = 0;
+    input.handle.set(2);
+    EXPECT_EQ(1, count); // still registered -> still fires
+
+    route2.reset(); // last route leaves -> data destroyed -> unregister
+    count = 0;
+    input.handle.set(3);
+    EXPECT_EQ(0, count); // unregistered exactly once
 }

--- a/src/bq/test/signaltest.cpp
+++ b/src/bq/test/signaltest.cpp
@@ -98,17 +98,14 @@ TEST(signal, constant)
 
     FrameInfo frame(1, signal_time_t(10));
 
-    auto r = c.update(frame);
-    EXPECT_EQ(r.nextUpdate, std::nullopt);
+    c.update(frame);
 }
 
 TEST(signal, signalContext)
 {
     auto c = makeSignalContext(constant(42));
 
-    UpdateResult r = c.update(FrameInfo(1, signal_time_t(0)));
-
-    EXPECT_EQ(std::nullopt, r.nextUpdate);
+    c.update(FrameInfo(1, signal_time_t(0)));
 
     EXPECT_EQ(Type<int const&>(), getType(c.evaluate<0>().get<0>()));
 
@@ -134,8 +131,7 @@ TEST(signal, signalInput)
 
     EXPECT_EQ(42, c.evaluate<0>().get<0>());
 
-    auto r = c.update(FrameInfo(1, {}));
-    EXPECT_EQ(std::nullopt, r.nextUpdate);
+    c.update(FrameInfo(1, {}));
 
     EXPECT_EQ(22, c.evaluate<0>().get<0>());
 
@@ -160,7 +156,6 @@ TEST(signal, map)
     auto r = c.update(FrameInfo(1, {}));
 
     EXPECT_FALSE(r.didChange);
-    EXPECT_EQ(std::nullopt, r.nextUpdate);
 
     input.handle.set(12);
 
@@ -170,7 +165,6 @@ TEST(signal, map)
 
     EXPECT_EQ(24, c.evaluate<0>().get<0>());
     EXPECT_TRUE(r.didChange);
-    EXPECT_EQ(std::nullopt, r.nextUpdate);
 }
 
 TEST(signal, mapReferenceToTemp)

--- a/src/bqui/src/windowimpl.h
+++ b/src/bqui/src/windowimpl.h
@@ -255,7 +255,7 @@ public:
             << std::endl;
     }
 
-    std::optional<bq::signal::signal_time_t> makeTransaction(
+    void makeTransaction(
             std::chrono::microseconds dt,
             std::optional<avg::AnimationOptions> const& animationOptions
             )
@@ -266,8 +266,8 @@ public:
 
         bq::signal::FrameInfo frameInfo(getNextFrameId(), dt);
 
-        auto updateResult = widgetInstanceSignal_.update(frameInfo);
-        updateResult = updateResult + titleSignal_.update(frameInfo);
+        widgetInstanceSignal_.update(frameInfo);
+        titleSignal_.update(frameInfo);
 
 
         if (titleSignal_.didChange<0>())
@@ -356,8 +356,6 @@ public:
 
             aseWindow.requestFrame();
         }
-
-        return updateResult.nextUpdate;
     }
 
     std::optional<bq::signal::signal_time_t> frame(std::chrono::microseconds dt)
@@ -383,7 +381,7 @@ public:
         auto timer = std::chrono::duration_cast<std::chrono::milliseconds>(
                 timer_);
 
-        auto timeToNext = makeTransaction(frame.dt, std::nullopt);
+        makeTransaction(frame.dt, std::nullopt);
 
         if (animating_)
         {
@@ -407,7 +405,7 @@ public:
         if (animating_)
             return std::chrono::microseconds(0);
 
-        return timeToNext;
+        return std::nullopt;
     }
 
     btl::UniqueId getId() const


### PR DESCRIPTION
Rework signal observation - the groundwork for on-demand rendering (#126).

- Fix `signal::input` to be a real observe leaf: `InputHandle::set()` now fires the observe callbacks (was a no-op), mirroring `stream::collect`.
- Expose `SignalContext::observe(callback)`, a context-level external-change wakeup. The mechanism existed on the signal impls but had no public entry point.
- Hold observers by shared_ptr with eager deregistration; document the wakeup contract: always-armed, fires on external change, may fire more than once per cycle - a wakeup, not a change count.

No behaviour change for existing code (observe has no consumer on master yet). New `observetest.cpp` covers the leaves, forwarding through map/merge/combine/conditional/join/forEach, diamonds, and the context API. bq green on clang-cl.
