### PR TITLE
Join introspection and render nodes on a shared id

### DIFF
--- a/src/bqui/include/bqui/widget/introspection.h
+++ b/src/bqui/include/bqui/widget/introspection.h
@@ -6,6 +6,7 @@
 
 #include <avg/obb.h>
 #include <avg/transform.h>
+#include <avg/rendertree/uniqueid.h>
 
 #include <memory>
 #include <optional>
@@ -63,6 +64,15 @@ namespace bqui::widget
         avg::Obb obb;
         DataMap data;
         std::vector<IntrospectionChild> children;
+
+        /**
+         * @brief The identity this node shares with its render-tree node.
+         *
+         * Set alongside the render `avg::IdNode` by `setElementId`, so a
+         * consumer can join a node in the introspection tree to the same node
+         * in the render/snapshot tree. Absent when the widget carries no id.
+         */
+        std::optional<avg::UniqueId> id;
     };
 
     /** @brief Wrap a node as a shared immutable child. */

--- a/src/bqui/src/agent/introspectionjson.cpp
+++ b/src/bqui/src/agent/introspectionjson.cpp
@@ -82,6 +82,10 @@ nlohmann::json toJson(widget::Introspection const& node)
     if (node.name)
         result["name"] = *node.name;
 
+    // The same numeric form avg's snapshot emits, so the two trees join on it.
+    if (node.id)
+        result["id"] = node.id->getValue();
+
     result["role"] = node.role;
 
     auto capabilities = nlohmann::json::array();

--- a/src/bqui/src/modifier/setid.cpp
+++ b/src/bqui/src/modifier/setid.cpp
@@ -22,8 +22,12 @@ AnyElementModifier setElementId(bq::signal::AnySignal<avg::UniqueId> id)
                     instance.getRenderTree().getRoot()
                     );
 
+            auto introspection = instance.getIntrospection();
+            introspection.id = id;
+
             return std::move(instance)
                 .setRenderTree(avg::RenderTree(std::move(container)))
+                .setIntrospection(std::move(introspection))
                 ;
         },
         std::move(id)

--- a/src/bqui/src/widget/introspection.cpp
+++ b/src/bqui/src/widget/introspection.cpp
@@ -23,6 +23,7 @@ bool operator==(Introspection const& lhs, Introspection const& rhs)
             || lhs.capabilities != rhs.capabilities
             || lhs.obb != rhs.obb
             || lhs.data != rhs.data
+            || lhs.id != rhs.id
             || lhs.children.size() != rhs.children.size())
     {
         return false;
@@ -44,6 +45,7 @@ Introspection resolveIntrospection(Introspection const& node,
     result.capabilities = node.capabilities;
     result.obb = parent * node.obb;
     result.data = node.data;
+    result.id = node.id;
 
     result.children.reserve(node.children.size());
     for (auto const& child : node.children)

--- a/src/bqui/test/introspectiontest.cpp
+++ b/src/bqui/test/introspectiontest.cpp
@@ -8,6 +8,7 @@
 
 #include <bqui/modifier/setwidgetintrospection.h>
 #include <bqui/modifier/setsize.h>
+#include <bqui/modifier/setid.h>
 #include <bqui/modifier/onclick.h>
 
 #include <bqui/shape/shape.h>
@@ -16,6 +17,7 @@
 
 #include <avg/color.h>
 #include <avg/transform.h>
+#include <avg/rendertree.h>
 
 #include <bq/signal/signal.h>
 #include <bq/signal/signalcontext.h>
@@ -288,6 +290,35 @@ TEST(introspection, resolveComposesDeepNestingAbsolutely)
     auto center = cur->obb.getCenter();
     EXPECT_FLOAT_EQ(expected, center[0]);
     EXPECT_FLOAT_EQ(expected, center[1]);
+}
+
+TEST(introspection, elementIdJoinsRenderAndIntrospection)
+{
+    // setElementId must stamp the same avg::UniqueId onto both sinks: the
+    // render IdNode and the introspection node. That shared value is the join
+    // key an out-of-process client uses to correlate the two trees.
+    avg::UniqueId const id;
+
+    auto element = (filledRect() | setId(bq::signal::constant(id)))
+        (BuildParams{})(bq::signal::constant(avg::Vector2f(200.0f, 100.0f)));
+
+    auto introspection =
+        bq::signal::makeSignalContext(element.getIntrospection())
+            .evaluate<0>().get<0>();
+
+    auto renderTree =
+        bq::signal::makeSignalContext(element.getRenderTree())
+            .evaluate<0>().get<0>();
+
+    auto const& root = renderTree.getRoot();
+    ASSERT_NE(nullptr, root);
+    ASSERT_TRUE(root->getId().has_value());
+    ASSERT_TRUE(introspection.id.has_value());
+
+    // Both sinks carry the exact id, so the two trees join on it.
+    EXPECT_EQ(id, *root->getId());
+    EXPECT_EQ(id, *introspection.id);
+    EXPECT_EQ(*root->getId(), *introspection.id);
 }
 
 TEST(introspection, resolveEqualsEagerComposition)


### PR DESCRIPTION
Give a widget's introspection node and its render/snapshot node the same id so an out-of-process client can join the two trees.

## Join key
- Render side already carries an `avg::UniqueId` on `avg::IdNode` (built by `setElementId`).
- Introspection side gains `std::optional<avg::UniqueId> id` on the `Introspection` struct.
- Both are stamped from the SINGLE `setElementId` seam with the same value, so #116's layout unification will extend the stamp to static children automatically (no extra wiring).

## Serialization
- Introspection JSON emits `"id"` as `UniqueId::getValue()` (a plain uint64 number) - identical to avg snapshot's `"id"` emission - so the two values compare equal across trees.

## Details
- `resolveIntrospection` carries the id to the resolved tree; `operator==` accounts for it.
- Stamped unconditionally, matching this base where `setElementId` always builds an IdNode (both sinks stay in agreement).

## Test
- `introspection.elementIdJoinsRenderAndIntrospection` builds a widget through `setElementId` and asserts the same `UniqueId` appears on both the render root and the resolved introspection node.

## Verify
Built with clang-cl; `btl bq avg bqui` suites all green (btl/bq/avg/bqui: 85/123/78/126 tests, 0 failures).