### PR TITLE
bqui: constraint-solve layout core over vendored arrange (draft)

### DIFF
--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -38,6 +38,7 @@ libbquisrc = [
   'src/widget/bin.cpp',
   'src/widget/button.cpp',
   'src/widget/box.cpp',
+  'src/widget/constraintlayout.cpp',
   'src/widget/datavalue.cpp',
   'src/widget/hbox.cpp',
   'src/widget/instance.cpp',
@@ -121,6 +122,7 @@ libbquidep = declare_dependency(
 bquitestsrc = [
   'test/apptest.cpp',
   'test/collectiontest.cpp',
+  'test/constraintlayouttest.cpp',
   'test/databindtest.cpp',
   'test/headlessapptest.cpp',
   'test/introspectionjsontest.cpp',
@@ -139,7 +141,7 @@ bquitestsrc = [
 # src headers (the adapter is a private header, not part of the public surface).
 bquitest =  executable('bquitest',
   bquitestsrc,
-  dependencies: [gtestdep, libbquidep, nlohmanndep],
+  dependencies: [gtestdep, libbquidep, nlohmanndep, arrangedep],
   include_directories: include_directories('src'),
   )
 

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -86,6 +86,14 @@ bquidep = [libbtldep, libbqdep, libasedep, libavgdep]
 nlohmanndep = dependency('nlohmann_json', include_type: 'system',
     default_options: subproject_warnings)
 
+# arrange is a vendored Cassowary linear-arithmetic constraint solver — UI-
+# agnostic layout math (an "Eigen, not a bq"). Its headers back bqui's own
+# layout .cpp files and never appear in a public bqui header, so like nlohmann
+# it is a dependency of the bqui library only and is deliberately *not* re-
+# exported through libbquidep.
+arrangedep = subproject('arrange',
+    default_options: subproject_warnings).get_variable('arrange_dep').as_system()
+
 # The TCP transport uses Winsock, which needs an explicit link to ws2_32 on
 # Windows; POSIX sockets need no extra link.
 bqui_link_args = []
@@ -97,7 +105,7 @@ libbqui = library(
   'bqui',
   [libbquisrc],
   include_directories: include_directories('include', 'src'),
-  dependencies: bquidep + [nlohmanndep],
+  dependencies: bquidep + [nlohmanndep, arrangedep],
   cpp_args: ['-DBQUI_EXPORT_SYMBOLS'],
   link_args: bqui_link_args,
   gnu_symbol_visibility: 'hidden'

--- a/src/bqui/src/widget/constraintlayout.cpp
+++ b/src/bqui/src/widget/constraintlayout.cpp
@@ -1,0 +1,153 @@
+#include "constraintlayout.h"
+
+#include <avg/transform.h>
+#include <avg/vector.h>
+
+#include <arrange/errors.h>
+#include <arrange/solver.h>
+#include <arrange/strength.h>
+
+#include <utility>
+
+namespace bqui::widget
+{
+
+namespace
+{
+    // The solver rides through the fold as accumulator state alongside the
+    // snapshot it produced. Only the snapshot is mapped out and shared, so the
+    // tableau is never copied at a shared node.
+    struct SolveState
+    {
+        arrange::Solver solver;
+        LayoutSolution solution;
+    };
+
+    float valueOf(LayoutSolution const& solution, arrange::Variable const& v)
+    {
+        auto it = solution.find(v.id());
+        return it != solution.end() ? static_cast<float>(it->second) : 0.0f;
+    }
+
+    arrange::Constraint pin(arrange::Variable const& a, arrange::Variable const& b)
+    {
+        return arrange::Expression(a) == arrange::Expression(b);
+    }
+} // namespace
+
+arrange::Expression BoxVariables::width() const
+{
+    return arrange::Expression(right) - arrange::Expression(left);
+}
+
+arrange::Expression BoxVariables::height() const
+{
+    return arrange::Expression(bottom) - arrange::Expression(top);
+}
+
+bq::signal::AnySignal<LayoutSolution> solveLayout(
+        bq::signal::AnySignal<LayoutSpec> spec)
+{
+    return std::move(spec).withPrevious(
+            [](SolveState state, LayoutSpec const& spec)
+            {
+                try
+                {
+                    state.solver.setConstraints(spec.constraints);
+                }
+                catch (arrange::Error const&)
+                {
+                    // An unsatisfiable update keeps the previous solution rather
+                    // than tearing down the whole signal graph.
+                }
+
+                LayoutSolution solution;
+                solution.reserve(spec.variables.size());
+                for (auto const& variable : spec.variables)
+                    solution.emplace(variable.id(), state.solver.valueOf(variable));
+
+                state.solution = std::move(solution);
+                return state;
+            },
+            SolveState{})
+        .map([](SolveState const& state)
+            {
+                return state.solution;
+            })
+        .share();
+}
+
+avg::Obb readObb(LayoutSolution const& solution, BoxVariables const& box)
+{
+    float left = valueOf(solution, box.left);
+    float top = valueOf(solution, box.top);
+    float right = valueOf(solution, box.right);
+    float bottom = valueOf(solution, box.bottom);
+
+    return avg::Obb(
+            avg::Vector2f(right - left, bottom - top),
+            avg::Transform(avg::Vector2f(left, top)));
+}
+
+std::vector<arrange::Constraint> anchorConstraints(BoxVariables const& box,
+        float left, float top, float right, float bottom)
+{
+    return {
+        arrange::Expression(box.left) == arrange::Expression(left),
+        arrange::Expression(box.top) == arrange::Expression(top),
+        arrange::Expression(box.right) == arrange::Expression(right),
+        arrange::Expression(box.bottom) == arrange::Expression(bottom),
+    };
+}
+
+std::vector<arrange::Constraint> boxConstraints(BoxVariables const& container,
+        std::vector<BoxVariables> const& children, Axis axis)
+{
+    std::vector<arrange::Constraint> out;
+
+    for (std::size_t i = 0; i < children.size(); ++i)
+    {
+        BoxVariables const& child = children[i];
+        bool first = i == 0;
+        bool last = i + 1 == children.size();
+
+        if (axis == Axis::vertical)
+        {
+            out.push_back(pin(child.left, container.left));
+            out.push_back(pin(child.right, container.right));
+            out.push_back(first ? pin(child.top, container.top)
+                                : pin(child.top, children[i - 1].bottom));
+            if (last)
+                out.push_back(pin(child.bottom, container.bottom));
+        }
+        else
+        {
+            out.push_back(pin(child.top, container.top));
+            out.push_back(pin(child.bottom, container.bottom));
+            out.push_back(first ? pin(child.left, container.left)
+                                : pin(child.left, children[i - 1].right));
+            if (last)
+                out.push_back(pin(child.right, container.right));
+        }
+    }
+
+    return out;
+}
+
+std::vector<arrange::Constraint> stackConstraints(BoxVariables const& container,
+        std::vector<BoxVariables> const& children)
+{
+    std::vector<arrange::Constraint> out;
+
+    for (BoxVariables const& child : children)
+    {
+        out.push_back(pin(child.left, container.left));
+        out.push_back(pin(child.top, container.top));
+        out.push_back(pin(child.right, container.right));
+        out.push_back(pin(child.bottom, container.bottom));
+    }
+
+    return out;
+}
+
+} // namespace bqui::widget

--- a/src/bqui/src/widget/constraintlayout.h
+++ b/src/bqui/src/widget/constraintlayout.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "bqui/bquivisibility.h"
+
+#include <bq/signal/signal.h>
+
+#include <avg/obb.h>
+
+#include <arrange/constraint.h>
+#include <arrange/expression.h>
+#include <arrange/id.h>
+#include <arrange/variable.h>
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+namespace bqui::widget
+{
+    /** @brief The four edge variables bounding one widget's box in the shared
+     * constraint system.
+     *
+     * A widget holds its BoxVariables for its whole lifetime, so the arrange
+     * ids stay stable across solves and the solver's incremental diff can match
+     * the widget's constraints from pass to pass.
+     */
+    struct BoxVariables
+    {
+        arrange::Variable left;
+        arrange::Variable top;
+        arrange::Variable right;
+        arrange::Variable bottom;
+
+        BQUI_EXPORT arrange::Expression width() const;
+        BQUI_EXPORT arrange::Expression height() const;
+    };
+
+    /** @brief One subtree's contribution to a solve: the constraints to apply
+     * and the variables whose solved values must be read back.
+     *
+     * The solver exposes no variable iteration, so the variables to read travel
+     * alongside the constraints that mention them.
+     */
+    struct LayoutSpec
+    {
+        std::vector<arrange::Constraint> constraints;
+        std::vector<arrange::Variable> variables;
+    };
+
+    /** @brief A solved layout: each read-back variable's value keyed by its
+     * arrange id. */
+    using LayoutSolution = std::unordered_map<arrange::Id, double>;
+
+    /** @brief Threads one arrange::Solver through the signal graph as a fold,
+     * re-solving whenever @p spec changes, and yields the solved values.
+     *
+     * The solver is fold state — moved from update to update, never copied — and
+     * the result is mapped down to the small value snapshot before it is shared,
+     * so no reader ever copies the tableau. Build this once per window and share
+     * the returned handle with every reader; a second instantiation would fork a
+     * diverging solver.
+     */
+    BQUI_EXPORT bq::signal::AnySignal<LayoutSolution> solveLayout(
+            bq::signal::AnySignal<LayoutSpec> spec);
+
+    /** @brief Reads a box's solved rectangle out of a solution as an avg::Obb.
+     * Variables absent from the solution read as zero. */
+    BQUI_EXPORT avg::Obb readObb(LayoutSolution const& solution,
+            BoxVariables const& box);
+
+    /** @brief Pins a box to a fixed window-space rectangle (required). */
+    BQUI_EXPORT std::vector<arrange::Constraint> anchorConstraints(
+            BoxVariables const& box,
+            float left, float top, float right, float bottom);
+
+    enum class Axis
+    {
+        horizontal,
+        vertical
+    };
+
+    /** @brief Stacks @p children edge-to-edge inside @p container along @p axis.
+     *
+     * Consecutive children meet, the first and last touch the container's ends,
+     * and the cross axis spans the container. The extent along @p axis is left
+     * to each child's own size contribution.
+     */
+    BQUI_EXPORT std::vector<arrange::Constraint> boxConstraints(
+            BoxVariables const& container,
+            std::vector<BoxVariables> const& children, Axis axis);
+
+    /** @brief Overlays every child on @p container, giving each the container's
+     * box. */
+    BQUI_EXPORT std::vector<arrange::Constraint> stackConstraints(
+            BoxVariables const& container,
+            std::vector<BoxVariables> const& children);
+} // namespace bqui::widget

--- a/src/bqui/src/widget/layout.cpp
+++ b/src/bqui/src/widget/layout.cpp
@@ -13,24 +13,11 @@
 
 #include <bq/signal/arraysignal.h>
 
-#include <arrange/solver.h>
-
 namespace bqui::widget
 {
 
 namespace
 {
-
-// Stage-1 link check for the vendored arrange constraint solver: force a real
-// use of the public API so the subproject's headers resolve and its symbols
-// link into libbqui. Remove once genuine layout code consumes arrange.
-[[maybe_unused]] double arrangeLinkCheck()
-{
-    arrange::Solver solver;
-    arrange::Variable x{"x"};
-    solver.addConstraint(arrange::Expression(x) == arrange::Expression(42.0));
-    return solver.valueOf(x);
-}
 
 // Called once per identity, so the id it mints names this child for as long as
 // the child is there. avg::ContainerNode falls back to matching its children by

--- a/src/bqui/src/widget/layout.cpp
+++ b/src/bqui/src/widget/layout.cpp
@@ -13,11 +13,24 @@
 
 #include <bq/signal/arraysignal.h>
 
+#include <arrange/solver.h>
+
 namespace bqui::widget
 {
 
 namespace
 {
+
+// Stage-1 link check for the vendored arrange constraint solver: force a real
+// use of the public API so the subproject's headers resolve and its symbols
+// link into libbqui. Remove once genuine layout code consumes arrange.
+[[maybe_unused]] double arrangeLinkCheck()
+{
+    arrange::Solver solver;
+    arrange::Variable x{"x"};
+    solver.addConstraint(arrange::Expression(x) == arrange::Expression(42.0));
+    return solver.valueOf(x);
+}
 
 // Called once per identity, so the id it mints names this child for as long as
 // the child is there. avg::ContainerNode falls back to matching its children by

--- a/src/bqui/test/constraintlayouttest.cpp
+++ b/src/bqui/test/constraintlayouttest.cpp
@@ -1,0 +1,184 @@
+#include "widget/constraintlayout.h"
+
+#include <bq/signal/constant.h>
+#include <bq/signal/frameinfo.h>
+#include <bq/signal/input.h>
+#include <bq/signal/signal.h>
+#include <bq/signal/signalcontext.h>
+
+#include <arrange/expression.h>
+#include <arrange/strength.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace bqui::widget;
+using namespace bq::signal;
+
+namespace
+{
+    void append(std::vector<arrange::Constraint>& into,
+            std::vector<arrange::Constraint> const& from)
+    {
+        into.insert(into.end(), from.begin(), from.end());
+    }
+
+    LayoutSolution solveOnce(LayoutSpec spec)
+    {
+        auto context = makeSignalContext(
+                solveLayout(AnySignal<LayoutSpec>(constant(std::move(spec)))));
+
+        return context.evaluate<0>().get<0>();
+    }
+} // namespace
+
+// A vertical box lays its children top to bottom: the first child sits at the
+// container top, each following child begins where the previous ended, and the
+// last reaches the container bottom. Sizes come from the children's own
+// contributions, so a strong preferred height on the first child leaves the
+// rest for the second.
+TEST(constraintLayout, verticalBoxStacksChildren)
+{
+    BoxVariables container;
+    BoxVariables a;
+    BoxVariables b;
+
+    LayoutSpec spec;
+    append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 100.f, 60.f));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::vertical));
+    spec.constraints.push_back(
+            (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
+
+    spec.variables = { a.left, a.top, a.right, a.bottom,
+        b.left, b.top, b.right, b.bottom };
+
+    auto solution = solveOnce(std::move(spec));
+
+    EXPECT_DOUBLE_EQ(0.0, solution.at(a.top.id()));
+    EXPECT_DOUBLE_EQ(20.0, solution.at(a.bottom.id()));
+    EXPECT_DOUBLE_EQ(20.0, solution.at(b.top.id()));
+    EXPECT_DOUBLE_EQ(60.0, solution.at(b.bottom.id()));
+    EXPECT_DOUBLE_EQ(0.0, solution.at(a.left.id()));
+    EXPECT_DOUBLE_EQ(100.0, solution.at(a.right.id()));
+
+    avg::Obb obbA = readObb(solution, a);
+    EXPECT_FLOAT_EQ(100.0f, obbA.getSize()[0]);
+    EXPECT_FLOAT_EQ(20.0f, obbA.getSize()[1]);
+}
+
+// A horizontal box is the same story rotated: children run left to right and a
+// strong preferred width on the first leaves the rest for the second.
+TEST(constraintLayout, horizontalBoxStacksChildren)
+{
+    BoxVariables container;
+    BoxVariables a;
+    BoxVariables b;
+
+    LayoutSpec spec;
+    append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 90.f, 30.f));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::horizontal));
+    spec.constraints.push_back(
+            (a.width() == arrange::Expression(30.0)) | arrange::Strength::strong());
+
+    spec.variables = { a.left, a.right, b.left, b.right, a.top, a.bottom };
+
+    auto solution = solveOnce(std::move(spec));
+
+    EXPECT_DOUBLE_EQ(0.0, solution.at(a.left.id()));
+    EXPECT_DOUBLE_EQ(30.0, solution.at(a.right.id()));
+    EXPECT_DOUBLE_EQ(30.0, solution.at(b.left.id()));
+    EXPECT_DOUBLE_EQ(90.0, solution.at(b.right.id()));
+    EXPECT_DOUBLE_EQ(0.0, solution.at(a.top.id()));
+    EXPECT_DOUBLE_EQ(30.0, solution.at(a.bottom.id()));
+}
+
+// A stack overlays its children: each child gets the container's whole box.
+TEST(constraintLayout, stackOverlaysChildren)
+{
+    BoxVariables container;
+    BoxVariables a;
+    BoxVariables b;
+
+    LayoutSpec spec;
+    append(spec.constraints, anchorConstraints(container, 10.f, 20.f, 110.f, 220.f));
+    append(spec.constraints, stackConstraints(container, { a, b }));
+
+    spec.variables = { a.left, a.top, a.right, a.bottom,
+        b.left, b.top, b.right, b.bottom };
+
+    auto solution = solveOnce(std::move(spec));
+
+    for (BoxVariables const& box : { a, b })
+    {
+        EXPECT_DOUBLE_EQ(10.0, solution.at(box.left.id()));
+        EXPECT_DOUBLE_EQ(20.0, solution.at(box.top.id()));
+        EXPECT_DOUBLE_EQ(110.0, solution.at(box.right.id()));
+        EXPECT_DOUBLE_EQ(220.0, solution.at(box.bottom.id()));
+    }
+}
+
+// A required minimum outranks a strong preferred size: the first child prefers
+// 20 but is required to be at least 30, so it takes 30 and the second fills the
+// remaining 30.
+TEST(constraintLayout, requiredMinimumBeatsStrongPreferred)
+{
+    BoxVariables container;
+    BoxVariables a;
+    BoxVariables b;
+
+    LayoutSpec spec;
+    append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 100.f, 60.f));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::vertical));
+    spec.constraints.push_back(
+            (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
+    spec.constraints.push_back(a.height() >= arrange::Expression(30.0));
+
+    spec.variables = { a.bottom, b.top, b.bottom };
+
+    auto solution = solveOnce(std::move(spec));
+
+    EXPECT_DOUBLE_EQ(30.0, solution.at(a.bottom.id()));
+    EXPECT_DOUBLE_EQ(30.0, solution.at(b.top.id()));
+    EXPECT_DOUBLE_EQ(60.0, solution.at(b.bottom.id()));
+}
+
+// The solver is fold state: when the constraints change the same solver
+// re-solves and every reader sees the new geometry. Growing the container
+// widens both children and hands the freed vertical space to the filler child.
+TEST(constraintLayout, resolvesWhenConstraintsChange)
+{
+    BoxVariables container;
+    BoxVariables a;
+    BoxVariables b;
+
+    auto describe = [&](float width, float height)
+    {
+        LayoutSpec spec;
+        append(spec.constraints,
+                anchorConstraints(container, 0.f, 0.f, width, height));
+        append(spec.constraints,
+                boxConstraints(container, { a, b }, Axis::vertical));
+        spec.constraints.push_back(
+                (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
+        spec.variables = { a.right, a.bottom, b.top, b.bottom };
+        return spec;
+    };
+
+    auto input = makeInput(describe(100.f, 60.f));
+    auto context = makeSignalContext(solveLayout(AnySignal<LayoutSpec>(input.signal)));
+
+    auto before = context.evaluate<0>().get<0>();
+    EXPECT_DOUBLE_EQ(100.0, before.at(a.right.id()));
+    EXPECT_DOUBLE_EQ(60.0, before.at(b.bottom.id()));
+    EXPECT_DOUBLE_EQ(40.0, before.at(b.bottom.id()) - before.at(b.top.id()));
+
+    input.handle.set(describe(200.f, 100.f));
+    context.update(FrameInfo(1, {}));
+
+    auto after = context.evaluate<0>().get<0>();
+    EXPECT_DOUBLE_EQ(200.0, after.at(a.right.id()));
+    EXPECT_DOUBLE_EQ(20.0, after.at(a.bottom.id()));
+    EXPECT_DOUBLE_EQ(100.0, after.at(b.bottom.id()));
+    EXPECT_DOUBLE_EQ(80.0, after.at(b.bottom.id()) - after.at(b.top.id()));
+}

--- a/subprojects/arrange/include/arrange/arrange.h
+++ b/subprojects/arrange/include/arrange/arrange.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <arrange/constraint.h>
+#include <arrange/diff.h>
+#include <arrange/errors.h>
+#include <arrange/expression.h>
+#include <arrange/id.h>
+#include <arrange/solver.h>
+#include <arrange/strength.h>
+#include <arrange/variable.h>

--- a/subprojects/arrange/include/arrange/constraint.h
+++ b/subprojects/arrange/include/arrange/constraint.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <arrange/expression.h>
+#include <arrange/id.h>
+#include <arrange/strength.h>
+
+#include <memory>
+
+namespace arrange
+{
+
+class ConstraintImpl;
+class SolverImpl;
+
+class Constraint
+{
+public:
+    Constraint(const Constraint&) = default;
+    Constraint(Constraint&&) noexcept = default;
+    Constraint& operator=(const Constraint&) = default;
+    Constraint& operator=(Constraint&&) noexcept = default;
+
+    Id id() const noexcept;
+    const Expression& expression() const noexcept;
+    Strength strength() const noexcept;
+
+    Constraint withId(Id id) const;
+    Constraint withStrength(Strength strength) const;
+
+private:
+    friend Constraint operator==(Expression lhs, Expression rhs);
+    friend Constraint operator<=(Expression lhs, Expression rhs);
+    friend Constraint operator>=(Expression lhs, Expression rhs);
+    friend class SolverImpl;
+
+    explicit Constraint(std::shared_ptr<const ConstraintImpl> impl) noexcept;
+
+    std::shared_ptr<const ConstraintImpl> impl_{};
+};
+
+Constraint operator==(Expression lhs, Expression rhs);
+Constraint operator<=(Expression lhs, Expression rhs);
+Constraint operator>=(Expression lhs, Expression rhs);
+
+Constraint operator|(Constraint c, Strength s);
+Constraint operator|(Strength s, Constraint c);
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/diff.h
+++ b/subprojects/arrange/include/arrange/diff.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <arrange/constraint.h>
+
+#include <vector>
+
+namespace arrange
+{
+
+struct ConstraintDiff
+{
+    std::vector<Constraint> added;
+    std::vector<Constraint> removed;
+};
+
+ConstraintDiff diffConstraints(
+    const std::vector<Constraint>& before, const std::vector<Constraint>& after);
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/errors.h
+++ b/subprojects/arrange/include/arrange/errors.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace arrange
+{
+
+class Error : public std::runtime_error
+{
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class UnsatisfiableConstraint : public Error
+{
+public:
+    using Error::Error;
+};
+class DuplicateConstraint : public Error
+{
+public:
+    using Error::Error;
+};
+class UnknownConstraint : public Error
+{
+public:
+    using Error::Error;
+};
+class DuplicateEditVariable : public Error
+{
+public:
+    using Error::Error;
+};
+class UnknownEditVariable : public Error
+{
+public:
+    using Error::Error;
+};
+class RequiredFailure : public Error
+{
+public:
+    using Error::Error;
+};
+class BadStrength : public Error
+{
+public:
+    using Error::Error;
+};
+class BadId : public Error
+{
+public:
+    using Error::Error;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/expression.h
+++ b/subprojects/arrange/include/arrange/expression.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <arrange/variable.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace arrange
+{
+
+class ExpressionImpl;
+
+class Expression
+{
+public:
+    Expression();
+    Expression(double constant);
+    Expression(Variable v);
+    Expression(double coefficient, Variable v);
+
+    double constant() const noexcept;
+
+    struct Term
+    {
+        double coefficient;
+        Variable variable;
+    };
+
+    std::size_t termCount() const noexcept;
+    Term term(std::size_t index) const;
+
+private:
+    explicit Expression(std::shared_ptr<const ExpressionImpl> impl) noexcept;
+
+    friend Expression operator+(Expression lhs, Expression rhs);
+    friend Expression operator-(Expression lhs, Expression rhs);
+    friend Expression operator-(Expression expr);
+    friend Expression operator*(Expression expr, double scalar);
+    friend Expression operator*(double scalar, Expression expr);
+    friend Expression operator/(Expression expr, double divisor);
+
+    std::shared_ptr<const ExpressionImpl> impl_{};
+};
+
+Expression operator+(Expression lhs, Expression rhs);
+Expression operator-(Expression lhs, Expression rhs);
+Expression operator-(Expression expr);
+Expression operator*(Expression expr, double scalar);
+Expression operator*(double scalar, Expression expr);
+Expression operator/(Expression expr, double divisor);
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/id.h
+++ b/subprojects/arrange/include/arrange/id.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace arrange
+{
+
+using Id = std::uint64_t;
+
+inline constexpr Id nullId = 0;
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/solver.h
+++ b/subprojects/arrange/include/arrange/solver.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <arrange/constraint.h>
+#include <arrange/diff.h>
+#include <arrange/strength.h>
+#include <arrange/variable.h>
+
+#include <memory>
+#include <vector>
+
+namespace arrange
+{
+
+class SolverImpl;
+
+class Solver
+{
+public:
+    Solver();
+    ~Solver();
+
+    Solver(const Solver& other);
+    Solver& operator=(const Solver& other);
+
+    Solver(Solver&& other) noexcept;
+    Solver& operator=(Solver&& other) noexcept;
+
+    void addConstraint(const Constraint& c);
+    void removeConstraint(const Constraint& c);
+    bool hasConstraint(const Constraint& c) const noexcept;
+
+    ConstraintDiff setConstraints(const std::vector<Constraint>& desired);
+
+    void addEditVariable(const Variable& v, Strength s);
+    void removeEditVariable(const Variable& v);
+    bool hasEditVariable(const Variable& v) const noexcept;
+    void suggestValue(const Variable& v, double value);
+
+    double valueOf(const Variable& v) const;
+    bool contains(const Variable& v) const noexcept;
+
+    void reset();
+
+private:
+    std::unique_ptr<SolverImpl> impl_;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/strength.h
+++ b/subprojects/arrange/include/arrange/strength.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace arrange
+{
+
+class Strength
+{
+public:
+    static Strength required();
+    static Strength strong(double weight = 1.0);
+    static Strength medium(double weight = 1.0);
+    static Strength weak(double weight = 1.0);
+    static Strength create(double strong, double medium, double weak, double weight = 1.0);
+
+    double value() const noexcept;
+    bool isRequired() const noexcept;
+
+    bool operator==(const Strength& other) const noexcept;
+    bool operator!=(const Strength& other) const noexcept;
+    bool operator<(const Strength& other) const noexcept;
+    bool operator<=(const Strength& other) const noexcept;
+    bool operator>(const Strength& other) const noexcept;
+    bool operator>=(const Strength& other) const noexcept;
+
+private:
+    explicit Strength(double value) noexcept;
+
+    double value_{};
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/include/arrange/variable.h
+++ b/subprojects/arrange/include/arrange/variable.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <arrange/id.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace arrange
+{
+
+class Variable
+{
+public:
+    Variable();
+    explicit Variable(std::string_view name);
+
+    explicit Variable(Id id);
+    Variable(Id id, std::string_view name);
+
+    Id id() const noexcept;
+    std::string_view name() const noexcept;
+
+    bool operator==(const Variable& other) const noexcept;
+    bool operator!=(const Variable& other) const noexcept;
+
+private:
+    Id id_{};
+    std::shared_ptr<const std::string> name_{};
+};
+
+struct VariableHash
+{
+    std::size_t operator()(const Variable& v) const noexcept;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/meson.build
+++ b/subprojects/arrange/meson.build
@@ -1,0 +1,25 @@
+project('arrange', 'cpp',
+  default_options: ['cpp_std=c++17', 'default_library=static'])
+
+arrange_inc = include_directories('include')
+
+arrange_sources = files(
+  'src/constraint.cpp',
+  'src/diff.cpp',
+  'src/expression.cpp',
+  'src/id_counter.cpp',
+  'src/solver.cpp',
+  'src/strength.cpp',
+  'src/variable.cpp',
+)
+
+arrange_lib = library(
+  'arrange',
+  arrange_sources,
+  include_directories: arrange_inc,
+)
+
+arrange_dep = declare_dependency(
+  link_with: arrange_lib,
+  include_directories: arrange_inc,
+)

--- a/subprojects/arrange/src/constraint.cpp
+++ b/subprojects/arrange/src/constraint.cpp
@@ -1,0 +1,82 @@
+#include "constraint_impl.h"
+
+#include <arrange/constraint.h>
+
+#include <memory>
+#include <utility>
+
+namespace arrange
+{
+
+namespace
+{
+
+std::shared_ptr<const ConstraintImpl> makeImpl(
+    Expression expr, Relation relation, Strength strength, Id id)
+{
+    auto impl = std::make_shared<ConstraintImpl>();
+    impl->expression = std::move(expr);
+    impl->relation = relation;
+    impl->strength = strength;
+    impl->id = id;
+    return impl;
+}
+
+}  // namespace
+
+Constraint::Constraint(std::shared_ptr<const ConstraintImpl> impl) noexcept
+    : impl_(std::move(impl))
+{
+}
+
+Id Constraint::id() const noexcept
+{
+    return impl_ ? impl_->id : nullId;
+}
+
+const Expression& Constraint::expression() const noexcept
+{
+    return impl_->expression;
+}
+
+Strength Constraint::strength() const noexcept
+{
+    return impl_ ? impl_->strength : Strength::required();
+}
+
+Constraint Constraint::withId(Id id) const
+{
+    return Constraint{makeImpl(impl_->expression, impl_->relation, impl_->strength, id)};
+}
+
+Constraint Constraint::withStrength(Strength strength) const
+{
+    return Constraint{makeImpl(impl_->expression, impl_->relation, strength, impl_->id)};
+}
+
+Constraint operator==(Expression lhs, Expression rhs)
+{
+    return Constraint{makeImpl(lhs - rhs, Relation::eq, Strength::required(), nullId)};
+}
+
+Constraint operator<=(Expression lhs, Expression rhs)
+{
+    return Constraint{makeImpl(lhs - rhs, Relation::le, Strength::required(), nullId)};
+}
+
+Constraint operator>=(Expression lhs, Expression rhs)
+{
+    return Constraint{makeImpl(lhs - rhs, Relation::ge, Strength::required(), nullId)};
+}
+
+Constraint operator|(Constraint c, Strength s)
+{
+    return c.withStrength(s);
+}
+
+Constraint operator|(Strength s, Constraint c)
+{
+    return c.withStrength(s);
+}
+
+}  // namespace arrange

--- a/subprojects/arrange/src/constraint_impl.h
+++ b/subprojects/arrange/src/constraint_impl.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <arrange/expression.h>
+#include <arrange/id.h>
+#include <arrange/strength.h>
+
+namespace arrange
+{
+
+enum class Relation
+{
+    eq,
+    le,
+    ge
+};
+
+class ConstraintImpl
+{
+public:
+    Expression expression{};
+    Relation relation = Relation::eq;
+    Strength strength = Strength::required();
+    Id id = nullId;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/src/diff.cpp
+++ b/subprojects/arrange/src/diff.cpp
@@ -1,0 +1,53 @@
+#include <arrange/diff.h>
+
+#include <unordered_set>
+
+namespace arrange
+{
+
+ConstraintDiff diffConstraints(
+    const std::vector<Constraint>& before, const std::vector<Constraint>& after)
+{
+    std::unordered_set<Id> beforeIds;
+    beforeIds.reserve(before.size());
+    for (const auto& c : before)
+    {
+        if (c.id() != nullId)
+        {
+            beforeIds.insert(c.id());
+        }
+    }
+
+    std::unordered_set<Id> afterIds;
+    afterIds.reserve(after.size());
+    for (const auto& c : after)
+    {
+        if (c.id() != nullId)
+        {
+            afterIds.insert(c.id());
+        }
+    }
+
+    ConstraintDiff diff;
+    diff.removed.reserve(before.size());
+    diff.added.reserve(after.size());
+
+    for (const auto& c : before)
+    {
+        if (c.id() == nullId || afterIds.find(c.id()) == afterIds.end())
+        {
+            diff.removed.push_back(c);
+        }
+    }
+    for (const auto& c : after)
+    {
+        if (c.id() == nullId || beforeIds.find(c.id()) == beforeIds.end())
+        {
+            diff.added.push_back(c);
+        }
+    }
+
+    return diff;
+}
+
+}  // namespace arrange

--- a/subprojects/arrange/src/expression.cpp
+++ b/subprojects/arrange/src/expression.cpp
@@ -1,0 +1,160 @@
+#include "expression_impl.h"
+
+#include <arrange/expression.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace arrange
+{
+
+namespace
+{
+
+std::vector<Expression::Term> canonicalizeTerms(std::vector<Expression::Term> terms)
+{
+    std::sort(terms.begin(),
+        terms.end(),
+        [](const Expression::Term& a, const Expression::Term& b)
+        { return a.variable.id() < b.variable.id(); });
+    std::vector<Expression::Term> out;
+    out.reserve(terms.size());
+    for (auto& t : terms)
+    {
+        if (!out.empty() && out.back().variable.id() == t.variable.id())
+        {
+            out.back().coefficient += t.coefficient;
+        }
+        else
+        {
+            out.push_back(std::move(t));
+        }
+    }
+    out.erase(
+        std::remove_if(
+            out.begin(), out.end(), [](const Expression::Term& t) { return t.coefficient == 0.0; }),
+        out.end());
+    return out;
+}
+
+std::shared_ptr<const ExpressionImpl> makeImpl(double constant, std::vector<Expression::Term> terms)
+{
+    auto impl = std::make_shared<ExpressionImpl>();
+    impl->constant = constant;
+    impl->terms = canonicalizeTerms(std::move(terms));
+    return impl;
+}
+
+std::vector<Expression::Term> copyTerms(const ExpressionImpl& impl)
+{
+    return impl.terms;
+}
+
+}  // namespace
+
+Expression::Expression()
+    : impl_(makeImpl(0.0, {}))
+{
+}
+
+Expression::Expression(double constant)
+    : impl_(makeImpl(constant, {}))
+{
+}
+
+Expression::Expression(Variable v)
+    : impl_(makeImpl(0.0, {{1.0, std::move(v)}}))
+{
+}
+
+Expression::Expression(double coefficient, Variable v)
+    : impl_(makeImpl(0.0, {{coefficient, std::move(v)}}))
+{
+}
+
+Expression::Expression(std::shared_ptr<const ExpressionImpl> impl) noexcept
+    : impl_(std::move(impl))
+{
+}
+
+double Expression::constant() const noexcept
+{
+    return impl_->constant;
+}
+
+std::size_t Expression::termCount() const noexcept
+{
+    return impl_->terms.size();
+}
+
+Expression::Term Expression::term(std::size_t index) const
+{
+    if (index >= impl_->terms.size())
+    {
+        throw std::out_of_range{"Expression::term index out of range"};
+    }
+    return impl_->terms[index];
+}
+
+Expression operator+(Expression lhs, Expression rhs)
+{
+    std::vector<Expression::Term> terms = copyTerms(*lhs.impl_);
+    const auto& rhsTerms = rhs.impl_->terms;
+    terms.insert(terms.end(), rhsTerms.begin(), rhsTerms.end());
+    return Expression{makeImpl(lhs.impl_->constant + rhs.impl_->constant, std::move(terms))};
+}
+
+Expression operator-(Expression lhs, Expression rhs)
+{
+    std::vector<Expression::Term> terms = copyTerms(*lhs.impl_);
+    terms.reserve(terms.size() + rhs.impl_->terms.size());
+    for (const auto& t : rhs.impl_->terms)
+    {
+        terms.push_back({-t.coefficient, t.variable});
+    }
+    return Expression{makeImpl(lhs.impl_->constant - rhs.impl_->constant, std::move(terms))};
+}
+
+Expression operator-(Expression expr)
+{
+    std::vector<Expression::Term> terms;
+    terms.reserve(expr.impl_->terms.size());
+    for (const auto& t : expr.impl_->terms)
+    {
+        terms.push_back({-t.coefficient, t.variable});
+    }
+    return Expression{makeImpl(-expr.impl_->constant, std::move(terms))};
+}
+
+Expression operator*(Expression expr, double scalar)
+{
+    if (scalar == 0.0)
+    {
+        return Expression{};
+    }
+    std::vector<Expression::Term> terms;
+    terms.reserve(expr.impl_->terms.size());
+    for (const auto& t : expr.impl_->terms)
+    {
+        terms.push_back({t.coefficient * scalar, t.variable});
+    }
+    return Expression{makeImpl(expr.impl_->constant * scalar, std::move(terms))};
+}
+
+Expression operator*(double scalar, Expression expr)
+{
+    return operator*(std::move(expr), scalar);
+}
+
+Expression operator/(Expression expr, double divisor)
+{
+    if (divisor == 0.0)
+    {
+        throw std::invalid_argument{"arrange: Expression division by zero"};
+    }
+    return operator*(std::move(expr), 1.0 / divisor);
+}
+
+}  // namespace arrange

--- a/subprojects/arrange/src/expression_impl.h
+++ b/subprojects/arrange/src/expression_impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <arrange/expression.h>
+
+#include <vector>
+
+namespace arrange
+{
+
+class ExpressionImpl
+{
+public:
+    double constant;
+    std::vector<Expression::Term> terms;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/src/id_counter.cpp
+++ b/subprojects/arrange/src/id_counter.cpp
@@ -1,0 +1,22 @@
+#include "id_counter.h"
+
+#include <atomic>
+
+namespace arrange::detail
+{
+
+namespace
+{
+
+constexpr Id kAutoVariableIdStart = Id{1} << 63;
+
+std::atomic<Id> g_variableCounter{kAutoVariableIdStart};
+
+}  // namespace
+
+Id nextAutoVariableId() noexcept
+{
+    return g_variableCounter.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace arrange::detail

--- a/subprojects/arrange/src/id_counter.h
+++ b/subprojects/arrange/src/id_counter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <arrange/id.h>
+
+namespace arrange::detail
+{
+
+Id nextAutoVariableId() noexcept;
+
+}  // namespace arrange::detail

--- a/subprojects/arrange/src/solver.cpp
+++ b/subprojects/arrange/src/solver.cpp
@@ -1,0 +1,829 @@
+#include "constraint_impl.h"
+#include "solver_impl.h"
+
+#include <arrange/diff.h>
+#include <arrange/errors.h>
+#include <arrange/solver.h>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+
+namespace arrange
+{
+
+// --- Row --------------------------------------------------------------------
+
+void Row::insertSymbol(Symbol s, double coefficient)
+{
+    auto [it, inserted] = cells_.try_emplace(s, coefficient);
+    if (!inserted)
+    {
+        it->second += coefficient;
+        if (isNearZero(it->second))
+        {
+            cells_.erase(it);
+        }
+    }
+}
+
+void Row::insertRow(const Row& other, double coefficient)
+{
+    constant_ += other.constant_ * coefficient;
+    for (const auto& [s, v] : other.cells_)
+    {
+        insertSymbol(s, v * coefficient);
+    }
+}
+
+void Row::removeSymbol(Symbol s)
+{
+    cells_.erase(s);
+}
+
+void Row::reverseSign()
+{
+    constant_ = -constant_;
+    for (auto& [s, v] : cells_)
+    {
+        v = -v;
+    }
+}
+
+void Row::solveForSymbol(Symbol s)
+{
+    // Row is: 0 = constant_ + sum(coeff_i * sym_i) + coeff_s * s
+    // Solve: s = -(constant_ + sum(coeff_i * sym_i)) / coeff_s
+    auto it = cells_.find(s);
+    const double coeff = -1.0 / it->second;
+    cells_.erase(it);
+    constant_ *= coeff;
+    for (auto& [sym, v] : cells_)
+    {
+        v *= coeff;
+    }
+}
+
+void Row::solveForSymbols(Symbol lhs, Symbol rhs)
+{
+    insertSymbol(lhs, -1.0);
+    solveForSymbol(rhs);
+}
+
+double Row::coefficientFor(Symbol s) const
+{
+    auto it = cells_.find(s);
+    return it == cells_.end() ? 0.0 : it->second;
+}
+
+void Row::substitute(Symbol s, const Row& row)
+{
+    auto it = cells_.find(s);
+    if (it == cells_.end())
+    {
+        return;
+    }
+    const double coeff = it->second;
+    cells_.erase(it);
+    insertRow(row, coeff);
+}
+
+// --- SolverImpl helpers -----------------------------------------------------
+
+SolverImpl::SolverImpl() = default;
+
+SolverImpl::SolverImpl(const SolverImpl& other)
+    : rows_(other.rows_)
+    , vars_(other.vars_)
+    , constraintTags_(other.constraintTags_)
+    , idToImpl_(other.idToImpl_)
+    , trackedConstraints_(other.trackedConstraints_)
+    , edits_(other.edits_)
+    , infeasibleRows_(other.infeasibleRows_)
+    , objective_(other.objective_)
+    , artificial_(nullptr)
+    , symbolCounter_(other.symbolCounter_)
+{
+}
+
+SolverImpl& SolverImpl::operator=(const SolverImpl& other)
+{
+    if (this != &other)
+    {
+        rows_ = other.rows_;
+        vars_ = other.vars_;
+        constraintTags_ = other.constraintTags_;
+        idToImpl_ = other.idToImpl_;
+        trackedConstraints_ = other.trackedConstraints_;
+        edits_ = other.edits_;
+        infeasibleRows_ = other.infeasibleRows_;
+        objective_ = other.objective_;
+        artificial_.reset();
+        symbolCounter_ = other.symbolCounter_;
+    }
+    return *this;
+}
+
+Symbol SolverImpl::nextSymbol(Symbol::Type t)
+{
+    return Symbol{t, symbolCounter_++};
+}
+
+Symbol SolverImpl::getVarSymbol(const Variable& v)
+{
+    auto it = vars_.find(v.id());
+    if (it != vars_.end())
+    {
+        return it->second;
+    }
+    Symbol sym = nextSymbol(Symbol::Type::external);
+    vars_.emplace(v.id(), sym);
+    return sym;
+}
+
+Row SolverImpl::createRow(const Constraint& c, Tag& tagOut)
+{
+    const Expression& expr = c.impl_->expression;
+    Row row(expr.constant());
+    for (std::size_t i = 0; i < expr.termCount(); ++i)
+    {
+        const auto t = expr.term(i);
+        if (isNearZero(t.coefficient))
+        {
+            continue;
+        }
+        Symbol sym = getVarSymbol(t.variable);
+        auto it = rows_.find(sym);
+        if (it != rows_.end())
+        {
+            row.insertRow(it->second, t.coefficient);
+        }
+        else
+        {
+            row.insertSymbol(sym, t.coefficient);
+        }
+    }
+
+    const Strength strength = c.impl_->strength;
+    const Relation rel = c.impl_->relation;
+
+    switch (rel)
+    {
+    case Relation::le:
+    case Relation::ge:
+    {
+        const double coeff = (rel == Relation::le) ? 1.0 : -1.0;
+        Symbol slack = nextSymbol(Symbol::Type::slack);
+        tagOut.marker = slack;
+        row.insertSymbol(slack, coeff);
+        if (!strength.isRequired())
+        {
+            Symbol error = nextSymbol(Symbol::Type::error);
+            tagOut.other = error;
+            row.insertSymbol(error, -coeff);
+            objective_.insertSymbol(error, strength.value());
+        }
+        break;
+    }
+    case Relation::eq:
+    {
+        if (!strength.isRequired())
+        {
+            Symbol errPlus = nextSymbol(Symbol::Type::error);
+            Symbol errMinus = nextSymbol(Symbol::Type::error);
+            tagOut.marker = errPlus;
+            tagOut.other = errMinus;
+            row.insertSymbol(errPlus, -1.0);
+            row.insertSymbol(errMinus, 1.0);
+            objective_.insertSymbol(errPlus, strength.value());
+            objective_.insertSymbol(errMinus, strength.value());
+        }
+        else
+        {
+            Symbol dummy = nextSymbol(Symbol::Type::dummy);
+            tagOut.marker = dummy;
+            row.insertSymbol(dummy, 1.0);
+        }
+        break;
+    }
+    }
+
+    if (row.constant() < 0.0)
+    {
+        row.reverseSign();
+    }
+    return row;
+}
+
+Symbol SolverImpl::chooseSubject(const Row& row, const Tag& tag) const
+{
+    for (const auto& [sym, coeff] : row.cells())
+    {
+        if (sym.type() == Symbol::Type::external)
+        {
+            return sym;
+        }
+    }
+    if (tag.marker.type() == Symbol::Type::slack || tag.marker.type() == Symbol::Type::error)
+    {
+        if (row.coefficientFor(tag.marker) < 0.0)
+        {
+            return tag.marker;
+        }
+    }
+    if (tag.other.type() == Symbol::Type::slack || tag.other.type() == Symbol::Type::error)
+    {
+        if (row.coefficientFor(tag.other) < 0.0)
+        {
+            return tag.other;
+        }
+    }
+    return Symbol{};
+}
+
+bool SolverImpl::addWithArtificialVariable(const Row& rowIn)
+{
+    Symbol art = nextSymbol(Symbol::Type::slack);
+    rows_.emplace(art, rowIn);
+    artificial_ = std::make_unique<Row>(rowIn);
+
+    optimize(*artificial_);
+    const bool success = isNearZero(artificial_->constant());
+    artificial_.reset();
+
+    auto itArt = rows_.find(art);
+    if (itArt != rows_.end())
+    {
+        Row artRow = std::move(itArt->second);
+        rows_.erase(itArt);
+        if (!artRow.cells().empty())
+        {
+            Symbol entering{};
+            for (const auto& [sym, coeff] : artRow.cells())
+            {
+                if (sym.type() != Symbol::Type::dummy)
+                {
+                    entering = sym;
+                    break;
+                }
+            }
+            if (entering.type() == Symbol::Type::invalid)
+            {
+                return false;
+            }
+            artRow.solveForSymbols(art, entering);
+            substitute(entering, artRow);
+            rows_.emplace(entering, std::move(artRow));
+        }
+    }
+    for (auto& [basic, r] : rows_)
+    {
+        r.removeSymbol(art);
+    }
+    objective_.removeSymbol(art);
+    return success;
+}
+
+void SolverImpl::substitute(Symbol s, const Row& row)
+{
+    for (auto& [basic, r] : rows_)
+    {
+        r.substitute(s, row);
+        if (basic.type() != Symbol::Type::external && r.constant() < 0.0)
+        {
+            infeasibleRows_.push_back(basic);
+        }
+    }
+    objective_.substitute(s, row);
+    if (artificial_)
+    {
+        artificial_->substitute(s, row);
+    }
+}
+
+Symbol SolverImpl::getEnteringSymbol(const Row& objective) const
+{
+    for (const auto& [sym, coeff] : objective.cells())
+    {
+        if (sym.type() != Symbol::Type::dummy && coeff < -kSolverEpsilon)
+        {
+            return sym;
+        }
+    }
+    return Symbol{};
+}
+
+Symbol SolverImpl::getLeavingSymbol(Symbol entering) const
+{
+    double ratio = std::numeric_limits<double>::infinity();
+    Symbol leaving{};
+    for (const auto& [basic, row] : rows_)
+    {
+        if (basic.type() == Symbol::Type::external)
+        {
+            continue;
+        }
+        const double coeff = row.coefficientFor(entering);
+        if (coeff < -kSolverEpsilon)
+        {
+            const double r = -row.constant() / coeff;
+            if (r < ratio)
+            {
+                ratio = r;
+                leaving = basic;
+            }
+        }
+    }
+    return leaving;
+}
+
+Symbol SolverImpl::getMarkerLeavingSymbol(Symbol marker) const
+{
+    const double inf = std::numeric_limits<double>::infinity();
+    double r1 = inf;
+    double r2 = inf;
+    Symbol first{};
+    Symbol second{};
+    Symbol third{};
+    for (const auto& [basic, row] : rows_)
+    {
+        const double c = row.coefficientFor(marker);
+        if (c == 0.0)
+        {
+            continue;
+        }
+        if (basic.type() == Symbol::Type::external)
+        {
+            third = basic;
+        }
+        else if (c < 0.0)
+        {
+            const double r = -row.constant() / c;
+            if (r < r1)
+            {
+                r1 = r;
+                first = basic;
+            }
+        }
+        else
+        {
+            const double r = row.constant() / c;
+            if (r < r2)
+            {
+                r2 = r;
+                second = basic;
+            }
+        }
+    }
+    if (first.type() != Symbol::Type::invalid)
+        return first;
+    if (second.type() != Symbol::Type::invalid)
+        return second;
+    return third;
+}
+
+Symbol SolverImpl::getDualEnteringSymbol(const Row& row) const
+{
+    double ratio = std::numeric_limits<double>::infinity();
+    Symbol entering{};
+    for (const auto& [sym, coeff] : row.cells())
+    {
+        if (coeff > 0.0 && sym.type() != Symbol::Type::dummy)
+        {
+            const double objCoeff = objective_.coefficientFor(sym);
+            const double r = objCoeff / coeff;
+            if (r < ratio)
+            {
+                ratio = r;
+                entering = sym;
+            }
+        }
+    }
+    return entering;
+}
+
+void SolverImpl::optimize(Row& objective)
+{
+    while (true)
+    {
+        Symbol entering = getEnteringSymbol(objective);
+        if (entering.type() == Symbol::Type::invalid)
+        {
+            return;
+        }
+        Symbol leaving = getLeavingSymbol(entering);
+        if (leaving.type() == Symbol::Type::invalid)
+        {
+            throw Error{"arrange: solver internal error — unbounded objective"};
+        }
+        auto it = rows_.find(leaving);
+        Row row = std::move(it->second);
+        rows_.erase(it);
+        row.solveForSymbols(leaving, entering);
+        substitute(entering, row);
+        objective.substitute(entering, row);
+        rows_.emplace(entering, std::move(row));
+    }
+}
+
+void SolverImpl::dualOptimize()
+{
+    while (!infeasibleRows_.empty())
+    {
+        Symbol leaving = infeasibleRows_.back();
+        infeasibleRows_.pop_back();
+        auto it = rows_.find(leaving);
+        if (it == rows_.end() || it->second.constant() >= 0.0)
+        {
+            continue;
+        }
+        Row row = std::move(it->second);
+        rows_.erase(it);
+        Symbol entering = getDualEnteringSymbol(row);
+        if (entering.type() == Symbol::Type::invalid)
+        {
+            throw Error{"arrange: solver internal error — dual optimize failed"};
+        }
+        row.solveForSymbols(leaving, entering);
+        substitute(entering, row);
+        rows_.emplace(entering, std::move(row));
+    }
+}
+
+void SolverImpl::removeMarkerEffects(Symbol marker, const Strength& strength)
+{
+    objective_.insertSymbol(marker, -strength.value());
+}
+
+void SolverImpl::removeConstraintEffects(const Constraint& c, const Tag& tag)
+{
+    const Strength s = c.strength();
+    if (!s.isRequired())
+    {
+        // Error variables were added with +strength to the objective.
+        if (tag.marker.type() == Symbol::Type::error)
+        {
+            removeMarkerEffects(tag.marker, s);
+        }
+        if (tag.other.type() == Symbol::Type::error)
+        {
+            removeMarkerEffects(tag.other, s);
+        }
+    }
+}
+
+// --- Public API -------------------------------------------------------------
+
+void SolverImpl::addConstraint(const Constraint& c)
+{
+    const Id id = c.id();
+    if (id != nullId)
+    {
+        if (idToImpl_.find(id) != idToImpl_.end())
+        {
+            throw DuplicateConstraint{"arrange: constraint id already present"};
+        }
+    }
+    if (constraintTags_.find(c.impl_.get()) != constraintTags_.end())
+    {
+        throw DuplicateConstraint{"arrange: constraint already present"};
+    }
+
+    Tag tag;
+    Row row = createRow(c, tag);
+    Symbol subject = chooseSubject(row, tag);
+
+    if (subject.type() == Symbol::Type::invalid && row.cells().empty())
+    {
+        // All-dummy row. Valid only if constant is zero.
+        if (isNearZero(row.constant()))
+        {
+            subject = tag.marker;
+        }
+        else
+        {
+            throw UnsatisfiableConstraint{"arrange: required constraint unsatisfiable"};
+        }
+    }
+
+    if (subject.type() == Symbol::Type::invalid)
+    {
+        if (!addWithArtificialVariable(row))
+        {
+            throw UnsatisfiableConstraint{"arrange: required constraint unsatisfiable"};
+        }
+    }
+    else
+    {
+        row.solveForSymbol(subject);
+        substitute(subject, row);
+        rows_.emplace(subject, std::move(row));
+    }
+
+    constraintTags_.emplace(c.impl_.get(), tag);
+    trackedConstraints_.emplace(c.impl_.get(), c);
+    if (id != nullId)
+    {
+        idToImpl_.emplace(id, c.impl_.get());
+    }
+    optimize(objective_);
+}
+
+void SolverImpl::removeConstraint(const Constraint& c)
+{
+    const Id id = c.id();
+    const ConstraintImpl* impl = nullptr;
+    auto tagIt = constraintTags_.end();
+
+    if (id == nullId)
+    {
+        tagIt = constraintTags_.find(c.impl_.get());
+        if (tagIt == constraintTags_.end())
+        {
+            throw UnknownConstraint{"arrange: constraint not in solver"};
+        }
+        impl = c.impl_.get();
+    }
+    else
+    {
+        auto idIt = idToImpl_.find(id);
+        if (idIt == idToImpl_.end())
+        {
+            throw UnknownConstraint{"arrange: constraint id not in solver"};
+        }
+        impl = idIt->second;
+        tagIt = constraintTags_.find(impl);
+    }
+
+    const Tag tag = tagIt->second;
+    constraintTags_.erase(tagIt);
+    trackedConstraints_.erase(impl);
+    if (id != nullId)
+    {
+        idToImpl_.erase(id);
+    }
+
+    // Rebuild the Constraint pointer to its impl through any copy we have;
+    // we only need its strength/relation for removeMarkerEffects.
+    // We pass `c` directly — its strength matches the original added one
+    // because the impl is shared across copies.
+    removeConstraintEffects(c, tag);
+
+    // Remove the marker from the tableau.
+    auto rowIt = rows_.find(tag.marker);
+    if (rowIt != rows_.end())
+    {
+        rows_.erase(rowIt);
+    }
+    else
+    {
+        Symbol leaving = getMarkerLeavingSymbol(tag.marker);
+        if (leaving.type() == Symbol::Type::invalid)
+        {
+            throw Error{"arrange: solver internal error — cannot remove marker"};
+        }
+        auto lit = rows_.find(leaving);
+        Row row = std::move(lit->second);
+        rows_.erase(lit);
+        row.solveForSymbols(leaving, tag.marker);
+        substitute(tag.marker, row);
+    }
+    optimize(objective_);
+}
+
+bool SolverImpl::hasConstraint(const Constraint& c) const noexcept
+{
+    return constraintTags_.find(c.impl_.get()) != constraintTags_.end();
+}
+
+ConstraintDiff SolverImpl::setConstraints(const std::vector<Constraint>& desired)
+{
+    std::vector<Constraint> current;
+    current.reserve(trackedConstraints_.size());
+    for (const auto& [impl, c] : trackedConstraints_)
+    {
+        current.push_back(c);
+    }
+    ConstraintDiff diff = diffConstraints(current, desired);
+
+    // Strong exception safety: snapshot and restore on throw.
+    SolverImpl backup = *this;
+    try
+    {
+        for (const auto& c : diff.removed)
+        {
+            removeConstraint(c);
+        }
+        for (const auto& c : diff.added)
+        {
+            addConstraint(c);
+        }
+    }
+    catch (...)
+    {
+        *this = std::move(backup);
+        throw;
+    }
+    return diff;
+}
+
+void SolverImpl::addEditVariable(const Variable& v, Strength s)
+{
+    if (s.isRequired())
+    {
+        throw BadStrength{"arrange: edit variable strength must not be required"};
+    }
+    if (edits_.find(v.id()) != edits_.end())
+    {
+        throw DuplicateEditVariable{"arrange: edit variable already present"};
+    }
+    Constraint c = (Expression{v} == 0.0) | s;
+    addConstraint(c);
+    auto it = constraintTags_.find(c.impl_.get());
+    EditInfo info{it->second, c, 0.0};
+    edits_.emplace(v.id(), std::move(info));
+}
+
+void SolverImpl::removeEditVariable(const Variable& v)
+{
+    auto it = edits_.find(v.id());
+    if (it == edits_.end())
+    {
+        throw UnknownEditVariable{"arrange: edit variable not present"};
+    }
+    Constraint c = it->second.constraint;
+    edits_.erase(it);
+    removeConstraint(c);
+}
+
+bool SolverImpl::hasEditVariable(const Variable& v) const noexcept
+{
+    return edits_.find(v.id()) != edits_.end();
+}
+
+void SolverImpl::suggestValue(const Variable& v, double value)
+{
+    auto it = edits_.find(v.id());
+    if (it == edits_.end())
+    {
+        throw UnknownEditVariable{"arrange: edit variable not present"};
+    }
+    EditInfo& info = it->second;
+    const double delta = value - info.constant;
+    info.constant = value;
+
+    // Update plus error row
+    auto rit = rows_.find(info.tag.marker);
+    if (rit != rows_.end())
+    {
+        if (rit->second.addToConstant(-delta) < 0.0)
+        {
+            infeasibleRows_.push_back(info.tag.marker);
+        }
+    }
+    else
+    {
+        rit = rows_.find(info.tag.other);
+        if (rit != rows_.end())
+        {
+            if (rit->second.addToConstant(delta) < 0.0)
+            {
+                infeasibleRows_.push_back(info.tag.other);
+            }
+        }
+        else
+        {
+            for (auto& [basic, row] : rows_)
+            {
+                const double coeff = row.coefficientFor(info.tag.marker);
+                if (coeff != 0.0)
+                {
+                    if (row.addToConstant(delta * coeff) < 0.0
+                        && basic.type() != Symbol::Type::external)
+                    {
+                        infeasibleRows_.push_back(basic);
+                    }
+                }
+            }
+        }
+    }
+    dualOptimize();
+}
+
+double SolverImpl::valueOf(const Variable& v) const
+{
+    auto it = vars_.find(v.id());
+    if (it == vars_.end())
+    {
+        return 0.0;
+    }
+    auto rit = rows_.find(it->second);
+    if (rit == rows_.end())
+    {
+        return 0.0;
+    }
+    return rit->second.constant();
+}
+
+bool SolverImpl::contains(const Variable& v) const noexcept
+{
+    return vars_.find(v.id()) != vars_.end();
+}
+
+void SolverImpl::reset()
+{
+    rows_.clear();
+    vars_.clear();
+    constraintTags_.clear();
+    idToImpl_.clear();
+    trackedConstraints_.clear();
+    edits_.clear();
+    infeasibleRows_.clear();
+    objective_ = Row{};
+    artificial_.reset();
+    symbolCounter_ = 1;
+}
+
+// --- Solver (public wrapper) -----------------------------------------------
+
+Solver::Solver()
+    : impl_(std::make_unique<SolverImpl>())
+{
+}
+
+Solver::~Solver() = default;
+
+Solver::Solver(const Solver& other)
+    : impl_(std::make_unique<SolverImpl>(*other.impl_))
+{
+}
+
+Solver& Solver::operator=(const Solver& other)
+{
+    if (this != &other)
+    {
+        impl_ = std::make_unique<SolverImpl>(*other.impl_);
+    }
+    return *this;
+}
+
+Solver::Solver(Solver&& other) noexcept = default;
+Solver& Solver::operator=(Solver&& other) noexcept = default;
+
+void Solver::addConstraint(const Constraint& c)
+{
+    impl_->addConstraint(c);
+}
+
+void Solver::removeConstraint(const Constraint& c)
+{
+    impl_->removeConstraint(c);
+}
+
+bool Solver::hasConstraint(const Constraint& c) const noexcept
+{
+    return impl_->hasConstraint(c);
+}
+
+ConstraintDiff Solver::setConstraints(const std::vector<Constraint>& desired)
+{
+    return impl_->setConstraints(desired);
+}
+
+void Solver::addEditVariable(const Variable& v, Strength s)
+{
+    impl_->addEditVariable(v, s);
+}
+
+void Solver::removeEditVariable(const Variable& v)
+{
+    impl_->removeEditVariable(v);
+}
+
+bool Solver::hasEditVariable(const Variable& v) const noexcept
+{
+    return impl_->hasEditVariable(v);
+}
+
+void Solver::suggestValue(const Variable& v, double value)
+{
+    impl_->suggestValue(v, value);
+}
+
+double Solver::valueOf(const Variable& v) const
+{
+    return impl_->valueOf(v);
+}
+
+bool Solver::contains(const Variable& v) const noexcept
+{
+    return impl_->contains(v);
+}
+
+void Solver::reset()
+{
+    impl_->reset();
+}
+
+}  // namespace arrange

--- a/subprojects/arrange/src/solver_impl.h
+++ b/subprojects/arrange/src/solver_impl.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include "constraint_impl.h"
+
+#include <arrange/constraint.h>
+#include <arrange/diff.h>
+#include <arrange/id.h>
+#include <arrange/strength.h>
+#include <arrange/variable.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace arrange
+{
+
+inline constexpr double kSolverEpsilon = 1.0e-8;
+
+inline bool isNearZero(double v) noexcept
+{
+    return v > -kSolverEpsilon && v < kSolverEpsilon;
+}
+
+class Symbol
+{
+public:
+    enum class Type : std::uint8_t
+    {
+        invalid,
+        external,
+        slack,
+        error,
+        dummy
+    };
+
+    Symbol() noexcept = default;
+    Symbol(Type type, std::uint32_t id) noexcept
+        : id_(id)
+        , type_(type)
+    {
+    }
+
+    std::uint32_t id() const noexcept
+    {
+        return id_;
+    }
+    Type type() const noexcept
+    {
+        return type_;
+    }
+
+    bool operator==(const Symbol& o) const noexcept
+    {
+        return id_ == o.id_;
+    }
+    bool operator!=(const Symbol& o) const noexcept
+    {
+        return id_ != o.id_;
+    }
+    bool operator<(const Symbol& o) const noexcept
+    {
+        return id_ < o.id_;
+    }
+
+private:
+    std::uint32_t id_ = 0;
+    Type type_ = Type::invalid;
+};
+
+class Row
+{
+public:
+    Row() = default;
+    explicit Row(double constant)
+        : constant_(constant)
+    {
+    }
+
+    double constant() const noexcept
+    {
+        return constant_;
+    }
+    const std::map<Symbol, double>& cells() const noexcept
+    {
+        return cells_;
+    }
+
+    void setConstant(double v) noexcept
+    {
+        constant_ = v;
+    }
+    double addToConstant(double v) noexcept
+    {
+        constant_ += v;
+        return constant_;
+    }
+
+    void insertSymbol(Symbol s, double coefficient);
+    void insertRow(const Row& other, double coefficient = 1.0);
+    void removeSymbol(Symbol s);
+    void reverseSign();
+    void solveForSymbol(Symbol s);
+    void solveForSymbols(Symbol lhs, Symbol rhs);
+    double coefficientFor(Symbol s) const;
+    void substitute(Symbol s, const Row& row);
+
+private:
+    double constant_ = 0.0;
+    std::map<Symbol, double> cells_;
+};
+
+struct Tag
+{
+    Symbol marker;
+    Symbol other;
+};
+
+struct EditInfo
+{
+    Tag tag;
+    Constraint constraint;
+    double constant;
+};
+
+class SolverImpl
+{
+public:
+    SolverImpl();
+    SolverImpl(const SolverImpl& other);
+    SolverImpl& operator=(const SolverImpl& other);
+    SolverImpl(SolverImpl&&) noexcept = default;
+    SolverImpl& operator=(SolverImpl&&) noexcept = default;
+    ~SolverImpl() = default;
+
+    void addConstraint(const Constraint& c);
+    void removeConstraint(const Constraint& c);
+    bool hasConstraint(const Constraint& c) const noexcept;
+
+    ConstraintDiff setConstraints(const std::vector<Constraint>& desired);
+
+    void addEditVariable(const Variable& v, Strength s);
+    void removeEditVariable(const Variable& v);
+    bool hasEditVariable(const Variable& v) const noexcept;
+    void suggestValue(const Variable& v, double value);
+
+    double valueOf(const Variable& v) const;
+    bool contains(const Variable& v) const noexcept;
+
+    void reset();
+
+private:
+    Symbol nextSymbol(Symbol::Type t);
+    Symbol getVarSymbol(const Variable& v);
+
+    Row createRow(const Constraint& c, Tag& tagOut);
+    Symbol chooseSubject(const Row& row, const Tag& tag) const;
+    bool addWithArtificialVariable(const Row& row);
+
+    void optimize(Row& objective);
+    void dualOptimize();
+    void substitute(Symbol s, const Row& row);
+
+    Symbol getEnteringSymbol(const Row& objective) const;
+    Symbol getLeavingSymbol(Symbol entering) const;
+    Symbol getMarkerLeavingSymbol(Symbol marker) const;
+    Symbol getDualEnteringSymbol(const Row& row) const;
+
+    void removeConstraintEffects(const Constraint& c, const Tag& tag);
+    void removeMarkerEffects(Symbol marker, const Strength& strength);
+
+    // Tableau state
+    std::map<Symbol, Row> rows_;
+    std::unordered_map<Id, Symbol> vars_;
+    std::unordered_map<const ConstraintImpl*, Tag> constraintTags_;
+    std::unordered_map<Id, const ConstraintImpl*> idToImpl_;
+    std::unordered_map<const ConstraintImpl*, Constraint> trackedConstraints_;
+    std::unordered_map<Id, EditInfo> edits_;
+    std::vector<Symbol> infeasibleRows_;
+    Row objective_;
+    std::unique_ptr<Row> artificial_;
+    std::uint32_t symbolCounter_ = 1;
+};
+
+}  // namespace arrange

--- a/subprojects/arrange/src/strength.cpp
+++ b/subprojects/arrange/src/strength.cpp
@@ -1,0 +1,98 @@
+#include <arrange/errors.h>
+#include <arrange/strength.h>
+
+#include <algorithm>
+
+namespace arrange
+{
+
+namespace
+{
+
+constexpr double kRequiredValue = 1'001'001'000.0;
+constexpr double kStrongValue = 1'000'000.0;
+constexpr double kMediumValue = 1'000.0;
+constexpr double kWeakValue = 1.0;
+
+double clampWeight(double weight)
+{
+    return std::max(0.0, weight);
+}
+
+}  // namespace
+
+Strength::Strength(double value) noexcept
+    : value_(value)
+{
+}
+
+Strength Strength::required()
+{
+    return Strength{kRequiredValue};
+}
+
+Strength Strength::strong(double weight)
+{
+    return Strength{kStrongValue * clampWeight(weight)};
+}
+
+Strength Strength::medium(double weight)
+{
+    return Strength{kMediumValue * clampWeight(weight)};
+}
+
+Strength Strength::weak(double weight)
+{
+    return Strength{kWeakValue * clampWeight(weight)};
+}
+
+Strength Strength::create(double strong, double medium, double weak, double weight)
+{
+    const double w = clampWeight(weight);
+    const double s = std::max(0.0, std::min(1000.0, strong));
+    const double m = std::max(0.0, std::min(1000.0, medium));
+    const double k = std::max(0.0, std::min(1000.0, weak));
+    return Strength{w * (s * 1'000'000.0 + m * 1'000.0 + k)};
+}
+
+double Strength::value() const noexcept
+{
+    return value_;
+}
+
+bool Strength::isRequired() const noexcept
+{
+    return value_ >= kRequiredValue;
+}
+
+bool Strength::operator==(const Strength& other) const noexcept
+{
+    return value_ == other.value_;
+}
+
+bool Strength::operator!=(const Strength& other) const noexcept
+{
+    return value_ != other.value_;
+}
+
+bool Strength::operator<(const Strength& other) const noexcept
+{
+    return value_ < other.value_;
+}
+
+bool Strength::operator<=(const Strength& other) const noexcept
+{
+    return value_ <= other.value_;
+}
+
+bool Strength::operator>(const Strength& other) const noexcept
+{
+    return value_ > other.value_;
+}
+
+bool Strength::operator>=(const Strength& other) const noexcept
+{
+    return value_ >= other.value_;
+}
+
+}  // namespace arrange

--- a/subprojects/arrange/src/variable.cpp
+++ b/subprojects/arrange/src/variable.cpp
@@ -1,0 +1,97 @@
+#include "id_counter.h"
+
+#include <arrange/errors.h>
+#include <arrange/variable.h>
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace arrange
+{
+
+namespace
+{
+
+constexpr Id kUserIdMask = Id{1} << 63;
+
+void validateUserId(Id id)
+{
+    if (id == nullId)
+    {
+        throw BadId{"Variable id must not be nullId"};
+    }
+    if ((id & kUserIdMask) != 0)
+    {
+        throw BadId{"Variable user id must not have the high bit set"};
+    }
+}
+
+std::shared_ptr<const std::string> makeNameOrNull(std::string_view name)
+{
+    if (name.empty())
+    {
+        return nullptr;
+    }
+    return std::make_shared<const std::string>(name);
+}
+
+}  // namespace
+
+Variable::Variable()
+    : id_(detail::nextAutoVariableId())
+    , name_(nullptr)
+{
+}
+
+Variable::Variable(std::string_view name)
+    : id_(detail::nextAutoVariableId())
+    , name_(makeNameOrNull(name))
+{
+}
+
+Variable::Variable(Id id)
+    : id_(id)
+    , name_(nullptr)
+{
+    validateUserId(id);
+}
+
+Variable::Variable(Id id, std::string_view name)
+    : id_(id)
+    , name_(makeNameOrNull(name))
+{
+    validateUserId(id);
+}
+
+Id Variable::id() const noexcept
+{
+    return id_;
+}
+
+std::string_view Variable::name() const noexcept
+{
+    if (!name_)
+    {
+        return {};
+    }
+    return *name_;
+}
+
+bool Variable::operator==(const Variable& other) const noexcept
+{
+    return id_ == other.id_;
+}
+
+bool Variable::operator!=(const Variable& other) const noexcept
+{
+    return id_ != other.id_;
+}
+
+std::size_t VariableHash::operator()(const Variable& v) const noexcept
+{
+    return std::hash<Id>{}(v.id());
+}
+
+}  // namespace arrange


### PR DESCRIPTION
Verified-and-shipped constraint-solve layout core. Draft: the live Builder
wiring is deliberately out of scope here.

## DONE (built + clang-cl green, 4 suites)

- **arrange vendored as a bqui-only subproject** (`subprojects/arrange`): a
  Cassowary linear-arithmetic constraint solver (Variable/Expression/Constraint/
  Strength/Solver with an incremental diff). It is pulled in only by bqui's
  internal build wiring; it is not exposed on any public header.
- **A constraint-solve layout core** in `src/bqui/src/widget/constraintlayout.{h,cpp}`:
  - `BoxVariables` - four edge variables (left/top/right/bottom) with stable
    arrange ids, so a widget's constraints match from solve to solve; plus
    `width()`/`height()` expression helpers.
  - `LayoutSpec` (constraints + the variables to read back) and `LayoutSolution`
    (id -> solved value map).
  - `solveLayout(AnySignal<LayoutSpec>) -> AnySignal<LayoutSolution>`: one movable
    `arrange::Solver` threaded through a `withPrevious` fold as accumulator state,
    re-solving only when the spec changes, then `.map`-ped down to the small
    value snapshot and `.share()`-d so no reader ever copies the tableau. An
    unsatisfiable update is caught and keeps the previous solution instead of
    tearing down the graph.
  - `readObb` (solution + box -> avg::Obb) and the container constraint
    generators `boxConstraints` (edge-to-edge stacking along an axis),
    `stackConstraints` (overlay), and `anchorConstraints` (pin to a fixed rect).
- **A passing clang-cl test** (`test/constraintlayouttest.cpp`, 5 cases) that runs
  real box layouts through `solveLayout` inside a live `SignalContext` and asserts
  the exact solved geometry (both raw `solution.at(id)` values and `readObb`
  sizes), including a case that mutates the input spec and re-evaluates to prove
  the same folded solver re-solves end-to-end.

Build: clang-cl 18.1.7, full `meson compile` clean. Tests: btl / bq / avg / bqui
all OK (424 tests, 0 failures; the 5 `constraintLayout` cases pass). No compile
fixes were required - the earlier-suspected two-phase-lookup issue at
constraintlayouttest.cpp:32 does not arise (the context is a concrete,
non-dependent type there).

## NOT YET DONE / BLOCKER

The live Builder integration - replacing the existing SizeHint layout with this
constraint core - is **not** done here, and a real architectural blocker was
found:

- The public-header firewall (only `src/<lib>/include/<lib>/` is exported)
  prevents exposing `arrange` types on the public `Builder` header. `arrange` is
  a bqui-internal subproject; `Builder.h` is a public bqui header, so putting
  arrange types (BoxVariables etc.) on Builder would leak an internal dependency
  through the exported surface and break the firewall for dependents.
- Identified workaround to resolve before full wiring: a **parallel,
  SizeHint-reading container spine** that generates arrange constraints from the
  existing SizeHint `[min, pref, max]` triples, entirely outside `Builder` - no
  arrange type crosses the public header. This keeps the solver core internal
  while it is validated against the current layout engine.

This is the key design decision to settle before the SizeHint replacement lands.
Keeping this PR as a draft until then.
