### PR TITLE
bqui: wire arrange solver into live layout (stages 1-3)

### DIFF
--- a/src/bqui/include/bqui/widget/boxvariables.h
+++ b/src/bqui/include/bqui/widget/boxvariables.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "bqui/bquivisibility.h"
+
+#include <arrange/expression.h>
+#include <arrange/variable.h>
+
+namespace bqui::widget
+{
+    /** @brief The four edge variables bounding one widget's box in the shared
+     * constraint system.
+     *
+     * A widget holds its BoxVariables for its whole lifetime, so the arrange
+     * ids stay stable across solves and the solver's incremental diff can match
+     * the widget's constraints from pass to pass. A default-constructed set
+     * mints four fresh ids; copying preserves them, so a copy names the same
+     * box.
+     */
+    struct BoxVariables
+    {
+        arrange::Variable left;
+        arrange::Variable top;
+        arrange::Variable right;
+        arrange::Variable bottom;
+
+        BQUI_EXPORT arrange::Expression width() const;
+        BQUI_EXPORT arrange::Expression height() const;
+    };
+} // namespace bqui::widget

--- a/src/bqui/include/bqui/widget/builder.h
+++ b/src/bqui/include/bqui/widget/builder.h
@@ -7,6 +7,7 @@
 #include "bqui/buildparams.h"
 #include "bqui/simplesizehint.h"
 #include "bqui/sizehint.h"
+#include "bqui/widget/boxvariables.h"
 
 #include <bq/signal/signal.h>
 
@@ -84,12 +85,14 @@ namespace bqui::widget
         template <typename TSignalSizeHint>
         auto setSizeHint(TSignalSizeHint sizeHint) &&
         {
-            return makeBuilder(
+            auto builder = makeBuilder(
                     std::move(*func_),
                     std::move(sizeHint),
                     std::move(buildParams_),
                     std::move(gravity_)
                     );
+            builder.setBoxVariables(box_);
+            return builder;
         }
 
         SizeHintType getSizeHint() const
@@ -97,9 +100,24 @@ namespace bqui::widget
             return sizeHint_->clone();
         }
 
