### PR TITLE
bq: move-thread withPrevious accumulator instead of copying

### DIFF
--- a/src/bq/include/bq/signal/signal.h
+++ b/src/bq/include/bq/signal/signal.h
@@ -342,6 +342,14 @@ namespace bq::signal
                 });
         }
 
+        /** @brief Folds over successive values, threading the accumulator
+         * through @p func each update.
+         *
+         * The accumulator is moved into @p func, so a large movable fold-state
+         * flows through without being copied. Because it is moved, a @p func
+         * that throws mid-update leaves the stored accumulator in a valid but
+         * moved-from state; the previous value is not preserved.
+         */
         template <typename... Us, typename TFunc, typename = std::enable_if_t<
             std::is_convertible_v<
                 ToSignalResultT<std::invoke_result_t<TFunc, Us..., Ts...>>,

--- a/src/bq/include/bq/signal/withprevious.h
+++ b/src/bq/include/bq/signal/withprevious.h
@@ -35,7 +35,7 @@ namespace bq::signal
         using InnerResultType = SignalTypeT<TStorage>;
 
         static FuncReturnType evaluateFunc(TFunc const& func,
-                FuncReturnType const& current,
+                FuncReturnType current,
                 InnerResultType inner)
         {
             return makeSignalResult(std::apply([&](auto&&... ts)
@@ -51,7 +51,7 @@ namespace bq::signal
                     }
                 },
                 std::tuple_cat(
-                    current.getTuple(),
+                    std::move(current).getTuple(),
                     std::move(inner).getTuple()
                 )));
         }
@@ -104,7 +104,7 @@ namespace bq::signal
             {
                 data.innerResult = sig_.evaluate(context, data.innerData);
                 data.currentResult = evaluateFunc(*func_,
-                        data.currentResult, data.innerResult);
+                        std::move(data.currentResult), data.innerResult);
             }
 
             return r;

--- a/src/bq/meson.build
+++ b/src/bq/meson.build
@@ -25,6 +25,7 @@ bqtest = executable('bqtest',
   'test/signaltest.cpp',
   'test/signalcontexttest.cpp',
   'test/streamtest.cpp',
+  'test/withprevioustest.cpp',
   dependencies: [libbqdep, gtestdep],
   )
 

--- a/src/bq/test/withprevioustest.cpp
+++ b/src/bq/test/withprevioustest.cpp
@@ -1,0 +1,203 @@
+#include <bq/signal/signal.h>
+#include <bq/signal/input.h>
+#include <bq/signal/combine.h>
+#include <bq/signal/signalcontext.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace bq::signal;
+
+namespace
+{
+    // Copy/move tally shared by every instance descending from a single seed.
+    // The seed hands this pointer to each copy/move so the whole family reports
+    // to one set of counters.
+    struct Counters
+    {
+        int copyCtor = 0;
+        int copyAssign = 0;
+        int moveCtor = 0;
+        int moveAssign = 0;
+
+        // Copies/assigns that carried a non-empty payload -- the ones that must
+        // stay at zero once the accumulator is move-threaded.
+        int heavyCopyCtor = 0;
+        int heavyCopyAssign = 0;
+
+        int foldCalls = 0;
+    };
+
+    // A movable, copyable stand-in for a heavy fold-state (e.g. the planned
+    // Cassowary solver). `apply` is an incremental delta-apply that mutates
+    // internal state, proving the fold-state persists and accumulates.
+    struct CountingSolver
+    {
+        std::vector<int> tableau;
+        Counters* counters = nullptr;
+
+        CountingSolver() = default; // empty seed is cheap
+        explicit CountingSolver(Counters* c) : counters(c) {}
+
+        CountingSolver(CountingSolver const& o)
+            : tableau(o.tableau), counters(o.counters)
+        {
+            if (counters)
+            {
+                ++counters->copyCtor;
+                if (!o.tableau.empty())
+                    ++counters->heavyCopyCtor;
+            }
+        }
+
+        CountingSolver(CountingSolver&& o) noexcept
+            : tableau(std::move(o.tableau)), counters(o.counters)
+        {
+            if (counters)
+                ++counters->moveCtor;
+        }
+
+        CountingSolver& operator=(CountingSolver const& o)
+        {
+            tableau = o.tableau;
+            counters = o.counters;
+            if (counters)
+            {
+                ++counters->copyAssign;
+                if (!o.tableau.empty())
+                    ++counters->heavyCopyAssign;
+            }
+            return *this;
+        }
+
+        CountingSolver& operator=(CountingSolver&& o) noexcept
+        {
+            tableau = std::move(o.tableau);
+            counters = o.counters;
+            if (counters)
+                ++counters->moveAssign;
+            return *this;
+        }
+
+        void apply(std::vector<int> const& delta)
+        {
+            for (int v : delta)
+                tableau.push_back(v);
+        }
+
+        int size() const { return static_cast<int>(tableau.size()); }
+    };
+}
+
+// (a) + (b): across several changed rounds the heavy payload is only moved,
+// never copied, and the fold-state accumulates incrementally (each delta-apply
+// sees the prior state). The terminal is a small mapped result read via const&,
+// so the only value flowing through the fold is the solver, threaded by move.
+TEST(withPrevious, movesAccumulatorNeverCopiesHeavyPayload)
+{
+    Counters counters;
+
+    auto input = makeInput<std::vector<int>>(std::vector<int>{ 1 });
+
+    auto solution = input.signal.withPrevious(
+            [&counters](CountingSolver solver, std::vector<int> delta)
+            {
+                ++counters.foldCalls;
+                solver.apply(delta);      // incremental delta-apply
+                return solver;            // same instance, moved out
+            },
+            CountingSolver(&counters))    // empty seed carrying the tally
+        .map([](CountingSolver const& s)  // read-only const& -> small result
+            {
+                return s.size();
+            });
+
+    auto c = makeSignalContext(solution);
+
+    // Initialization runs the fold once against the initial input.
+    EXPECT_EQ(1, c.evaluate<0>().get<0>());
+    EXPECT_EQ(1, counters.foldCalls);
+
+    for (int frame = 1; frame <= 5; ++frame)
+    {
+        input.handle.set(std::vector<int>{ frame * 10 });
+        auto r = c.update(FrameInfo(frame, {}));
+        EXPECT_TRUE(r.didChange);
+    }
+
+    // (b) fold-state persisted and accumulated: seed round + 5 rounds.
+    EXPECT_EQ(6, c.evaluate<0>().get<0>());
+    EXPECT_EQ(6, counters.foldCalls);
+
+    // (a) the heavy payload was never copied, only moved.
+    EXPECT_EQ(0, counters.heavyCopyCtor);
+    EXPECT_EQ(0, counters.heavyCopyAssign);
+
+    // The only copy allowed is the empty seed copied once into the per-context
+    // fold-state; no populated solver is ever copied.
+    EXPECT_LE(counters.copyCtor, 1);
+    EXPECT_EQ(0, counters.copyAssign);
+
+    // Sanity: the accumulator really was threaded by move.
+    EXPECT_GT(counters.moveCtor + counters.moveAssign, 0);
+}
+
+// (c): with .map(read const&).share() and two downstream readers combined in a
+// single context, the fold evaluates exactly once per frame (not forked), and
+// the accumulator is still never heavy-copied.
+TEST(withPrevious, sharedFanOutSingleEvalNoCopies)
+{
+    Counters counters;
+
+    auto input = makeInput<std::vector<int>>(std::vector<int>{ 1 });
+
+    auto shared = input.signal.withPrevious(
+            [&counters](CountingSolver solver, std::vector<int> delta)
+            {
+                ++counters.foldCalls;
+                solver.apply(delta);
+                return solver;
+            },
+            CountingSolver(&counters))
+        .map([](CountingSolver const& s)     // read-only const&, small result
+            {
+                return s.size();
+            })
+        .share();                            // share the small results
+
+    // Two downstream readers of the shared node inside one context.
+    std::vector<AnySignal<int>> readers;
+    readers.push_back(shared.map([](int n) { return n; }));
+    readers.push_back(shared.map([](int n) { return n * 2; }));
+    auto combined = combine(readers);
+
+    auto c = makeSignalContext(combined);
+
+    // Initialize: the fold runs exactly once even though two readers exist.
+    auto v = c.evaluate<0>().get<0>();
+    EXPECT_EQ(1, v.at(0));
+    EXPECT_EQ(2, v.at(1));
+    EXPECT_EQ(1, counters.foldCalls);
+
+    for (int frame = 1; frame <= 4; ++frame)
+    {
+        input.handle.set(std::vector<int>{ frame });
+        c.update(FrameInfo(frame, {}));
+    }
+
+    // Exactly one fold evaluation per frame despite the fan-out: init + 4.
+    EXPECT_EQ(5, counters.foldCalls);
+
+    // Accumulated fold-state visible through the shared/mapped result.
+    v = c.evaluate<0>().get<0>();
+    EXPECT_EQ(5, v.at(0));
+    EXPECT_EQ(10, v.at(1));
+
+    // The solver was never copied: map reads via const&, share caches only the
+    // small int result.
+    EXPECT_EQ(0, counters.heavyCopyCtor);
+    EXPECT_EQ(0, counters.heavyCopyAssign);
+    EXPECT_EQ(0, counters.copyAssign);
+    EXPECT_LE(counters.copyCtor, 1);
+}


### PR DESCRIPTION
`withPrevious` now moves its fold-state accumulator into the fold function each update instead of copying it. Three edits in `withprevious.h`: take the accumulator by value, feed it to `tuple_cat` as an rvalue via the existing `SignalResult::getTuple() &&`, and `std::move` it in `update()`. No change needed in `signalresult.h`.

Motivation: the planned layout rewrite threads a large movable fold-state (a Cassowary solver) through `withPrevious` - now with zero heavy copies. Generally useful. (Intended pattern maps the accumulator to a small result and shares THAT, since a signal's terminal output is cached by value.)

Backward-compatible: const-ref fold lambdas (e.g. `stream/iterate.h`) bind identically; a by-value lambda gets a move. Full bq suite passes (98 tests, clang-cl).

Semantics note (documented in a doxygen note on `withPrevious`): a fold that throws mid-update leaves the accumulator in a valid-but-moved-from state, not preserved.

New `withprevioustest.cpp` proves zero heavy copies over several rounds, incremental persistence, and single-eval under `.map(const&).share()` fan-out.