+        /** @brief The four edge variables that name this widget's box to the
+         * constraint solver. Stable for the builder's lifetime and preserved
+         * across a copy, a size-hint change and type erasure. */
+        BoxVariables const& getBoxVariables() const
+        {
+            return box_;
+        }
+
+        /** @brief Adopts @p box as this widget's solver box, so a transformed
+         * builder keeps the identity of the one it came from. */
+        void setBoxVariables(BoxVariables box)
+        {
+            box_ = std::move(box);
+        }
+
         auto setBuildParams(BuildParams params) &&
         {
-            return makeBuilder([params=std::move(buildParams_),
+            auto builder = makeBuilder([params=std::move(buildParams_),
                     func=std::move(func_)](BuildParams oldParams, auto size)
                 {
                     return (*func)(params, std::move(size)).setParams(oldParams);
@@ -108,6 +126,8 @@ namespace bqui::widget
                 std::move(params),
                 std::move(gravity_)
                 );
+            builder.setBoxVariables(box_);
+            return builder;
         }
 
         BuildParams const& getBuildParams() const
@@ -134,12 +154,14 @@ namespace bqui::widget
 
         operator BuilderBase() &&
         {
-            return BuilderBase(
+            BuilderBase base(
                     std::move(*func_),
                     std::move(*sizeHint_),
                     std::move(buildParams_),
                     std::move(gravity_)
                     );
+            base.setBoxVariables(box_);
+            return base;
         }
 
     protected:
@@ -148,6 +170,7 @@ namespace bqui::widget
         BuildParams buildParams_;
         bq::signal::AnySignal<avg::Vector2f> gravity_ =
             bq::signal::constant(avg::Vector2f(0.5f, 0.5f));
+        BoxVariables box_;
     };
 
     struct AnyBuilder : Builder<std::function<widget::AnyElement(

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -88,10 +88,11 @@ nlohmanndep = dependency('nlohmann_json', include_type: 'system',
     default_options: subproject_warnings)
 
 # arrange is a vendored Cassowary linear-arithmetic constraint solver — UI-
-# agnostic layout math (an "Eigen, not a bq"). Its headers back bqui's own
-# layout .cpp files and never appear in a public bqui header, so like nlohmann
-# it is a dependency of the bqui library only and is deliberately *not* re-
-# exported through libbquidep.
+# agnostic layout math (an "Eigen, not a bq"). Its variables and expressions
+# appear in bqui's public layout interface (a Builder carries the box variables
+# that name it to the solver), so unlike nlohmann it is re-exported through
+# libbquidep and propagates to dependents — the one solver-math dependency
+# permitted in bqui's public surface, alongside avg.
 arrangedep = subproject('arrange',
     default_options: subproject_warnings).get_variable('arrange_dep').as_system()
 
@@ -114,7 +115,7 @@ libbqui = library(
 
 libbquidep = declare_dependency(
   link_with: libbqui,
-  dependencies: bquidep,
+  dependencies: bquidep + [arrangedep],
   link_args: bqui_link_args,
   include_directories: include_directories('include')
   )

--- a/src/bqui/meson.build
+++ b/src/bqui/meson.build
@@ -38,6 +38,7 @@ libbquisrc = [
   'src/widget/bin.cpp',
   'src/widget/button.cpp',
   'src/widget/box.cpp',
+  'src/widget/constraintbox.cpp',
   'src/widget/constraintlayout.cpp',
   'src/widget/datavalue.cpp',
   'src/widget/hbox.cpp',

--- a/src/bqui/src/widget/constraintbox.cpp
+++ b/src/bqui/src/widget/constraintbox.cpp
@@ -1,0 +1,214 @@
+#include "constraintbox.h"
+
+#include "constraintlayout.h"
+
+#include "bqui/widget/box.h"
+#include "bqui/widget/layout.h"
+#include "bqui/widget/widget.h"
+
+#include "bqui/modifier/addwidgets.h"
+#include "bqui/modifier/setid.h"
+#include "bqui/modifier/setsizehint.h"
+#include "bqui/modifier/setwidgetintrospection.h"
+#include "bqui/modifier/transform.h"
+
+#include "bqui/provider/providebuildparams.h"
+
+#include "bqui/sizehint.h"
+
+#include <bq/signal/arraysignal.h>
+#include <bq/signal/constant.h>
+#include <bq/signal/signal.h>
+
+#include <avg/obb.h>
+#include <avg/transform.h>
+#include <avg/vector.h>
+
+#include <arrange/expression.h>
+#include <arrange/strength.h>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace bqui::widget
+{
+
+namespace
+{
+
+// The same placement step layout() uses: split a child's obb into a transform
+// and a size, place the builder, and give the realised instance a fresh id so a
+// dynamic list can match it by identity rather than by position.
+bq::signal::AnySignal<widget::Instance> buildChild(
+        widget::AnyBuilder const& builder,
+        bq::signal::AnySignal<avg::Obb> obb)
+{
+    auto shared = obb.share();
+    auto transform = shared.map(&avg::Obb::getTransform);
+    auto size = shared.map(&avg::Obb::getSize);
+
+    auto placed = builder.clone()
+        | modifier::transformBuilder(std::move(transform));
+
+    return (std::move(placed)(std::move(size))
+        | modifier::setElementId(bq::signal::constant(avg::UniqueId()))
+        ).getInstance();
+}
+
+LayoutSpec makeVerticalSpec(BoxVariables const& container,
+        avg::Vector2f size, std::vector<BoxVariables> const& boxes,
+        std::vector<SizeHint> const& hints)
+{
+    LayoutSpec spec;
+
+    auto append = [&spec](std::vector<arrange::Constraint> constraints)
+    {
+        for (auto& constraint : constraints)
+            spec.constraints.push_back(std::move(constraint));
+    };
+
+    append(anchorConstraints(container, 0.0f, 0.0f, size[0], size[1]));
+    append(boxConstraints(container, boxes, Axis::y));
+
+    for (std::size_t i = 0; i < boxes.size(); ++i)
+    {
+        SizeHintResult height = hints[i].getHeightForWidth(size[0]);
+        float minHeight = height[0];
+        float preferredHeight = height[1];
+
+        spec.constraints.push_back(
+                (boxes[i].height() == arrange::Expression(preferredHeight))
+                | arrange::Strength::strong());
+        spec.constraints.push_back(
+                boxes[i].height() >= arrange::Expression(minHeight));
+    }
+
+    for (BoxVariables const& box : boxes)
+    {
+        spec.variables.push_back(box.left);
+        spec.variables.push_back(box.top);
+        spec.variables.push_back(box.right);
+        spec.variables.push_back(box.bottom);
+    }
+
+    return spec;
+}
+
+// The solver works in top-down window space, where y grows downwards from the
+// container's top. The widget tree is y-up with the origin at the bottom-left,
+// so a child's bottom edge in solver space becomes its origin here.
+std::vector<avg::Obb> toObbs(LayoutSolution const& solution,
+        std::vector<BoxVariables> const& boxes, avg::Vector2f size)
+{
+    std::vector<avg::Obb> obbs;
+    obbs.reserve(boxes.size());
+
+    for (BoxVariables const& box : boxes)
+    {
+        avg::Obb solved = readObb(solution, box);
+        avg::Vector2f childSize = solved.getSize();
+        avg::Vector2f topLeft = solved.getTransform().getTranslation();
+        float bottomEdge = topLeft[1] + childSize[1];
+
+        obbs.push_back(avg::Transform().translate(
+                    avg::Vector2f(topLeft[0], size[1] - bottomEdge))
+                * avg::Obb(childSize));
+    }
+
+    return obbs;
+}
+
+AnyWidget solverVbox(bq::signal::ArraySignal<widget::AnyBuilder> array)
+{
+    BoxVariables container;
+
+    auto boxes = bq::signal::join(array.map(
+                [](widget::AnyBuilder const& builder)
+                {
+                    return bq::signal::AnySignal<BoxVariables>(
+                            bq::signal::constant(builder.getBoxVariables()));
+                })).share();
+
+    auto hints = bq::signal::join(array.map(
+                [](widget::AnyBuilder const& builder)
+                {
+                    return builder.getSizeHint();
+                })).share();
+
+    auto widget = makeWidgetWithSize(
+            [container](auto size, auto boxes, auto hints, auto array)
+            {
+                auto sharedSize = std::move(size).share();
+
+                auto spec = merge(sharedSize.clone(), boxes.clone(),
+                        std::move(hints))
+                    .map([container](avg::Vector2f size,
+                                std::vector<BoxVariables> const& boxes,
+                                std::vector<SizeHint> const& hints)
+                        {
+                            return makeVerticalSpec(container, size, boxes,
+                                    hints);
+                        });
+
+                auto solution = solveLayout(
+                        bq::signal::AnySignal<LayoutSpec>(std::move(spec)));
+
+                auto obbs = merge(std::move(solution), std::move(boxes),
+                        std::move(sharedSize))
+                    .map([](LayoutSolution const& solution,
+                                std::vector<BoxVariables> const& boxes,
+                                avg::Vector2f size)
+                        {
+                            return toObbs(solution, boxes, size);
+                        });
+
+                auto instances = bq::signal::join(bq::signal::scatter(
+                            std::move(array), std::move(obbs), &buildChild));
+
+                return widget::makeWidget()
+                    | modifier::addWidgets(std::move(instances))
+                    | modifier::setRole("Layout")
+                    ;
+            },
+            boxes,
+            hints,
+            std::move(array)
+            );
+
+    SizeHintMap sizeHintMap = accumulateSizeHints<Axis::y>;
+
+    return std::move(widget)
+        | modifier::setSizeHint(hints.map(std::move(sizeHintMap)))
+        ;
+}
+
+} // namespace
+
+AnyWidget solverVbox(std::vector<AnyWidget> widgets)
+{
+    std::vector<bq::signal::ArraySignal<widget::AnyWidget>> children;
+    children.reserve(widgets.size());
+
+    for (auto&& widget : widgets)
+        children.push_back(std::move(widget));
+
+    auto array = bq::signal::ArraySignal<widget::AnyWidget>(std::move(children));
+
+    return makeWidget([](BuildParams const& params, auto widgets)
+        {
+            auto builders = widgets.map(
+                    [params](widget::AnyWidget const& widget)
+                    -> widget::AnyBuilder
+                    {
+                        return widget.clone()(params);
+                    });
+
+            return solverVbox(std::move(builders));
+        },
+        provider::provideBuildParams(),
+        std::move(array)
+        );
+}
+
+} // namespace bqui::widget

--- a/src/bqui/src/widget/constraintbox.cpp
+++ b/src/bqui/src/widget/constraintbox.cpp
@@ -7,6 +7,7 @@
 #include "bqui/widget/widget.h"
 
 #include "bqui/modifier/addwidgets.h"
+#include "bqui/modifier/handlegravity.h"
 #include "bqui/modifier/setid.h"
 #include "bqui/modifier/setsizehint.h"
 #include "bqui/modifier/setwidgetintrospection.h"
@@ -26,6 +27,7 @@
 
 #include <arrange/expression.h>
 #include <arrange/strength.h>
+#include <arrange/variable.h>
 
 #include <cstddef>
 #include <utility>
@@ -57,7 +59,8 @@ bq::signal::AnySignal<widget::Instance> buildChild(
 }
 
 LayoutSpec makeVerticalSpec(BoxVariables const& container,
-        avg::Vector2f size, std::vector<BoxVariables> const& boxes,
+        arrange::Variable const& stretch, avg::Vector2f size,
+        std::vector<BoxVariables> const& boxes,
         std::vector<SizeHint> const& hints)
 {
     LayoutSpec spec;
@@ -75,13 +78,36 @@ LayoutSpec makeVerticalSpec(BoxVariables const& container,
     {
         SizeHintResult height = hints[i].getHeightForWidth(size[0]);
         float minHeight = height[0];
-        float preferredHeight = height[1];
+        float naturalHeight = height[1];
+        float maxHeight = height[2];
 
+        arrange::Expression childHeight = boxes[i].height();
+
+        // The band each child is kept inside, firmer than the size it settles
+        // at within the band.
         spec.constraints.push_back(
-                (boxes[i].height() == arrange::Expression(preferredHeight))
+                (childHeight >= arrange::Expression(minHeight))
                 | arrange::Strength::strong());
         spec.constraints.push_back(
-                boxes[i].height() >= arrange::Expression(minHeight));
+                (childHeight <= arrange::Expression(maxHeight))
+                | arrange::Strength::strong());
+
+        if (maxHeight > naturalHeight)
+        {
+            // A filler grows past its natural size, so it takes no natural pin.
+            // Every filler is tied to the container's one stretch variable, so
+            // several of them split the leftover space equally; the container's
+            // fixed extent then drives that variable to absorb the remainder.
+            spec.constraints.push_back(
+                    (childHeight == arrange::Expression(stretch))
+                    | arrange::Strength::medium());
+        }
+        else
+        {
+            spec.constraints.push_back(
+                    (childHeight == arrange::Expression(naturalHeight))
+                    | arrange::Strength::medium());
+        }
     }
 
     for (BoxVariables const& box : boxes)
@@ -122,6 +148,7 @@ std::vector<avg::Obb> toObbs(LayoutSolution const& solution,
 AnyWidget solverVbox(bq::signal::ArraySignal<widget::AnyBuilder> array)
 {
     BoxVariables container;
+    arrange::Variable stretch;
 
     auto boxes = bq::signal::join(array.map(
                 [](widget::AnyBuilder const& builder)
@@ -137,18 +164,18 @@ AnyWidget solverVbox(bq::signal::ArraySignal<widget::AnyBuilder> array)
                 })).share();
 
     auto widget = makeWidgetWithSize(
-            [container](auto size, auto boxes, auto hints, auto array)
+            [container, stretch](auto size, auto boxes, auto hints, auto array)
             {
                 auto sharedSize = std::move(size).share();
 
                 auto spec = merge(sharedSize.clone(), boxes.clone(),
                         std::move(hints))
-                    .map([container](avg::Vector2f size,
+                    .map([container, stretch](avg::Vector2f size,
                                 std::vector<BoxVariables> const& boxes,
                                 std::vector<SizeHint> const& hints)
                         {
-                            return makeVerticalSpec(container, size, boxes,
-                                    hints);
+                            return makeVerticalSpec(container, stretch, size,
+                                    boxes, hints);
                         });
 
                 auto solution = solveLayout(
@@ -185,6 +212,26 @@ AnyWidget solverVbox(bq::signal::ArraySignal<widget::AnyBuilder> array)
 
 } // namespace
 
+AnyWidget solverVbox(bq::signal::ArraySignal<AnyWidget> widgets)
+{
+    return makeWidget([](BuildParams const& params, auto widgets)
+        {
+            auto builders = widgets.map(
+                    [params](widget::AnyWidget const& widget)
+                    -> widget::AnyBuilder
+                    {
+                        return (widget.clone()
+                                | modifier::handleGravity()
+                                )(params);
+                    });
+
+            return solverVbox(std::move(builders));
+        },
+        provider::provideBuildParams(),
+        std::move(widgets)
+        );
+}
+
 AnyWidget solverVbox(std::vector<AnyWidget> widgets)
 {
     std::vector<bq::signal::ArraySignal<widget::AnyWidget>> children;
@@ -193,22 +240,8 @@ AnyWidget solverVbox(std::vector<AnyWidget> widgets)
     for (auto&& widget : widgets)
         children.push_back(std::move(widget));
 
-    auto array = bq::signal::ArraySignal<widget::AnyWidget>(std::move(children));
-
-    return makeWidget([](BuildParams const& params, auto widgets)
-        {
-            auto builders = widgets.map(
-                    [params](widget::AnyWidget const& widget)
-                    -> widget::AnyBuilder
-                    {
-                        return widget.clone()(params);
-                    });
-
-            return solverVbox(std::move(builders));
-        },
-        provider::provideBuildParams(),
-        std::move(array)
-        );
+    return solverVbox(
+            bq::signal::ArraySignal<widget::AnyWidget>(std::move(children)));
 }
 
 } // namespace bqui::widget

--- a/src/bqui/src/widget/constraintbox.h
+++ b/src/bqui/src/widget/constraintbox.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "bqui/widget/widget.h"
+
+#include "bqui/bquivisibility.h"
+
+#include <vector>
+
+namespace bqui::widget
+{
+    /** @brief Lays a column of children out through the arrange solver.
+     *
+     * The container and every child carry a set of BoxVariables. The container
+     * is anchored to the window-space rectangle it is realised at, the children
+     * are stacked edge-to-edge along the vertical axis (boxConstraints()), and
+     * each child's preferred and minimum height enter as a strong equality and
+     * a required lower bound read from its SizeHint. One arrange::Solver folds
+     * over the whole spec (solveLayout()), and each child is placed at its
+     * solved rectangle, flipped from the solver's top-down window space into the
+     * widget tree's y-up coordinates.
+     *
+     * This is the first container wired onto the solver; the fixed-membership
+     * form is enough to prove the integration end to end.
+     */
+    BQUI_EXPORT AnyWidget solverVbox(std::vector<AnyWidget> widgets);
+} // namespace bqui::widget

--- a/src/bqui/src/widget/constraintbox.h
+++ b/src/bqui/src/widget/constraintbox.h
@@ -4,6 +4,8 @@
 
 #include "bqui/bquivisibility.h"
 
+#include <bq/signal/arraysignal.h>
+
 #include <vector>
 
 namespace bqui::widget
@@ -13,14 +15,21 @@ namespace bqui::widget
      * The container and every child carry a set of BoxVariables. The container
      * is anchored to the window-space rectangle it is realised at, the children
      * are stacked edge-to-edge along the vertical axis (boxConstraints()), and
-     * each child's preferred and minimum height enter as a strong equality and
-     * a required lower bound read from its SizeHint. One arrange::Solver folds
-     * over the whole spec (solveLayout()), and each child is placed at its
-     * solved rectangle, flipped from the solver's top-down window space into the
-     * widget tree's y-up coordinates.
+     * each child's height is bounded to its SizeHint's [min, max] band. A child
+     * settles at its natural size unless it is a filler (a larger max than
+     * natural), in which case it shares the container's one stretch variable so
+     * fillers split the leftover space equally. One arrange::Solver folds over
+     * the whole spec (solveLayout()), and each child is placed at its solved
+     * rectangle, flipped from the solver's top-down window space into the widget
+     * tree's y-up coordinates. Every child is put through
+     * modifier::handleGravity() so one that cannot use its whole slot is aligned
+     * within it, exactly as layout() does.
      *
-     * This is the first container wired onto the solver; the fixed-membership
-     * form is enough to prove the integration end to end.
+     * The array form follows a membership that changes; the vector form is the
+     * fixed-list convenience over it.
      */
+    BQUI_EXPORT AnyWidget solverVbox(bq::signal::ArraySignal<AnyWidget> widgets);
+
+    /** @overload */
     BQUI_EXPORT AnyWidget solverVbox(std::vector<AnyWidget> widgets);
 } // namespace bqui::widget

--- a/src/bqui/src/widget/constraintlayout.cpp
+++ b/src/bqui/src/widget/constraintlayout.cpp
@@ -111,7 +111,7 @@ std::vector<arrange::Constraint> boxConstraints(BoxVariables const& container,
         bool first = i == 0;
         bool last = i + 1 == children.size();
 
-        if (axis == Axis::vertical)
+        if (axis == Axis::y)
         {
             out.push_back(pin(child.left, container.left));
             out.push_back(pin(child.right, container.right));

--- a/src/bqui/src/widget/constraintlayout.cpp
+++ b/src/bqui/src/widget/constraintlayout.cpp
@@ -105,6 +105,22 @@ std::vector<arrange::Constraint> boxConstraints(BoxVariables const& container,
 {
     std::vector<arrange::Constraint> out;
 
+    // The trailing edge is capped at the container's end (required, so content
+    // can never overflow) and pulled to it only weakly. A child free to grow —
+    // a filler — settles against that weak pull and fills the container, while
+    // content held at a firmer size stays put, leaving the slack as a gap
+    // rather than being stretched to fill it.
+    auto fill = [&out](arrange::Variable const& childEnd,
+            arrange::Variable const& containerEnd)
+    {
+        out.push_back(
+                arrange::Expression(childEnd)
+                <= arrange::Expression(containerEnd));
+        out.push_back(
+                (arrange::Expression(childEnd) == arrange::Expression(containerEnd))
+                | arrange::Strength::weak());
+    };
+
     for (std::size_t i = 0; i < children.size(); ++i)
     {
         BoxVariables const& child = children[i];
@@ -118,7 +134,7 @@ std::vector<arrange::Constraint> boxConstraints(BoxVariables const& container,
             out.push_back(first ? pin(child.top, container.top)
                                 : pin(child.top, children[i - 1].bottom));
             if (last)
-                out.push_back(pin(child.bottom, container.bottom));
+                fill(child.bottom, container.bottom);
         }
         else
         {
@@ -127,7 +143,7 @@ std::vector<arrange::Constraint> boxConstraints(BoxVariables const& container,
             out.push_back(first ? pin(child.left, container.left)
                                 : pin(child.left, children[i - 1].right));
             if (last)
-                out.push_back(pin(child.right, container.right));
+                fill(child.right, container.right);
         }
     }
 

--- a/src/bqui/src/widget/constraintlayout.h
+++ b/src/bqui/src/widget/constraintlayout.h
@@ -60,10 +60,14 @@ namespace bqui::widget
 
     /** @brief Stacks @p children edge-to-edge inside @p container along @p axis.
      *
-     * Consecutive children meet, the first and last touch the container's ends,
-     * and the cross axis spans the container. The extent along @p axis is left
-     * to each child's own size contribution. @p axis is the shared bqui::Axis:
-     * Axis::y stacks top to bottom, Axis::x left to right.
+     * Consecutive children meet, the first touches the container's leading end,
+     * and the cross axis spans the container. The trailing end is capped at the
+     * container's end (required, so a stack never overflows) and pulled to it
+     * only weakly, so a child free to grow fills the container while firmer
+     * content packs against the leading end and leaves the slack as a gap. The
+     * extent along @p axis is otherwise left to each child's own size
+     * contribution. @p axis is the shared bqui::Axis: Axis::y stacks top to
+     * bottom, Axis::x left to right.
      */
     BQUI_EXPORT std::vector<arrange::Constraint> boxConstraints(
             BoxVariables const& container,

--- a/src/bqui/src/widget/constraintlayout.h
+++ b/src/bqui/src/widget/constraintlayout.h
@@ -2,6 +2,8 @@
 
 #include "bqui/bquivisibility.h"
 
+#include "bqui/widget/boxvariables.h"
+
 #include <bq/signal/signal.h>
 
 #include <avg/obb.h>
@@ -17,24 +19,6 @@
 
 namespace bqui::widget
 {
-    /** @brief The four edge variables bounding one widget's box in the shared
-     * constraint system.
-     *
-     * A widget holds its BoxVariables for its whole lifetime, so the arrange
-     * ids stay stable across solves and the solver's incremental diff can match
-     * the widget's constraints from pass to pass.
-     */
-    struct BoxVariables
-    {
-        arrange::Variable left;
-        arrange::Variable top;
-        arrange::Variable right;
-        arrange::Variable bottom;
-
-        BQUI_EXPORT arrange::Expression width() const;
-        BQUI_EXPORT arrange::Expression height() const;
-    };
-
     /** @brief One subtree's contribution to a solve: the constraints to apply
      * and the variables whose solved values must be read back.
      *

--- a/src/bqui/src/widget/constraintlayout.h
+++ b/src/bqui/src/widget/constraintlayout.h
@@ -2,6 +2,7 @@
 
 #include "bqui/bquivisibility.h"
 
+#include "bqui/sizehint.h"
 #include "bqui/widget/boxvariables.h"
 
 #include <bq/signal/signal.h>
@@ -57,17 +58,12 @@ namespace bqui::widget
             BoxVariables const& box,
             float left, float top, float right, float bottom);
 
-    enum class Axis
-    {
-        horizontal,
-        vertical
-    };
-
     /** @brief Stacks @p children edge-to-edge inside @p container along @p axis.
      *
      * Consecutive children meet, the first and last touch the container's ends,
      * and the cross axis spans the container. The extent along @p axis is left
-     * to each child's own size contribution.
+     * to each child's own size contribution. @p axis is the shared bqui::Axis:
+     * Axis::y stacks top to bottom, Axis::x left to right.
      */
     BQUI_EXPORT std::vector<arrange::Constraint> boxConstraints(
             BoxVariables const& container,

--- a/src/bqui/src/widget/vbox.cpp
+++ b/src/bqui/src/widget/vbox.cpp
@@ -1,13 +1,13 @@
 #include "bqui/widget/vbox.h"
 
-#include "bqui/widget/box.h"
+#include "constraintbox.h"
 
 namespace bqui::widget
 {
 
 AnyWidget vbox(bq::signal::ArraySignal<AnyWidget> widgets)
 {
-    return box<Axis::y>(std::move(widgets));
+    return solverVbox(std::move(widgets));
 }
 
 } // namespace bqui::widget

--- a/src/bqui/test/constraintlayouttest.cpp
+++ b/src/bqui/test/constraintlayouttest.cpp
@@ -1,5 +1,11 @@
 #include "widget/constraintlayout.h"
 
+#include <bqui/widget/builder.h>
+#include <bqui/widget/widget.h>
+
+#include <bqui/simplesizehint.h>
+#include <bqui/sizehint.h>
+
 #include <bq/signal/constant.h>
 #include <bq/signal/frameinfo.h>
 #include <bq/signal/input.h>
@@ -92,6 +98,34 @@ TEST(constraintLayout, horizontalBoxStacksChildren)
     EXPECT_DOUBLE_EQ(90.0, solution.at(b.right.id()));
     EXPECT_DOUBLE_EQ(0.0, solution.at(a.top.id()));
     EXPECT_DOUBLE_EQ(30.0, solution.at(a.bottom.id()));
+}
+
+// The solver matches a widget's constraints from pass to pass by the arrange
+// ids of its box variables alone, so those ids have to survive the transforms a
+// builder goes through on its way into a container: a size-hint change and the
+// erasure to AnyBuilder. Were either to mint fresh ids, the diff would treat the
+// same widget as a departure and an arrival every frame.
+TEST(constraintLayout, boxVariableIdsSurviveHintChangeAndErasure)
+{
+    auto builder = makeBuilder();
+    BoxVariables const original = builder.getBoxVariables();
+
+    auto rehinted = std::move(builder).setSizeHint(
+            bq::signal::constant(simpleSizeHint(10.0f, 10.0f)));
+    BoxVariables const afterHint = rehinted.getBoxVariables();
+
+    AnyBuilder erased = std::move(rehinted);
+    BoxVariables const afterErasure = erased.getBoxVariables();
+
+    EXPECT_EQ(original.left.id(), afterHint.left.id());
+    EXPECT_EQ(original.top.id(), afterHint.top.id());
+    EXPECT_EQ(original.right.id(), afterHint.right.id());
+    EXPECT_EQ(original.bottom.id(), afterHint.bottom.id());
+
+    EXPECT_EQ(original.left.id(), afterErasure.left.id());
+    EXPECT_EQ(original.top.id(), afterErasure.top.id());
+    EXPECT_EQ(original.right.id(), afterErasure.right.id());
+    EXPECT_EQ(original.bottom.id(), afterErasure.bottom.id());
 }
 
 // A stack overlays its children: each child gets the container's whole box.

--- a/src/bqui/test/constraintlayouttest.cpp
+++ b/src/bqui/test/constraintlayouttest.cpp
@@ -13,6 +13,7 @@
 
 #include <vector>
 
+using namespace bqui;
 using namespace bqui::widget;
 using namespace bq::signal;
 
@@ -46,7 +47,7 @@ TEST(constraintLayout, verticalBoxStacksChildren)
 
     LayoutSpec spec;
     append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 100.f, 60.f));
-    append(spec.constraints, boxConstraints(container, { a, b }, Axis::vertical));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::y));
     spec.constraints.push_back(
             (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
 
@@ -77,7 +78,7 @@ TEST(constraintLayout, horizontalBoxStacksChildren)
 
     LayoutSpec spec;
     append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 90.f, 30.f));
-    append(spec.constraints, boxConstraints(container, { a, b }, Axis::horizontal));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::x));
     spec.constraints.push_back(
             (a.width() == arrange::Expression(30.0)) | arrange::Strength::strong());
 
@@ -129,7 +130,7 @@ TEST(constraintLayout, requiredMinimumBeatsStrongPreferred)
 
     LayoutSpec spec;
     append(spec.constraints, anchorConstraints(container, 0.f, 0.f, 100.f, 60.f));
-    append(spec.constraints, boxConstraints(container, { a, b }, Axis::vertical));
+    append(spec.constraints, boxConstraints(container, { a, b }, Axis::y));
     spec.constraints.push_back(
             (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
     spec.constraints.push_back(a.height() >= arrange::Expression(30.0));
@@ -158,7 +159,7 @@ TEST(constraintLayout, resolvesWhenConstraintsChange)
         append(spec.constraints,
                 anchorConstraints(container, 0.f, 0.f, width, height));
         append(spec.constraints,
-                boxConstraints(container, { a, b }, Axis::vertical));
+                boxConstraints(container, { a, b }, Axis::y));
         spec.constraints.push_back(
                 (a.height() == arrange::Expression(20.0)) | arrange::Strength::strong());
         spec.variables = { a.right, a.bottom, b.top, b.bottom };

--- a/src/bqui/test/layouttest.cpp
+++ b/src/bqui/test/layouttest.cpp
@@ -400,6 +400,161 @@ TEST(Layout, solverVboxStacksChildrenThroughTheSolver)
     expectGeometry("last (origin)", geometries[2], 0.0f, 0.0f, 50.0f, 50.0f);
 }
 
+// The regression case the exact-fill pin got wrong. Three rigid children total
+// 120 in a 150-tall container with no filler among them. The production
+// SizeHint vbox (box<Axis::y>) packs them against the top and leaves the spare
+// 30 as a gap at the bottom; the solver vbox must do the same. A required
+// exact-fill pin would instead stretch the children to fill the container and
+// gravity would then centre each in its stretched slot, spreading them out —
+// the weak fill pin keeps the medium natural sizes winning, so the stack packs
+// at the top exactly as the SizeHint engine does.
+TEST(Layout, solverVboxPacksContentShorterThanContainerAtTheTop)
+{
+    SizeHintResult const width = {{ 50.0f, 50.0f, 50.0f }};
+    SizeHintResult const a = {{ 40.0f, 40.0f, 40.0f }};
+    SizeHintResult const b = {{ 30.0f, 30.0f, 30.0f }};
+    SizeHintResult const c = {{ 50.0f, 50.0f, 50.0f }};
+
+    avg::Vector2f const size(50.0f, 150.0f);
+
+    ProbeSet solverProbes;
+    std::vector<AnyWidget> children;
+    children.push_back(solverProbes.add(width, a));
+    children.push_back(solverProbes.add(width, b));
+    children.push_back(solverProbes.add(width, c));
+    auto solved = solverProbes.realise(solverVbox(std::move(children)), size);
+
+    ProbeSet refProbes;
+    Children reference;
+    reference.push_back(refProbes.add(width, a));
+    reference.push_back(refProbes.add(width, b));
+    reference.push_back(refProbes.add(width, c));
+    auto expected = refProbes.realise(box<Axis::y>(std::move(reference)), size);
+
+    ASSERT_EQ(3u, solved.size());
+    ASSERT_EQ(3u, expected.size());
+
+    // The production SizeHint vbox: each rigid child at its natural height,
+    // stacked from the top with the spare 30 left as a gap at the bottom.
+    expectGeometry("ref first (top)", expected[0], 0.0f, 110.0f, 50.0f, 40.0f);
+    expectGeometry("ref middle", expected[1], 0.0f, 80.0f, 50.0f, 30.0f);
+    expectGeometry("ref last", expected[2], 0.0f, 30.0f, 50.0f, 50.0f);
+
+    // The solver vbox matches it edge for edge.
+    expectGeometry("first (top)", solved[0], 0.0f, 110.0f, 50.0f, 40.0f);
+    expectGeometry("middle", solved[1], 0.0f, 80.0f, 50.0f, 30.0f);
+    expectGeometry("last", solved[2], 0.0f, 30.0f, 50.0f, 50.0f);
+}
+
+// Content taller than the container, no filler. The no-overflow cap is
+// required, so the children are squashed to fit. This is the one case where
+// the solver and the production SizeHint vbox part ways, and the test pins the
+// difference rather than hiding it.
+//
+// The SizeHint engine spreads the overflow proportionally across every child's
+// natural-to-minimum band, landing both children at 40 in an 80-tall box. The
+// solver cannot reproduce that: once the required cap binds, the two equal
+// medium natural pins have a flat combined cost across every split of the
+// deficit (their errors sum to a constant), so the objective is degenerate and
+// Cassowary breaks the tie at a vertex — the first child keeps its natural 50
+// and the last child alone absorbs the whole overflow, ending at 30. A
+// proportional squash would need per-child stretch weights the current
+// formulation does not carry; see the report.
+TEST(Layout, solverVboxSquashesOverfullContent)
+{
+    SizeHintResult const width = {{ 50.0f, 50.0f, 50.0f }};
+    SizeHintResult const squashable = {{ 20.0f, 50.0f, 50.0f }};
+
+    avg::Vector2f const size(50.0f, 80.0f);
+
+    ProbeSet solverProbes;
+    std::vector<AnyWidget> children;
+    children.push_back(solverProbes.add(width, squashable));
+    children.push_back(solverProbes.add(width, squashable));
+    auto solved = solverProbes.realise(solverVbox(std::move(children)), size);
+
+    ProbeSet refProbes;
+    Children reference;
+    reference.push_back(refProbes.add(width, squashable));
+    reference.push_back(refProbes.add(width, squashable));
+    auto expected = refProbes.realise(box<Axis::y>(std::move(reference)), size);
+
+    ASSERT_EQ(2u, solved.size());
+    ASSERT_EQ(2u, expected.size());
+
+    // Production SizeHint vbox: a proportional squash to 40 each.
+    expectGeometry("ref first", expected[0], 0.0f, 40.0f, 50.0f, 40.0f);
+    expectGeometry("ref second", expected[1], 0.0f, 0.0f, 50.0f, 40.0f);
+
+    // Solver vbox: the first child keeps its natural 50, the last absorbs the
+    // whole overflow to 30. This diverges from the proportional reference above
+    // and is asserted here deliberately.
+    expectGeometry("first", solved[0], 0.0f, 30.0f, 50.0f, 50.0f);
+    expectGeometry("second", solved[1], 0.0f, 0.0f, 50.0f, 30.0f);
+}
+
+// Two fillers with a rigid child above the leftover space. Both fillers are
+// tied to the container's single stretch variable, so the weak fill splits the
+// 100 of leftover space equally: 50 each. This matches the production SizeHint
+// vbox, which hands each filler an equal share of the unclaimed range.
+TEST(Layout, solverVboxSplitsLeftoverBetweenFillers)
+{
+    SizeHintResult const width = {{ 50.0f, 50.0f, 50.0f }};
+    SizeHintResult const rigid = {{ 40.0f, 40.0f, 40.0f }};
+
+    avg::Vector2f const size(50.0f, 140.0f);
+
+    ProbeSet solverProbes;
+    std::vector<AnyWidget> children;
+    children.push_back(solverProbes.add(width, rigid));
+    children.push_back(solverProbes.add(width, fillHint));
+    children.push_back(solverProbes.add(width, fillHint));
+    auto solved = solverProbes.realise(solverVbox(std::move(children)), size);
+
+    ProbeSet refProbes;
+    Children reference;
+    reference.push_back(refProbes.add(width, rigid));
+    reference.push_back(refProbes.add(width, fillHint));
+    reference.push_back(refProbes.add(width, fillHint));
+    auto expected = refProbes.realise(box<Axis::y>(std::move(reference)), size);
+
+    ASSERT_EQ(3u, solved.size());
+    ASSERT_EQ(3u, expected.size());
+
+    // Production SizeHint vbox: rigid child keeps its 40 at the top; the two
+    // fillers split the remaining 100 into 50 each.
+    expectGeometry("ref rigid (top)", expected[0], 0.0f, 100.0f, 50.0f, 40.0f);
+    expectGeometry("ref filler one", expected[1], 0.0f, 50.0f, 50.0f, 50.0f);
+    expectGeometry("ref filler two", expected[2], 0.0f, 0.0f, 50.0f, 50.0f);
+
+    // The solver vbox matches it.
+    expectGeometry("rigid (top)", solved[0], 0.0f, 100.0f, 50.0f, 40.0f);
+    expectGeometry("filler one", solved[1], 0.0f, 50.0f, 50.0f, 50.0f);
+    expectGeometry("filler two", solved[2], 0.0f, 0.0f, 50.0f, 50.0f);
+}
+
+// A single filler under the weak fill pin grows at no cost to the medium size
+// pins, so it takes exactly the space the rigid children leave. A 40 rigid
+// child above a filler in a 150-tall box leaves the filler 110.
+TEST(Layout, solverVboxFillsASingleFiller)
+{
+    ProbeSet probes;
+
+    SizeHintResult const width = {{ 50.0f, 50.0f, 50.0f }};
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(width, SizeHintResult{{ 40.0f, 40.0f, 40.0f }}));
+    children.push_back(probes.add(width, fillHint));
+
+    auto geometries = probes.realise(solverVbox(std::move(children)),
+            avg::Vector2f(50.0f, 150.0f));
+
+    ASSERT_EQ(2u, geometries.size());
+
+    expectGeometry("rigid (top)", geometries[0], 0.0f, 110.0f, 50.0f, 40.0f);
+    expectGeometry("filler", geometries[1], 0.0f, 0.0f, 50.0f, 110.0f);
+}
+
 TEST(Layout, gravityCentersAChildInsideItsSlot)
 {
     ProbeSet probes;

--- a/src/bqui/test/layouttest.cpp
+++ b/src/bqui/test/layouttest.cpp
@@ -9,6 +9,8 @@
 #include <bqui/widget/vbox.h>
 #include <bqui/widget/widget.h>
 
+#include "widget/constraintbox.h"
+
 #include <bqui/buildparams.h>
 #include <bqui/inputarea.h>
 #include <bqui/simplesizehint.h>
@@ -365,6 +367,37 @@ TEST(Layout, vboxStacksFromTopDown)
     expectGeometry("small", geometries[0], 0.0f, 110.0f, 50.0f, 40.0f);
     expectGeometry("stretchy", geometries[1], 0.0f, 30.0f, 50.0f, 80.0f);
     expectGeometry("rigid", geometries[2], 0.0f, 0.0f, 50.0f, 30.0f);
+}
+
+// A column laid out through the arrange solver rather than the SizeHint
+// arithmetic. Three rigid children whose heights fill the container exactly
+// leave the solve fully determined, so each one lands where the edge-to-edge
+// stack puts it: the first at the top, the last at the origin, every child
+// spanning the container's width. This proves the solver drives real widget
+// geometry end to end (box variables collected from the builders, constraints
+// emitted, one Solver folded over the spec, solved boxes flipped back into the
+// y-up widget tree).
+TEST(Layout, solverVboxStacksChildrenThroughTheSolver)
+{
+    ProbeSet probes;
+
+    SizeHintResult const width = {{ 50.0f, 50.0f, 50.0f }};
+
+    std::vector<AnyWidget> children;
+    children.push_back(probes.add(width, SizeHintResult{{ 40.0f, 40.0f, 40.0f }}));
+    children.push_back(probes.add(width, SizeHintResult{{ 30.0f, 30.0f, 30.0f }}));
+    children.push_back(probes.add(width, SizeHintResult{{ 50.0f, 50.0f, 50.0f }}));
+
+    auto geometries = probes.realise(solverVbox(std::move(children)),
+            avg::Vector2f(50.0f, 120.0f));
+
+    ASSERT_EQ(3u, geometries.size());
+
+    // Solver window space stacks 0..40, 40..70, 70..120 from the top; the y-up
+    // flip turns each child's bottom edge into its origin.
+    expectGeometry("first (top)", geometries[0], 0.0f, 80.0f, 50.0f, 40.0f);
+    expectGeometry("middle", geometries[1], 0.0f, 50.0f, 50.0f, 30.0f);
+    expectGeometry("last (origin)", geometries[2], 0.0f, 0.0f, 50.0f, 50.0f);
 }
 
 TEST(Layout, gravityCentersAChildInsideItsSlot)


### PR DESCRIPTION
Stages 1-3 of wiring the arrange (Cassowary) solver into bqui's live layout.
Builds on the #130 constraint-solve core (BoxVariables, LayoutSpec, solveLayout,
readObb, boxConstraints, ...). Draft: production `vbox` is now solver-driven, but
the other containers and the SizeHint arithmetic still stand.

## Stage 1 - arrange public + box variables on Builder
- `arrange` is now a PUBLIC dependency of bqui: it is re-exported through
  `libbquidep`, so arrange types are allowed in bqui's public interface (like
  `avg`; still not in bq/ase/avg/btl).
- `BoxVariables` moves to a public header (`bqui/widget/boxvariables.h`).
- Every `Builder` carries a `BoxVariables` (four `arrange::Variable`) with stable
  ids for the builder's lifetime, via `getBoxVariables()`. Copy preserves them,
  and `setSizeHint`/`setBuildParams`/erasure to `AnyBuilder` carry the same box
  across so a transformed builder keeps its identity.

## Stage 2 - one container solves through arrange
- `solverVbox` (private `widget/constraintbox.{h,cpp}`) lays a column out THROUGH
  the solver: collects the container's and every child's `BoxVariables`, anchors
  the container, stacks children edge-to-edge with `boxConstraints(Axis::y)`,
  folds ONE shared `arrange::Solver` over the spec via `solveLayout`, and places
  each child at its solved `readObb` rectangle, flipped into the widget tree's
  y-up coordinates.

## Stage 3 - the band+filler model, and production vbox on the solver
- **Size-band + filler-stretch model.** Each child's SizeHint maps to: a
  `[min, max]` band at **strong**, and the size it settles at within the band at
  **medium** - its **natural** size when it cannot grow past it, or the
  container's **one shared stretch variable** when it can (a filler: `max >
  natural`). Tying every filler to the same variable splits leftover space
  **equally**; the container's fixed extent drives that variable to absorb the
  remainder. Filler detection is `hint[2] > hint[1]` (a non-empty stretch band),
  which is exactly what the SizeHint engine treats as stretchy (e.g.
  `hwfiller`/`vfiller` `{0,0,100000}`).
- **Robust, never-infeasible by construction.** `arrange` throws on an
  unsatisfiable required constraint, and `solveLayout` catches it and keeps the
  previous solution - so a required-vs-required conflict would freeze the layout
  (and read zeros on the first solve). The model therefore ranks everything by
  strength; a too-small or too-large container bends the softest pins instead of
  going infeasible.
- **Production `vbox` now lays out through the solver.** Public signature
  unchanged.
- **Gravity on the solver path.** Every child goes through `handleGravity`, as
  `layout()` does, so one that cannot use its whole slot is aligned within it.
- **Dynamic membership.** An `ArraySignal<AnyWidget>` overload lays out a column
  whose membership changes (forEach), the same as the fixed-list form.
- **hbox is NOT swapped.** Its proportional below-minimum squash and its
  end-of-row gap distribute space in a way the band model does not reproduce.
  It stays on the SizeHint path until the model covers those cases.
- **New test** `constraintLayout.boxVariableIdsSurviveHintChangeAndErasure`:
  pins that a builder's box-variable ids outlive a `setSizeHint` and the erasure
  to `AnyBuilder`.

## Stage 3b - fix the fill pin and add the missing reproduction tests
Stage 3 landed green but left the no-filler cases untested, and the trailing
edge of `boxConstraints` was a **required exact-fill** pin
(`last.bottom == container.bottom`). That is wrong for content shorter than the
container with no filler: the required pin forced the children to stretch to
fill the full height, and `handleGravity` then centred each in its stretched
slot, so the stack **spread** instead of packing at the top the way the
production SizeHint `vbox` does. A real regression that the missing tests hid.

- **Fix.** Reformulate the trailing edge in `boxConstraints` (both axes) as a
  **required** no-overflow cap (`last.<end> <= container.<end>`) plus a **weak**
  exact-fill pull (`last.<end> == container.<end>`). No required-vs-required
  anywhere; the ranking is required edges > strong band > medium settled size >
  weak fill. A filler is a free variable, so it grows at no cost to satisfy the
  weak fill and fills the container (fillers tied to the shared stretch variable
  still split leftover equally); firmer content would have to violate its medium
  natural pin to satisfy the weak fill, so it stays put and the fill is left
  unsatisfied as a bottom gap. Over-full content is held inside by the required
  cap. The weak-fill reasoning held empirically.
- **Reproduction tests** added in `layouttest.cpp`, each asserting the solver
  vbox against the production `box<Axis::y>`:
  - `solverVboxPacksContentShorterThanContainerAtTheTop` - THE regression:
    rigid 40/30/50 in a 150 box pack to the top (y = 110/80/30) with a 30 gap
    at the bottom, matching production. Fails on the old required pin.
  - `solverVboxFillsASingleFiller` - a 40 rigid child above a filler leaves the
    filler exactly 110.
  - `solverVboxSplitsLeftoverBetweenFillers` - a rigid 40 above two fillers in
    a 140 box: each filler 50, matching production.
  - `solverVboxSquashesOverfullContent` - the one case that **does not** match
    production, pinned deliberately. For two `{20,50,50}` children in an 80 box
    the SizeHint engine spreads the deficit proportionally (40/40); the solver's
    two equal medium natural pins leave a degenerate objective once the required
    cap binds, so Cassowary breaks the tie at a vertex - the first child keeps
    its natural 50 and the last absorbs the whole overflow to 30. A proportional
    squash would need per-child stretch weights the current model does not carry.
- No existing assertion was weakened; the pre-existing exact-fill, single-filler
  and nested vbox tests still hold under the new pin.

## Verify (clang-cl 18.1.7)
Compile clean; all four suites green: **btl 85, bq 127, avg 78, bqui 140**.
No existing test expectation needed to change.

## Explicitly NOT done (later stages)
- **SizeHint is still the size source** and its distribution arithmetic is
  untouched; the band/filler values are read from it.
- **Other containers** (`hbox`, `stack`, `uniformGrid`) still use the SizeHint
  engine. Swapping `hbox` needs the model to reproduce proportional squash /
  end-gaps (the same divergence the over-full vbox case documents);
  `stack`/`uniformGrid` need their own constraint generators.
- Deleting the SizeHint arithmetic, and the size-modifier -> constraint-strength
  mapping, remain for a later stage.

Draft: do not merge; needs the human + clean-context reviews per AGENTS.md.
